### PR TITLE
dynamic-shape silu kernel example

### DIFF
--- a/examples/jit_cpp/silu_dynamic/README.md
+++ b/examples/jit_cpp/silu_dynamic/README.md
@@ -1,0 +1,6 @@
+Usage:
+
+```bash
+export PTO_LIB_PATH=${ASCEND_TOOLKIT_HOME}  # reuse CANN 8.5.0 headers
+python ./run_silu.py
+```

--- a/examples/jit_cpp/silu_dynamic/jit_util_silu.py
+++ b/examples/jit_cpp/silu_dynamic/jit_util_silu.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+import ctypes
+
+import torch
+
+ASCEND_TOOLKIT_HOME = os.environ["ASCEND_TOOLKIT_HOME"]
+PTO_LIB_PATH = os.environ["PTO_LIB_PATH"]
+BLOCK_DIM = 20  # 910B4, TODO: query platform information
+
+
+def compile_cpp(kernel_cpp: str, verbose: bool = False, timeout: int = 120) -> str:
+    lib_path = os.path.join(os.path.dirname(kernel_cpp), "rilu_jit.so")
+
+    flags = [
+        "-fPIC",
+        "-shared",
+        "-xcce",
+        "--npu-arch=dav-2201",
+        "-DMEMORY_BASE",  # here hardcoded for A2A3; TODO: expose this option to jit interface
+        "-O2",
+        "-std=c++17",
+        f"-I{PTO_LIB_PATH}/include",
+    ]
+
+    command = ["bisheng", *flags, kernel_cpp, "-o", lib_path]
+    if verbose:
+        print(f"compile {kernel_cpp} with command: \n", command)
+
+    try:
+        subprocess.run(command, timeout=timeout)
+    except Exception as e:
+        raise RuntimeError(f"Compile failed: {e}") from e
+
+    if verbose:
+        print(f"generated {lib_path}")
+    return lib_path
+
+
+def torch_to_ctypes(tensor):
+    return ctypes.c_void_p(tensor.data_ptr())
+
+
+def load_lib(lib_path, check_type=True):
+    lib_path = os.path.abspath(lib_path)
+    lib = ctypes.CDLL(lib_path)
+
+    if check_type:
+        lib.call_kernel.argtypes = [
+            ctypes.c_uint32,  # blockDim
+            ctypes.c_void_p,  # stream
+            ctypes.c_void_p,  # y
+            ctypes.c_void_p,  # x
+            ctypes.c_int,  # N
+        ]
+        lib.call_kernel.restype = None
+
+    default_block_dim = BLOCK_DIM
+
+    def silu_func(x, y, block_dim=default_block_dim, stream_ptr=None):
+        if stream_ptr is None:
+            stream_ptr = torch.npu.current_stream()._as_parameter_
+        N = x.numel()
+        lib.call_kernel(
+            block_dim,
+            stream_ptr,
+            torch_to_ctypes(y),
+            torch_to_ctypes(x),
+            N,
+        )
+
+    return silu_func
+
+
+def jit_compile(src_path, clean_up=True):
+    lib_path = compile_cpp(src_path, verbose=True)
+    func = load_lib(lib_path)
+    if clean_up:
+        os.remove(lib_path)
+    return func

--- a/examples/jit_cpp/silu_dynamic/run_silu.py
+++ b/examples/jit_cpp/silu_dynamic/run_silu.py
@@ -1,0 +1,49 @@
+import random
+import torch
+import torch_npu
+
+from jit_util_silu import jit_compile
+
+
+def silu_ref(x):
+    return x * torch.sigmoid(x)
+
+
+def random_2d_shape(
+    min_m=1,
+    max_m=2048,
+    min_n=1,
+    max_n=2048,
+):
+    m = random.randint(min_m, max_m)
+    n = random.randint(min_n, max_n)
+    return [m, n]
+
+
+def test_silu_random_2d(num_tests=20):
+    device = "npu"
+    dtype = torch.float16
+    torch.npu.set_device(device)
+
+    silu_func = jit_compile("silu_dynamic.cpp")
+
+    for i in range(num_tests):
+        shape = random_2d_shape()
+
+        x = torch.rand(shape, device=device, dtype=dtype)
+        y = torch.empty_like(x)
+
+        silu_func(y, x)
+        torch.npu.synchronize()
+
+        y_ref = silu_ref(x)
+
+        torch.testing.assert_close(y, y_ref, rtol=0.1, atol=1e-5)
+
+        print(f"Test {i+1}/{num_tests} passed — shape: {shape}")
+
+    print("\nAll 2D random shape SILU tests passed!")
+
+
+if __name__ == "__main__":
+    test_silu_random_2d(num_tests=100)

