### PR TITLE
(github) manylinux wheels for multi-arch

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -22,18 +22,18 @@ jobs:
             python_version: py3.11
             py_ver: "311"
           - os: ubuntu-22.04-arm
-            arch: arm64
+            arch: aarch64
             python_version: py3.10
             py_ver: "310"
           - os: ubuntu-22.04-arm
-            arch: arm64
+            arch: aarch64
             python_version: py3.11
             py_ver: "311"
 
     runs-on: ${{ matrix.os }}
 
     container:
-      image: quay.io/ascend/manylinux:8.5.0-910b-manylinux_2_28-${{ matrix.python_version }}
+      image: quay.io/ascend/manylinux:8.5.1-910b-manylinux_2_28-${{ matrix.python_version }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -1,12 +1,11 @@
-name: Python Packaging
+name: Multi-platform Manylinux wheels
 
 on:
   workflow_dispatch:
 
 jobs:
-  pypackaging:
+  manylinux-wheels-build:
     name: manylinux build (py${{ matrix.py_ver }})
-    runs-on: ubuntu-latest
 
     continue-on-error: true
 
@@ -20,6 +19,14 @@ jobs:
           - arch: x86_64
             python_version: py3.11
             py_ver: "311"
+          - arch: aarch64
+            python_version: py3.10
+            py_ver: "310"
+          - arch: aarch64
+            python_version: py3.11
+            py_ver: "311"
+
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm64' || 'ubuntu-24.04' }}
 
     container:
       image: quay.io/ascend/manylinux:8.5.0-910b-manylinux_2_28-${{ matrix.python_version }}

--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -13,20 +13,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
+          - os: ubuntu-22.04
+            arch: x86_64
             python_version: py3.10
             py_ver: "310"
-          - arch: x86_64
+          - os: ubuntu-22.04
+            arch: x86_64
             python_version: py3.11
             py_ver: "311"
-          - arch: aarch64
+          - os: ubuntu-22.04-arm
+            arch: arm64
             python_version: py3.10
             py_ver: "310"
-          - arch: aarch64
+          - os: ubuntu-22.04-arm
+            arch: arm64
             python_version: py3.11
             py_ver: "311"
 
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm64' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.os }}
 
     container:
       image: quay.io/ascend/manylinux:8.5.0-910b-manylinux_2_28-${{ matrix.python_version }}


### PR DESCRIPTION
This PR extends the manylinux wheels generation for `aarch64`.

TODOs:

- [x] GitHub actions does not pick-up an aarch64 runner host