### PR TITLE
(core) drop include kernel_operator.h 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(PIP_INSTALL "True if building via pip" OFF)
 
-find_package(PythonLibs REQUIRED)
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(Torch REQUIRED)
 
@@ -57,12 +57,6 @@ set(CMAKE_CPP_COMPILE_OPTIONS -xc++ "SHELL:-include stdint.h"
 
 include_directories(${ASCEND_HOME_PATH}/include
                     ${ASCEND_DRIVER_PATH}/kernel/inc)
-
-# set PTO_LIB_PATH before running cmake, for example: export
-# PTO_LIB_PATH=[YOUR_PATH]/pto-isa
-set(PTO_LIB_PATH
-    "$ENV{PTO_LIB_PATH}"
-    CACHE STRING "PTO library path")
 
 if(EXISTS ${ASCEND_CANN_PACKAGE_PATH}/tools/tikcpp/ascendc_kernel_cmake)
   set(ASCENDC_CMAKE_DIR

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ clean:
 
 setup_once:
 	pip3 install -r requirements.txt
-	pip3 install torch-npu==2.8.0.post2 --extra-index-url https://download.pytorch.org/whl/cpu # https://github.com/sgl-project/sgl-kernel-npu/pull/326
+	pip3 install torch-npu==2.8.0.post2 --extra-index-url https://download.pytorch.org/whl/cpu
 
-build_cmake:
+build_cmake: clean
 	bash scripts/build.sh
 
 build_wheel:

--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -13,7 +13,7 @@ for the full License text.
 
 #include <pto/pto-inst.hpp>
 
-#include "kernel_operator.h"
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_batch_matrix_square.cpp
+++ b/csrc/kernel/kernel_batch_matrix_square.cpp
@@ -10,7 +10,8 @@ for the full License text.
 #define MEMORY_BASE
 #include <pto/pto-inst.hpp>
 
-#include "kernel_operator.h"
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+
 using namespace pto;
 
 template <typename InputT, typename OutputT, uint32_t MatrixSize>

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -29,7 +29,7 @@ extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
 
 #include <pto/pto-inst.hpp>
 
-#include "kernel_operator.h"
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -13,7 +13,7 @@ for the full License text.
 
 #include <pto/pto-inst.hpp>
 
-#include "kernel_operator.h"
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_tri_inv_trick.cpp
+++ b/csrc/kernel/kernel_tri_inv_trick.cpp
@@ -10,7 +10,8 @@ for the full License text.
 #define MEMORY_BASE
 #include <pto/pto-inst.hpp>
 
-#include "kernel_operator.h"
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+
 using namespace pto;
 
 /*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,7 @@ source "$_ASCEND_INSTALL_PATH"/bin/setenv.bash
 echo "Current compile soc version is ${SOC_VERSION}"
 
 # See https://docs.pytorch.org/cppdocs/installing.html
-CMAKE_PREFIX_PATH=$(python3 -c "import torch; print(torch.utils.cmake_prefix_path)")
+CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}:$(python3 -c "import torch; print(torch.utils.cmake_prefix_path)")
 export CMAKE_PREFIX_PATH
 
 


### PR DESCRIPTION
This MR removes the AscendC `#include "kernel_operator.h"` statement with the macro definition `GM_ADDR`. It shows that it is possible to also remove the `ascendc_library` as mentioned in #3 