--- a/examples/jit_cpp/silu_dynamic/silu_dynamic.cpp
+++ b/examples/jit_cpp/silu_dynamic/silu_dynamic.cpp
@@ -1,0 +1,132 @@
+#include <pto/pto-inst.hpp>
+using namespace pto;
+
+constexpr uint32_t BUFFER_NUM      = 2;
+constexpr uint32_t UB_ALLOC_BYTES  = 48 * 1024;
+constexpr uint32_t ELEMENTS_PER_TILE = UB_ALLOC_BYTES / 2;
+
+constexpr unsigned X_PING   = 0x00000;
+constexpr unsigned X_PONG   = (X_PING + 0x8000 + 0x100);
+constexpr unsigned CAL_PING = 0x10000;
+constexpr unsigned CAL_PONG = (CAL_PING + 0x8000 + 0x100);
+
+// SiLU: y = x / (1 + exp(-x))
+template <typename T>
+AICORE void runTSilu(__gm__ T *y, __gm__ T *x, uint32_t num_elements)
+{
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+
+    const uint32_t num_cores = block_num;
+    const uint32_t elements_per_core = (num_elements + num_cores - 1) / num_cores; // ceil
+    const uint32_t offset_this_core  = elements_per_core * block_idx;
+
+    if (offset_this_core >= num_elements) return;
+
+    uint32_t elements_to_process = elements_per_core;
+    if (offset_this_core + elements_to_process > num_elements) {
+        elements_to_process = num_elements - offset_this_core;
+    }
+    if (elements_to_process == 0) return;
+
+    using ShapeDim5 = pto::Shape<1, 1, 1, 1, ELEMENTS_PER_TILE>;
+    using StridDim5 = pto::Stride<1, 1, 1, 1, 1>;
+    using GlobalData = pto::GlobalTensor<T, ShapeDim5, StridDim5>;
+
+    GlobalData xGlobal(x + offset_this_core);
+    GlobalData yGlobal(y + offset_this_core);
+
+    using TileData = Tile<TileType::Vec, T,
+                          1, ELEMENTS_PER_TILE,
+                          BLayout::RowMajor,
+                          -1, -1>;
+
+    set_flag(PIPE_V,    PIPE_MTE2, EVENT_ID0);
+    set_flag(PIPE_V,    PIPE_MTE2, EVENT_ID1);
+    set_flag(PIPE_MTE3, PIPE_V,    EVENT_ID0);
+    set_flag(PIPE_MTE3, PIPE_V,    EVENT_ID1);
+
+    uint32_t x_offset = 0;
+    uint32_t y_offset = 0;
+
+    for (uint32_t num_processed = 0, ping = 1;
+         num_processed < elements_to_process;
+         num_processed += ELEMENTS_PER_TILE)
+    {
+        const uint32_t remaining = elements_to_process - num_processed;
+        const uint32_t cur_cols  = (remaining >= ELEMENTS_PER_TILE) ? ELEMENTS_PER_TILE : remaining;
+
+        const int8_t  buf = ping ? 0 : 1;
+        const event_t ev  = ping ? (event_t)EVENT_ID0 : (event_t)EVENT_ID1;
+
+        TileData xTile(1, cur_cols);
+        TileData calTile(1, cur_cols);
+
+        if (buf == 0) {
+            TASSIGN(xTile,  X_PING);
+            TASSIGN(calTile, CAL_PING);
+        } else {
+            TASSIGN(xTile,  X_PONG);
+            TASSIGN(calTile, CAL_PONG);
+        }
+
+        TASSIGN(xGlobal, (x + offset_this_core + x_offset));
+        TASSIGN(yGlobal, (y + offset_this_core + y_offset));
+
+        wait_flag(PIPE_V, PIPE_MTE2, ev);
+        TLOAD(xTile, xGlobal);
+        pipe_barrier(PIPE_ALL);
+
+        set_flag(PIPE_MTE2, PIPE_V, ev);
+        wait_flag(PIPE_MTE2, PIPE_V, ev);
+
+        wait_flag(PIPE_MTE3, PIPE_V, ev);
+
+        TMULS(calTile, xTile, (T)-1);
+        pipe_barrier(PIPE_ALL);
+
+        TEXP(calTile, calTile);
+        pipe_barrier(PIPE_ALL);
+
+        TADDS(calTile, calTile, (T)1);
+        pipe_barrier(PIPE_ALL);
+
+        TDIV(calTile, xTile, calTile);
+        pipe_barrier(PIPE_ALL);
+
+        set_flag(PIPE_V, PIPE_MTE3, ev);
+        wait_flag(PIPE_V, PIPE_MTE3, ev);
+
+        TSTORE(yGlobal, calTile);
+        pipe_barrier(PIPE_ALL);
+
+        set_flag(PIPE_MTE3, PIPE_V, ev);
+        set_flag(PIPE_V, PIPE_MTE2, ev);
+
+        x_offset += cur_cols;
+        y_offset += cur_cols;
+        ping = 1 - ping;
+    }
+
+    wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
+    wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
+
+#else
+    // Cube branch: do nothing
+#endif
+}
+
+__global__ AICORE void silu_custom(__gm__ void *x, __gm__ void *y, uint32_t num_elements)
+{
+    runTSilu<half>((__gm__ half *)y, (__gm__ half *)x, num_elements);
+}
+
+extern "C" void call_kernel(uint32_t blockDim, void *stream,
+                            uint8_t *x, uint8_t *y, uint32_t num_elements)
+{
+    silu_custom<<<blockDim, nullptr, stream>>>(x, y, num_elements);
+}


### PR DESCRIPTION
Cleaned-up the silu kernel example from Mirko.

Output from `examples/jit_cpp/silu_dynamic/run_silu.py`:

```
...
Test 91/100 passed — shape: [2023, 2015]
Test 92/100 passed — shape: [342, 1880]
Test 93/100 passed — shape: [7, 1086]
Test 94/100 passed — shape: [508, 205]
Test 95/100 passed — shape: [56, 2037]
Test 96/100 passed — shape: [674, 1621]
Test 97/100 passed — shape: [717, 313]
Test 98/100 passed — shape: [1335, 1147]
Test 99/100 passed — shape: [1344, 1576]
Test 100/100 passed — shape: [477, 1792]

All 2D random shape SILU tests passed!
```

Todo: 
- [ ] checking software pipelining not be slower than [ascendc](https://github.com/learning-chip/ascendc-samples/tree/main/1_silu)