### PR TITLE
Pipelining vector-based column sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 venv/
 kernel_meta/
 doxygen/documentation/
+benchmark_data/

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -101,7 +101,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
     // For every output column j-th
-    for (int32_t j = 0; j < S; j++) {
+    for (int32_t j = S-1; j >= 0; j--) {
       // Column sweep on each column.
 
       // `b` vector is  j-th standard vector (e_j).
@@ -114,7 +114,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       // Must be offset by UB address
       TASSIGN(x, out_start_ub_addr + j * S * sizeof(T));
 
-      for (int32_t k = S - 1; k >= 0; k--) {
+      for (int32_t k = j; k >= 1; k--) {
         TASSIGN(A_k, k * S * sizeof(T));
 
         set_flag(PIPE_V, PIPE_S, EVENT_ID0);

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -101,7 +101,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
     // For every output column j-th
-    for (int32_t j = S-1; j >= 0; j--) {
+    for (int32_t j = S - 1; j >= 0; j--) {
       // Column sweep on each column.
 
       // `b` vector is  j-th standard vector (e_j).

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -115,20 +115,67 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       TASSIGN(x, out_start_ub_addr + j * S * sizeof(T));
 
       T alpha = static_cast<T>(1);
+      T pending_alpha = static_cast<T>(0);
+      int32_t pending_k = -1;
 
-      for (int32_t k = j; k >= 1; k--) {
-        TASSIGN(A_k, k * S * sizeof(T));
+      if constexpr (std::is_same_v<T, float>) {
+        float next_alpha_base = 0.0f;
 
-        // Keep the scalar pipe busy with the x write while the vector pipe
-        // computes the rank-1 update for the next backward-substitution step.
-        TMULS(diff, A_k, alpha);
-        x.SetValue(k, alpha);
-        pipe_barrier(PIPE_V);
-        TSUB(b, b, diff);
+        for (int32_t k = j; k >= 1; k--) {
+          TASSIGN(A_k, k * S * sizeof(T));
 
-        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
-        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-        alpha = b.GetValue(k - 1);
+          // Software-pipeline two neighboring iterations:
+          // 1. overlap the previous scalar x write and current scalar b lane
+          //    read with the current TMULS;
+          // 2. form the next alpha from one diff lane while TSUB updates the
+          //    full vector state for the next iteration.
+          TMULS(diff, A_k, alpha);
+          set_flag(PIPE_V, PIPE_S, EVENT_ID1);
+
+          if (pending_k >= 0) {
+            x.SetValue(pending_k, pending_alpha);
+          }
+          if (k < j) {
+            wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+            next_alpha_base = b.GetValue(k - 1);
+          }
+          pipe_barrier(PIPE_V);
+          TSUB(b, b, diff);
+          set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+
+          pending_k = k;
+          pending_alpha = alpha;
+
+          wait_flag(PIPE_V, PIPE_S, EVENT_ID1);
+          alpha = next_alpha_base - diff.GetValue(k - 1);
+        }
+        if (j > 0) {
+          wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        }
+      } else {
+        for (int32_t k = j; k >= 1; k--) {
+          TASSIGN(A_k, k * S * sizeof(T));
+
+          // Half kernels still overlap the previous x write with the current
+          // TMULS, but keep the next alpha on the original b.GetValue path to
+          // avoid scalar half arithmetic in AICORE code.
+          TMULS(diff, A_k, alpha);
+          if (pending_k >= 0) {
+            x.SetValue(pending_k, pending_alpha);
+          }
+          pipe_barrier(PIPE_V);
+          TSUB(b, b, diff);
+
+          pending_k = k;
+          pending_alpha = alpha;
+
+          set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+          wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+          alpha = b.GetValue(k - 1);
+        }
+      }
+      if (pending_k >= 0) {
+        x.SetValue(pending_k, pending_alpha);
       }
       x.SetValue(0, alpha);
     }

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -107,47 +107,49 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
 
       TASSIGN(x, out_start_ub_addr + j * S * sizeof(T));
 
-      float alpha = 1.0f;
-      float pending_alpha = 0.0f;
-      int32_t pending_k = -1;
+      if (j == 0) {
+        x.SetValue(0, static_cast<T>(1));
+        continue;
+      }
 
-      float next_alpha_base = 0.0f;
+      float xk = 1.0f;
+      float xkp1 = xk;
 
-      for (int32_t k = j; k >= 1; k--) {
+      TASSIGN(A_k, j * S * sizeof(T));
+      TMULS(diff, A_k, static_cast<T>(xk));
+      set_flag(PIPE_V, PIPE_S, EVENT_ID1);
+
+      pipe_barrier(PIPE_V);
+      TSUB(b, b, diff);
+      set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+
+      wait_flag(PIPE_V, PIPE_S, EVENT_ID1);
+      xk = -static_cast<float>(diff.GetValue(j - 1));
+
+      for (int32_t k = j - 1; k >= 1; --k) {
         TASSIGN(A_k, k * S * sizeof(T));
 
-        // Software-pipeline two neighboring iterations:
-        // 1. overlap the previous scalar x write and current scalar b lane
-        //    read with the current TMULS;
-        // 2. form the next alpha from one diff lane while TSUB updates the
-        //    full vector state for the next iteration.
-        TMULS(diff, A_k, static_cast<T>(alpha));
+        // Keep one x lane buffered so the scalar write from the previous
+        // step overlaps the current vector update.
+        TMULS(diff, A_k, static_cast<T>(xk));
         set_flag(PIPE_V, PIPE_S, EVENT_ID1);
 
-        if (pending_k >= 0) {
-          x.SetValue(pending_k, static_cast<T>(pending_alpha));
-        }
-        if (k < j) {
-          wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-          next_alpha_base = static_cast<float>(b.GetValue(k - 1));
-        }
+        x.SetValue(k + 1, static_cast<T>(xkp1));
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        const float bkm1 = static_cast<float>(b.GetValue(k - 1));
         pipe_barrier(PIPE_V);
         TSUB(b, b, diff);
         set_flag(PIPE_V, PIPE_S, EVENT_ID0);
 
-        pending_k = k;
-        pending_alpha = alpha;
+        xkp1 = xk;
 
         wait_flag(PIPE_V, PIPE_S, EVENT_ID1);
-        alpha = next_alpha_base - static_cast<float>(diff.GetValue(k - 1));
+        xk = bkm1 - static_cast<float>(diff.GetValue(k - 1));
       }
-      if (j > 0) {
-        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-      }
-      if (pending_k >= 0) {
-        x.SetValue(pending_k, static_cast<T>(pending_alpha));
-      }
-      x.SetValue(0, static_cast<T>(alpha));
+
+      wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+      x.SetValue(1, static_cast<T>(xkp1));
+      x.SetValue(0, static_cast<T>(xk));
     }
 
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -123,7 +123,6 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
         const T alpha = b.GetValue(k);
         x.SetValue(k, alpha);
 
-        if (k > 0) {
           // b[:k] -= A[:k, k] * x[k]
           TEXPANDS(diff, static_cast<T>(0));
           TMULS(diff, A_k, alpha);
@@ -132,7 +131,11 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
 
           TSUB(b, b, diff);
         }
-      }
+      set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+      // x[k] = b[k] / A[k, k]
+      const T alpha = b.GetValue(0);
+      x.SetValue(0, alpha);
     }
 
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -74,7 +74,6 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
   TASSIGN(diff, UB_ZERO_ADDR + matrix_in_size + b_size);
   TileVecData A_k(1, S);
 
-  // synchronization operations between hardware pipelines
   set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
   set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
 
@@ -83,7 +82,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
        (tile_id < num_tiles_per_aiv) &&
        (global_tile_id + tile_id < total_length / tile_len);
        ++tile_id) {
-    // Set output to all zeros.
+    // TODO (filip) do we have to explictly zero Tiles?
     wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
     TEXPANDS(inv_matrix_out, static_cast<T>(0));
     set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
@@ -94,24 +93,18 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
     GlobalData global_out(vec_out);
     TASSIGN(global_in, vec_in + (global_tile_id + tile_id) * tile_len);
     TASSIGN(global_out, vec_out + (global_tile_id + tile_id) * tile_len);
-    // load data from global memory to UB buffer
     TLOAD(matrix_in, global_in);
 
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-    // For every output column j-th
+    // Find inverse by doing back-sub for each basis vector b_j
     for (int32_t j = S - 1; j >= 0; j--) {
-      // Column sweep on each column.
-
-      // `b` vector is  j-th standard vector (e_j).
       TEXPANDS(b, static_cast<T>(0));
       set_flag(PIPE_V, PIPE_S, EVENT_ID0);
       wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
       b.SetValue(j, static_cast<T>(1));
 
-      // Solve A x = e_j for vector x
-      // Must be offset by UB address
       TASSIGN(x, out_start_ub_addr + j * S * sizeof(T));
 
       float alpha = 1.0f;

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -114,70 +114,47 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       // Must be offset by UB address
       TASSIGN(x, out_start_ub_addr + j * S * sizeof(T));
 
-      T alpha = static_cast<T>(1);
-      T pending_alpha = static_cast<T>(0);
+      float alpha = 1.0f;
+      float pending_alpha = 0.0f;
       int32_t pending_k = -1;
 
-      if constexpr (std::is_same_v<T, float>) {
-        float next_alpha_base = 0.0f;
+      float next_alpha_base = 0.0f;
 
-        for (int32_t k = j; k >= 1; k--) {
-          TASSIGN(A_k, k * S * sizeof(T));
+      for (int32_t k = j; k >= 1; k--) {
+        TASSIGN(A_k, k * S * sizeof(T));
 
-          // Software-pipeline two neighboring iterations:
-          // 1. overlap the previous scalar x write and current scalar b lane
-          //    read with the current TMULS;
-          // 2. form the next alpha from one diff lane while TSUB updates the
-          //    full vector state for the next iteration.
-          TMULS(diff, A_k, alpha);
-          set_flag(PIPE_V, PIPE_S, EVENT_ID1);
+        // Software-pipeline two neighboring iterations:
+        // 1. overlap the previous scalar x write and current scalar b lane
+        //    read with the current TMULS;
+        // 2. form the next alpha from one diff lane while TSUB updates the
+        //    full vector state for the next iteration.
+        TMULS(diff, A_k, static_cast<T>(alpha));
+        set_flag(PIPE_V, PIPE_S, EVENT_ID1);
 
-          if (pending_k >= 0) {
-            x.SetValue(pending_k, pending_alpha);
-          }
-          if (k < j) {
-            wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-            next_alpha_base = b.GetValue(k - 1);
-          }
-          pipe_barrier(PIPE_V);
-          TSUB(b, b, diff);
-          set_flag(PIPE_V, PIPE_S, EVENT_ID0);
-
-          pending_k = k;
-          pending_alpha = alpha;
-
-          wait_flag(PIPE_V, PIPE_S, EVENT_ID1);
-          alpha = next_alpha_base - diff.GetValue(k - 1);
+        if (pending_k >= 0) {
+          x.SetValue(pending_k, static_cast<T>(pending_alpha));
         }
-        if (j > 0) {
+        if (k < j) {
           wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+          next_alpha_base = static_cast<float>(b.GetValue(k - 1));
         }
-      } else {
-        for (int32_t k = j; k >= 1; k--) {
-          TASSIGN(A_k, k * S * sizeof(T));
+        pipe_barrier(PIPE_V);
+        TSUB(b, b, diff);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
 
-          // Half kernels still overlap the previous x write with the current
-          // TMULS, but keep the next alpha on the original b.GetValue path to
-          // avoid scalar half arithmetic in AICORE code.
-          TMULS(diff, A_k, alpha);
-          if (pending_k >= 0) {
-            x.SetValue(pending_k, pending_alpha);
-          }
-          pipe_barrier(PIPE_V);
-          TSUB(b, b, diff);
+        pending_k = k;
+        pending_alpha = alpha;
 
-          pending_k = k;
-          pending_alpha = alpha;
-
-          set_flag(PIPE_V, PIPE_S, EVENT_ID0);
-          wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-          alpha = b.GetValue(k - 1);
-        }
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID1);
+        alpha = next_alpha_base - static_cast<float>(diff.GetValue(k - 1));
+      }
+      if (j > 0) {
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
       }
       if (pending_k >= 0) {
-        x.SetValue(pending_k, pending_alpha);
+        x.SetValue(pending_k, static_cast<T>(pending_alpha));
       }
-      x.SetValue(0, alpha);
+      x.SetValue(0, static_cast<T>(alpha));
     }
 
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -82,7 +82,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
        (tile_id < num_tiles_per_aiv) &&
        (global_tile_id + tile_id < total_length / tile_len);
        ++tile_id) {
-    // TODO (filip) do we have to explictly zero Tiles?
+    // Set output to all zeros.
     wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
     TEXPANDS(inv_matrix_out, static_cast<T>(0));
     set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
@@ -99,6 +99,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
     // Find inverse by doing back-sub for each basis vector b_j
+    // Solve A x = e_j for vector x
     for (int32_t j = S - 1; j >= 0; j--) {
       TEXPANDS(b, static_cast<T>(0));
       set_flag(PIPE_V, PIPE_S, EVENT_ID0);
@@ -112,11 +113,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
         continue;
       }
 
-      float xk = 1.0f;
-      float xkp1 = xk;
-
       TASSIGN(A_k, j * S * sizeof(T));
-      TMULS(diff, A_k, static_cast<T>(xk));
       set_flag(PIPE_V, PIPE_S, EVENT_ID1);
 
       pipe_barrier(PIPE_V);
@@ -124,7 +121,9 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       set_flag(PIPE_V, PIPE_S, EVENT_ID0);
 
       wait_flag(PIPE_V, PIPE_S, EVENT_ID1);
-      xk = -static_cast<float>(diff.GetValue(j - 1));
+      // Scalar core only supports fp32 arithmetic, so use float rather than T
+      float xk = -static_cast<float>(diff.GetValue(j - 1));
+      float xkp1 = 1.0f;
 
       for (int32_t k = j - 1; k >= 1; --k) {
         TASSIGN(A_k, k * S * sizeof(T));

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -114,27 +114,22 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       // Must be offset by UB address
       TASSIGN(x, out_start_ub_addr + j * S * sizeof(T));
 
+      T alpha = static_cast<T>(1);
+
       for (int32_t k = j; k >= 1; k--) {
         TASSIGN(A_k, k * S * sizeof(T));
 
+        // Keep the scalar pipe busy with the x write while the vector pipe
+        // computes the rank-1 update for the next backward-substitution step.
+        TMULS(diff, A_k, alpha);
+        x.SetValue(k, alpha);
+        pipe_barrier(PIPE_V);
+        TSUB(b, b, diff);
+
         set_flag(PIPE_V, PIPE_S, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-        // x[k] = b[k] / A[k, k]
-        const T alpha = b.GetValue(k);
-        x.SetValue(k, alpha);
-
-          // b[:k] -= A[:k, k] * x[k]
-          TEXPANDS(diff, static_cast<T>(0));
-          TMULS(diff, A_k, alpha);
-          set_flag(PIPE_V, PIPE_S, EVENT_ID0);
-          wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-
-          TSUB(b, b, diff);
-        }
-      set_flag(PIPE_V, PIPE_S, EVENT_ID0);
-      wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
-      // x[k] = b[k] / A[k, k]
-      const T alpha = b.GetValue(0);
+        alpha = b.GetValue(k - 1);
+      }
       x.SetValue(0, alpha);
     }
 

--- a/python/pto_kernels/__init__.py
+++ b/python/pto_kernels/__init__.py
@@ -2,4 +2,5 @@
 # See https://github.com/facebookresearch/pytorch3d/issues/1531#issuecomment-1538198217
 import torch  # noqa
 
+from .benchmarking import do_bench  # noqa
 from .pto_kernels_ops import *  # noqa

--- a/python/pto_kernels/benchmarking.py
+++ b/python/pto_kernels/benchmarking.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Callable, Literal
+
+import torch
+
+
+def do_bench(
+    fn: Callable[[], object],
+    warmup_iters: int = 5,
+    benchmark_iters: int = 15,
+    aggregation: Literal["mean", "none"] = "mean",
+    unit: Literal["s", "ms", "us", "ns"] = "us",
+    flush_cache: bool = True,
+) -> float | list[float]:
+    import torch_npu
+
+    start_events = [torch.npu.Event(enable_timing=True) for _ in range(benchmark_iters)]
+    end_events = [torch.npu.Event(enable_timing=True) for _ in range(benchmark_iters)]
+
+    cache = None
+    if flush_cache:
+        cache = torch.empty((256 * 1024 * 1024,), dtype=torch.int8).npu()
+
+    for _ in range(warmup_iters):
+        fn()
+    torch_npu.npu.synchronize()
+
+    for i in range(benchmark_iters):
+        if cache is not None:
+            cache.zero_()
+        start_events[i].record()
+        fn()
+        end_events[i].record()
+
+    torch_npu.npu.synchronize()
+    factor = {"s": 1e-3, "ms": 1e0, "us": 1e3, "ns": 1e6}[unit]
+    times = [
+        factor * start.elapsed_time(end) for start, end in zip(start_events, end_events)
+    ]
+    if aggregation == "mean":
+        return sum(times) / len(times)
+    return times

--- a/tests/test_tri_inv_col_sweep.py
+++ b/tests/test_tri_inv_col_sweep.py
@@ -130,3 +130,53 @@ def test_tri_inv_col_sweep_np_linalg_inv(
     # https://nhigham.com/wp-content/uploads/2023/08/high89t.pdf
     scaled_rtol = min([0.05, 10 * (matrix_size + batch_size) * rtol])
     assert torch.allclose(actual, golden_numpy_as_torch, atol=atol, rtol=scaled_rtol)
+
+
+def plot_csv(path):
+    import matplotlib.pyplot as plt
+
+    series = {}
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            key = (row["dtype"], row["batch_size"])
+            series.setdefault(key, [[], []])
+            series[key][0].append(int(row["matrix_size"]))
+            series[key][1].append(float(row["bandwidth_gbps"]))
+
+    for (dt, bs), (xs, ys) in sorted(series.items()):
+        order = sorted(range(len(xs)), key=xs.__getitem__)
+        plt.plot(
+            [xs[i] for i in order],
+            [ys[i] for i in order],
+            marker="o",
+            label=f"{dt}, bs={bs}",
+        )
+    plt.xlabel("matrix_size")
+    plt.ylabel("bandwidth_gbps")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(str(path).replace(".csv", ".png"))
+
+
+if __name__ == "__main__":
+    import csv
+    from pathlib import Path
+    from pto_kernels import do_bench
+
+    rows = [["dtype", "matrix_size", "batch_size", "time_ms", "bandwidth_gbps"]]
+    for dt in (np.float16, np.float32):
+        for S in (16, 32, 64, 128):
+            for bs in (256,):
+                x = torch.from_numpy(rand_np_tril(bs, S, dt).transpose(0, 2, 1)).npu()
+                ms = do_bench(lambda: pto_tri_inv(x), unit="ms")
+                n_el, size = x.numel(), x.element_size()
+                gbps = 2 * n_el * size / (ms / 1e3) / 1e9
+                print(f"{dt.__name__}, N={S}, bs={bs}, {ms:.3f} ms, {gbps:.3f} GB/s")
+                rows.append([dt.__name__, S, bs, ms, gbps])
+
+    output = Path("benchmark_data/tri_inv_col_sweep.csv")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="") as f:
+        csv.writer(f).writerows(rows)
+    print(output)
+    plot_csv(output)


### PR DESCRIPTION
Speedup is 2x-3x over all fp32 cases. Since the kernel is bound by the scalar core the fp16 sees less improvment as half of the bandwidth but GetValue and SetValue is still just as slow in fp16.


Plotted with #58 

| # 34fd010 | # 78e3da0 |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/622e98c3-9f6b-4a53-9c30-fd3a18cb4306" width="100%"> | <img src="https://github.com/user-attachments/assets/262d0bfd-37a4-49a5-b9c9-2e836a7ac107" width="100%"> |


## Profiling

The col sweep has two main work items: `LD+ST` for scalar core, and `MUL+SUB` for vector core.

Original kernel showing significant pipeline gaps
<img width="1488" height="390" alt="image" src="https://github.com/user-attachments/assets/d35573ac-0ec4-40ce-99b1-9010f019806a" />


Here is the fully overlapped kernel where loads are done in parallel to stores.
<img width="1501" height="337" alt="image" src="https://github.com/user-attachments/assets/b1fa6800-e35a-4e31-8a20-9d8503dbd76a" />



