### PR TITLE
Code hygiene remove membase define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,14 +47,8 @@ set(CMAKE_COMPILER bisheng)
 set(CMAKE_C_COMPILER ${CMAKE_COMPILER})
 set(CMAKE_CXX_COMPILER ${CMAKE_COMPILER})
 
-add_compile_options(
-  -D_FORTIFY_SOURCE=2
-  -O2
-  -DMEMORY_BASE
-  -std=c++17
-  -Wno-macro-redefined
-  -Wno-ignored-attributes
-  -fstack-protector-strong)
+add_compile_options(-D_FORTIFY_SOURCE=2 -O2 -std=c++17 -Wno-macro-redefined
+                    -Wno-ignored-attributes -fstack-protector-strong)
 
 add_link_options(-s -Wl,-z,relro -Wl,-z,now)
 
@@ -119,10 +113,6 @@ ascendc_library(
   csrc/kernel/kernel_batch_matrix_square.cpp
   csrc/kernel/kernel_tri_inv_rec_unroll.cpp
   csrc/kernel/kernel_tri_inv_trick.cpp)
-
-# TODO(anastasios): Configure this depending on the NPU device. For A5, use
-# REGISTER_BASE.
-ascendc_compile_definitions(no_workspace_kernel PRIVATE MEMORY_BASE=1)
 
 ascendc_include_directories(
   no_workspace_kernel PRIVATE ${libpto_isa_headers_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,14 @@ set(CMAKE_COMPILER bisheng)
 set(CMAKE_C_COMPILER ${CMAKE_COMPILER})
 set(CMAKE_CXX_COMPILER ${CMAKE_COMPILER})
 
-add_compile_options(-D_FORTIFY_SOURCE=2 -O2 -std=c++17 -Wno-macro-redefined
-                    -Wno-ignored-attributes -fstack-protector-strong)
+add_compile_options(
+  -D_FORTIFY_SOURCE=2
+  -O2
+  -DMEMORY_BASE
+  -std=c++17
+  -Wno-macro-redefined
+  -Wno-ignored-attributes
+  -fstack-protector-strong)
 
 add_link_options(-s -Wl,-z,relro -Wl,-z,now)
 
@@ -113,6 +119,10 @@ ascendc_library(
   csrc/kernel/kernel_batch_matrix_square.cpp
   csrc/kernel/kernel_tri_inv_rec_unroll.cpp
   csrc/kernel/kernel_tri_inv_trick.cpp)
+
+# TODO(anastasios): Configure this depending on the NPU device. For A5, use
+# REGISTER_BASE.
+ascendc_compile_definitions(no_workspace_kernel PRIVATE MEMORY_BASE=1)
 
 ascendc_include_directories(
   no_workspace_kernel PRIVATE ${libpto_isa_headers_SOURCE_DIR}/include

--- a/csrc/host/utils.h
+++ b/csrc/host/utils.h
@@ -90,6 +90,7 @@ inline at::Tensor CopyTensorHostToDevice(const at::Tensor& cpu_tensor) {
  * @param [in] scalar_data_type Data type of scalar
  * @return at::Tensor Tensor on NPU containing the `cpu_scalar`.
  */
+[[maybe_unused]]
 inline at::Tensor CopyScalarToDevice(const c10::Scalar& cpu_scalar,
                                      at::ScalarType scalar_data_type) {
   return CopyTensorHostToDevice(

--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -7,16 +7,13 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 
 template <typename T, unsigned matrix_size>
 AICORE void runTAbs(__gm__ T* x, __gm__ T* z, uint32_t total_length) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
   // define GlobalData on global memory with shape and stride
   using ShapeDim5 = pto::Shape<1, 1, 1, matrix_size, matrix_size>;
   using StrideDim5 = pto::Stride<1, 1, 1, matrix_size, 1>;
@@ -76,6 +73,7 @@ AICORE void runTAbs(__gm__ T* x, __gm__ T* z, uint32_t total_length) {
     set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
   }
+#endif
 }
 
 extern "C" __global__ AICORE void vabs_fp16(GM_ADDR x, GM_ADDR z,
@@ -91,5 +89,3 @@ extern "C" __global__ AICORE void vabs_fp32(GM_ADDR x, GM_ADDR z,
   // main kernel, in_length is dynamic input
   runTAbs<float, martix_size>((__gm__ float*)x, (__gm__ float*)z, in_length);
 }
-
-#endif

--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -9,8 +9,6 @@ for the full License text.
 
 #if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
 
-#define MEMORY_BASE
-
 #include <pto/pto-inst.hpp>
 
 #define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"

--- a/csrc/kernel/kernel_batch_matrix_square.cpp
+++ b/csrc/kernel/kernel_batch_matrix_square.cpp
@@ -6,8 +6,6 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-
-#define MEMORY_BASE
 #include <pto/pto-inst.hpp>
 
 #define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"

--- a/csrc/kernel/kernel_batch_matrix_square.cpp
+++ b/csrc/kernel/kernel_batch_matrix_square.cpp
@@ -6,9 +6,8 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-#include <pto/pto-inst.hpp>
 
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -6,27 +6,7 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-#if defined __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-// Placeholder for VEC compilation (the real kernel is CUBE-only).
-#include <pto/common/type.hpp>
-
-extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
-                                                     uint32_t matrix_size) {}
-
-extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
-                                                     uint32_t matrix_size) {}
-
-#elif (__CHECK_FEATURE_AT_PRECOMPILE) || \
-    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
-
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 
@@ -45,6 +25,9 @@ AICORE inline void WaitFlag(uint32_t id) {
 template <typename InputT, typename OutputT, uint32_t matrix_size>
 AICORE void runKernelSimpleMatMul(__gm__ InputT* a, __gm__ InputT* b,
                                   __gm__ OutputT* c) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // Cube compilation
+
   constexpr uint32_t tile_len = matrix_size * matrix_size;
 
   /* Global Memory / Tensors */
@@ -113,6 +96,7 @@ AICORE void runKernelSimpleMatMul(__gm__ InputT* a, __gm__ InputT* b,
   SetFlag<PIPE_M, PIPE_FIX>(0);   // M pipe sets flag for FIX pipe
   WaitFlag<PIPE_M, PIPE_FIX>(0);  // FIX pipe waits for M pipe to set flag
   TSTORE(c_global_out, c_l0_tile);
+#endif
 }
 
 template <typename T>
@@ -158,5 +142,3 @@ extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
   run_simple_matmul<float>((__gm__ float*)a, (__gm__ float*)b, (__gm__ float*)c,
                            matrix_size);
 }
-
-#endif

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -9,7 +9,6 @@ for the full License text.
 #if defined __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
 
 // Placeholder for VEC compilation (the real kernel is CUBE-only).
-#define MEMORY_BASE
 #include <pto/common/type.hpp>
 
 extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
@@ -24,8 +23,6 @@ extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
 
 #elif (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
-
-#define MEMORY_BASE
 
 #include <pto/pto-inst.hpp>
 

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -7,10 +7,6 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-#define MEMORY_BASE
-
 #include <pto/pto-inst.hpp>
 
 #include "kernel_utils.h"
@@ -32,6 +28,8 @@ using namespace pto;
 template <typename T, unsigned S /* Matrix Size */>
 AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
                        uint32_t total_length) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
   set_mask_norm();
   set_vector_mask(-1, -1);
 
@@ -143,6 +141,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
   }
   wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
   wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+#endif
 }
 
 extern "C" __global__ AICORE void triv_inv_col_sweep_fp16(
@@ -170,5 +169,3 @@ extern "C" __global__ AICORE void triv_inv_col_sweep_fp32(
     runTTriInv<float, 128>((__gm__ float*)x, (__gm__ float*)z, in_length);
   }
 }
-
-#endif

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -7,11 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#include <pto/pto-inst.hpp>
-
 #include "kernel_utils.h"
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -7,12 +7,8 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#include <cstdint>
-#include <pto/pto-inst.hpp>
-
 #include "kernel_utils.h"
 
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 using namespace pto;
 using namespace kernel_utils;
 

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -7,7 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#define MEMORY_BASE
+#include <cstdint>
 #include <pto/pto-inst.hpp>
 
 #include "kernel_utils.h"
@@ -448,7 +448,6 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
   /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;  // fractal size for half
-  constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
   constexpr uint32_t NumL0Buffers = 2;
 
   if (get_block_idx() * NumTilesPerCubeIter >= total_tiles) {

--- a/csrc/kernel/kernel_tri_inv_trick.cpp
+++ b/csrc/kernel/kernel_tri_inv_trick.cpp
@@ -6,8 +6,6 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-
-#define MEMORY_BASE
 #include <pto/pto-inst.hpp>
 
 #define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"

--- a/csrc/kernel/kernel_tri_inv_trick.cpp
+++ b/csrc/kernel/kernel_tri_inv_trick.cpp
@@ -6,9 +6,8 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-#include <pto/pto-inst.hpp>
 
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -8,7 +8,6 @@ for the full License text.
 */
 #pragma once
 
-#define MEMORY_BASE
 #include <pto/pto-inst.hpp>
 
 namespace kernel_utils {

--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -8,7 +8,13 @@ for the full License text.
 */
 #pragma once
 
+#define MEMORY_BASE
+
+#include <cstdint>
 #include <pto/pto-inst.hpp>
+
+// To avoid #include "kernel_operator.h"
+#define GM_ADDR __gm__ uint8_t*
 
 namespace kernel_utils {
 /**


### PR DESCRIPTION
* Fixes https://github.com/huawei-csl/pto-kernels/actions/runs/22804675898/job/66151788098?pr=42#step:4:29
* Defines `MEMORY_BASE` and `GM_ADDR` inside `kernel_utils.h` only.

## TODO

- [ ] Fix unused `SetWaitFlag`