### PR TITLE
Support variable-length for BSND tri_inv_rec_unroll

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -27,8 +27,8 @@ pep8:
 pylint:
   run: true
   options:
-    max-args: 8
-    max-positional-arguments: 8
+    max-args: 10
+    max-positional-arguments: 10
   disable:
     - import-error
     - import-outside-toplevel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,14 @@ include(${ASCENDC_CMAKE_DIR}/ascendc.cmake)
 
 include(FetchContent)
 
+# certain operations need newer pto-isa header, not CANN 8.5.0 default (pin
+# commit on 2026/03/16
+# https://gitcode.com/cann/pto-isa/commit/313817be696792a4e16a7ea5994ec98e34391613?ref=master)
+# to use default CANN 8.5.0 headers set GIT_TAG "8.5.0"
 FetchContent_Declare(
   libpto_isa_headers
   GIT_REPOSITORY https://gitcode.com/cann/pto-isa.git
-  GIT_TAG 8.5.0)
+  GIT_TAG "313817be696792a4e16a7ea5994ec98e34391613")
 
 FetchContent_Populate(libpto_isa_headers)
 

--- a/csrc/host/pybind11.cpp
+++ b/csrc/host/pybind11.cpp
@@ -38,6 +38,7 @@ PYBIND11_MODULE(pto_kernels_ops, m) {
   m.def("pto_simple_matmul", &pto_isa_ops::run_simple_matmul);
   m.def("pto_tri_inv_trick", &pto_isa_ops::run_tri_inv_trick);
   m.def("pto_tri_inv_rec_unroll", &pto_isa_ops::run_tri_inv_rec_unroll,
-        py::arg("M"), py::arg("is_bsnd_format") = false);
+        py::arg("M"), py::arg("is_bsnd_format") = false,
+        py::arg("cu_seqlens") = at::zeros({1}));
   m.def("pto_tri_inv", &pto_isa_ops::run_tri_inv);
 }

--- a/csrc/host/torch_tri_inv_rec_unroll.h
+++ b/csrc/host/torch_tri_inv_rec_unroll.h
@@ -25,10 +25,13 @@ namespace pto_isa_ops {
  * in memory, and thus we define num_bsnd_heads=0. If true, then the matrices
  * are stored in "strided mode". In this case we define:
  * num_bsnd_heads=M.size(-2), which is used to do strided load / store ops.
+ * @param cu_seqlens A 1-dimensional torch tensor that contains the lengths
+ * of each input sequence (it is the cummulative sum of the lengths)
  * @return at::Tensor Tensor containing inverses of input matrices.
  */
-at::Tensor run_tri_inv_rec_unroll(const at::Tensor& M,
-                                  const bool is_bsnd_format = false) {
+at::Tensor run_tri_inv_rec_unroll(
+    const at::Tensor& M, const bool is_bsnd_format = false,
+    const at::Tensor& cu_seqlens = at::zeros({1})) {
   const at::Device device = M.options().device();
   const auto dtype = M.options().dtype();
   const auto dtype_out = at::kFloat;
@@ -43,9 +46,19 @@ at::Tensor run_tri_inv_rec_unroll(const at::Tensor& M,
       is_bsnd_format ? static_cast<uint32_t>(M.size(-2)) : 0;
 
   const uint32_t num_elems = static_cast<uint32_t>(M.numel());
-  const uint32_t total_tiles =
-      static_cast<uint32_t>(num_elems / (matrix_size * matrix_size));
-
+  uint32_t total_tiles = 0;
+  if (is_bsnd_format && (cu_seqlens.numel() > 1)) {
+    for (int j = 1; j < cu_seqlens.size(0); ++j) {
+      const uint32_t this_seq_len = static_cast<uint32_t>(
+          cu_seqlens[j].item<int>() - cu_seqlens[j - 1].item<int>());
+      total_tiles +=
+          static_cast<uint32_t>((this_seq_len + matrix_size - 1) / matrix_size);
+    }
+    total_tiles = total_tiles * num_bsnd_heads;
+  } else {
+    total_tiles =
+        static_cast<uint32_t>(num_elems / (matrix_size * matrix_size));
+  }
   uint32_t block_dim = GetNumCubeCores();
   if (total_tiles < block_dim) {
     block_dim = total_tiles;
@@ -60,8 +73,14 @@ at::Tensor run_tri_inv_rec_unroll(const at::Tensor& M,
   I_neg.fill_diagonal_(-1);
 
   if (dtype == at::kHalf) {
-    EXEC_KERNEL_CMD(tri_inv_rec_unroll_fp16, block_dim, M_inv, M, I_neg,
-                    matrix_size, total_tiles, num_bsnd_heads);
+    if (cu_seqlens.numel() == 1) {
+      void* void_null_ptr = nullptr;
+      EXEC_KERNEL_CMD(tri_inv_rec_unroll_fp16, block_dim, M_inv, M, I_neg,
+                      matrix_size, total_tiles, num_bsnd_heads, void_null_ptr);
+    } else {
+      EXEC_KERNEL_CMD(tri_inv_rec_unroll_fp16, block_dim, M_inv, M, I_neg,
+                      matrix_size, total_tiles, num_bsnd_heads, cu_seqlens);
+    }
   }
 
   return M_inv;

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -7,7 +7,9 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
+#ifndef MEMORY_BASE
 #define MEMORY_BASE
+#endif
 #include <pto/pto-inst.hpp>
 
 #include "kernel_utils.h"
@@ -20,6 +22,54 @@ using namespace kernel_utils;
   (((tile_id) / (N)) * (S) * (N) * (D) + ((tile_id) % (N)) * (D))
 
 /*
+ * For aligned BSND, tile_id enumerates chunk-major then head-major and maps to
+ * a fixed-stride address inside the dense BSND tensor.
+ */
+AICORE inline uint32_t GetBSNDFixedTileOffset(uint32_t tile_id,
+                                              uint32_t num_bsnd_heads,
+                                              uint32_t matrix_size) {
+  return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
+}
+
+/**
+ * @brief Struct containing starting address and size of a single tile
+ */
+struct BSNDVarlenTileInfo {
+  uint32_t bsnd_offset; /**< Contains the starting index in the global tensor */
+  uint32_t valid_size;  /**< This is the size (num_rows/cols) of the tile */
+};
+
+/*
+ * For cu_seqlens-based varlen BSND, tile_id still enumerates chunk-major then
+ * head-major. We recover the owning sequence by scanning cu_seqlens and
+ * counting chunks per sequence.
+ */
+AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(
+    uint32_t tile_id, uint32_t num_bsnd_heads, uint32_t matrix_size,
+    __gm__ int32_t* cu_seqlens) {
+  const uint32_t head_idx = tile_id % num_bsnd_heads;
+  const uint32_t chunk_idx = tile_id / num_bsnd_heads;
+
+  uint32_t seq_start = static_cast<uint32_t>(cu_seqlens[0]);
+  uint32_t accumulated_chunks = 0;
+  for (uint32_t seq_idx = 0;; ++seq_idx) {
+    const uint32_t seq_end = static_cast<uint32_t>(cu_seqlens[seq_idx + 1]);
+    const uint32_t seq_len = seq_end - seq_start;
+    const uint32_t seq_num_chunks = CeilDiv(seq_len, matrix_size);
+    if (chunk_idx < accumulated_chunks + seq_num_chunks) {
+      const uint32_t local_chunk_idx = chunk_idx - accumulated_chunks;
+      const uint32_t row_start = seq_start + local_chunk_idx * matrix_size;
+      const uint32_t valid_size =
+          min(static_cast<uint32_t>(seq_end - row_start), matrix_size);
+      return {row_start * num_bsnd_heads * matrix_size + head_idx * matrix_size,
+              valid_size};
+    }
+    accumulated_chunks += seq_num_chunks;
+    seq_start = seq_end;
+  }
+}
+
+/*
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
  * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
  * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
@@ -30,7 +80,7 @@ using namespace kernel_utils;
  * @tparam MatrixSize Size of the entire input/output matrices.
  * @tparam SrcL1TileT The actual tile type of the src matrix.
  * @tparam DstL0TileT The actual tile type of the dst matrix.
-
+ *
  * @param src Tile in L1 memory.
  * @param dst Tile in L0A or L0B memory.
  */
@@ -72,7 +122,7 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
  * @tparam MatrixSize Size of the entire input/output matrices.
  * @tparam SrcL1TileT The actual tile type of the src matrix.
  * @tparam DstL0TileT The actual tile type of the dst matrix.
-
+ *
  * @param src Tile in L1 memory.
  * @param dst Tile in L0A or L0B memory.
  * @param block_size Size of diagonal blocks. Needs: block_size >= FractalSize.
@@ -444,7 +494,8 @@ template <typename InputT, typename OutputT, uint32_t MatrixSize,
 AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          __gm__ InputT* M, __gm__ InputT* I_neg,
                                          uint32_t total_tiles,
-                                         uint32_t num_bsnd_heads = 0) {
+                                         uint32_t num_bsnd_heads = 0,
+                                         __gm__ int32_t* cu_seqlens = nullptr) {
   /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;  // fractal size for half
@@ -462,7 +513,10 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileIn =
       GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
-
+  using GlobalTileDynamicShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GlobalTileDynamicStride = Stride<1, 1, 1, DYNAMIC, 1>;
+  using GlobalTileDynamicIn = GlobalTensor<InputT, GlobalTileDynamicShape,
+                                           GlobalTileDynamicStride, Layout::ND>;
   using GlobalTileStridesINeg =
       BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
   using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn,
@@ -475,15 +529,22 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
                                      GlobalTileStridesOut, Layout::ND>;
-
+  using GlobalTileDynamicOut =
+      GlobalTensor<OutputT, GlobalTileDynamicShape, GlobalTileDynamicStride,
+                   Layout::ND>;
   using TileL1AB =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
            MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
+  using TileL1ABDynamic =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           DYNAMIC, DYNAMIC, SLayout::RowMajor, 512, PadValue::Zero>;
 
   // L0 Memory
   using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
   using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
   using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
+  using TileL0CDynamic =
+      TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
   GlobalTileINeg I_neg_global_in(I_neg);
 
@@ -525,6 +586,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
 
   /* Main iteration - Compute all tiles */
+  uint32_t bsnd_tile_offsets[NumTilesPerCubeIter] = {0};
+  uint32_t bsnd_tile_valid_sizes[NumTilesPerCubeIter] = {0};
   uint32_t next_tile_id_that_waits_for_pipe_fix_pipe_m = 0;
   set_flag(PIPE_FIX, PIPE_M,
            static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
@@ -541,13 +604,39 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
       if constexpr (IsBSND) {
-        GlobalTileIn M_global_in(
-            M + BSND_OFFSET(global_index + tile_id, num_bsnd_heads, MatrixSize,
-                            MatrixSize),
-            {}, {static_cast<int>(MatrixSize * num_bsnd_heads)});
+        const uint32_t global_tile_id = global_index + tile_id;
+        if (cu_seqlens != nullptr) {
+          const BSNDVarlenTileInfo tile_info =
+              GetBSNDVarlenTileInfoFromCuSeqlens(global_tile_id, num_bsnd_heads,
+                                                 MatrixSize, cu_seqlens);
+          bsnd_tile_offsets[tile_id] = tile_info.bsnd_offset;
+          bsnd_tile_valid_sizes[tile_id] = tile_info.valid_size;
+        } else {
+          bsnd_tile_offsets[tile_id] = GetBSNDFixedTileOffset(
+              global_tile_id, num_bsnd_heads, MatrixSize);
+          bsnd_tile_valid_sizes[tile_id] = MatrixSize;
+        }
+        const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
+        const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
+        const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
-        TLOAD(Y_l1_tile[tile_id],
-              M_global_in);  // Copies NumTilesPerCubeIter tiles at once
+        if (valid_size < MatrixSize) {
+          TileL1ABDynamic Y_dyn_l1_tile(valid_size, valid_size);
+          TASSIGN(Y_dyn_l1_tile,
+                  0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+          GlobalTileDynamicIn M_global_in_dyn(
+              M + bsnd_offset,
+              {1, 1, 1, static_cast<int>(valid_size),
+               static_cast<int>(valid_size)},
+              {1, 1, 1, row_stride, 1});
+          TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
+          set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+          wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+          TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
+        } else {
+          GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
+          TLOAD(Y_l1_tile[tile_id], M_global_in);
+        }
       } else {
         GlobalTileIn M_global_in(M + (global_index + tile_id) * TileLen);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
@@ -576,11 +665,23 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
 
       /* Store result */
       if constexpr (IsBSND) {
-        GlobalTileOut M_inv_global_out(
-            M_inv + BSND_OFFSET(global_index + tile_id, num_bsnd_heads,
-                                MatrixSize, MatrixSize),
-            {}, {static_cast<int>(MatrixSize * num_bsnd_heads)});
-        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+        const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
+        const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
+        const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
+        if (valid_size < MatrixSize) {
+          TileL0CDynamic c_l0_tail_tile(valid_size, valid_size);
+          TASSIGN(c_l0_tail_tile,
+                  0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+          GlobalTileDynamicOut M_inv_global_out_dyn(
+              M_inv + bsnd_offset,
+              {1, 1, 1, static_cast<int>(valid_size),
+               static_cast<int>(valid_size)},
+              {1, 1, 1, row_stride, 1});
+          TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
+        } else {
+          GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {}, {row_stride});
+          TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+        }
       } else {
         GlobalTileOut M_inv_global_out(M_inv +
                                        (global_index + tile_id) * TileLen);
@@ -607,12 +708,14 @@ template <typename InputT, typename OutputT, uint32_t MatrixSize,
           uint32_t NumTilesPerCubeIter, bool IsBSND>
 AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
                                      __gm__ InputT* I_neg, uint32_t total_tiles,
-                                     uint32_t num_bsnd_heads = 0) {
+                                     uint32_t num_bsnd_heads = 0,
+                                     __gm__ int32_t* cu_seqlens = nullptr) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // Cube compilation
 
   TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
-                        IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads);
+                        IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
+                                cu_seqlens);
 #else
 // Nothing to do on AIV
 #endif
@@ -623,29 +726,30 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
                                    __gm__ InputT* tensor_in,
                                    __gm__ InputT* minus_identity_in,
                                    uint32_t matrix_size, uint32_t num_matrices,
-                                   uint32_t num_bsnd_heads) {
+                                   uint32_t num_bsnd_heads,
+                                   __gm__ int32_t* cu_seqlens = nullptr) {
   static_assert(std::is_same_v<InputT, half>,
                 "tri_inv_rec_unroll supports only fp16.");
   switch (matrix_size) {
     case 16:
       runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, cu_seqlens);
       break;
     case 32:
       runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, cu_seqlens);
       break;
     case 64:
       runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, cu_seqlens);
       break;
     case 128:
       runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, cu_seqlens);
       break;
   }
 }
@@ -669,26 +773,26 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
 extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
     __gm__ void* tensor_out, __gm__ void* tensor_in,
     __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
-    uint32_t num_bsnd_heads) {
+    uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
   if (num_bsnd_heads == 0) {
     if (num_matrices <= get_block_num()) {
       run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
                              false /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
       run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
                              false /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else {
       run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
                              false /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     }
   } else {
     if (num_matrices <= get_block_num()) {
@@ -696,19 +800,19 @@ extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
                              true /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
       run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
                              true /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else {
       run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
                              true /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     }
   }
 }

--- a/examples/jit_cpp/fast_inverse/.gitignore
+++ b/examples/jit_cpp/fast_inverse/.gitignore
@@ -1,0 +1,2 @@
+benchmark_results
+*.so

--- a/examples/jit_cpp/fast_inverse/README.md
+++ b/examples/jit_cpp/fast_inverse/README.md
@@ -52,12 +52,11 @@ and batch configurations.
 
 ### Varlen BSND mode
 
-The standalone example also supports variable-length BSND inputs by padding each
-sequence to the next multiple of `D` and passing a `chunk_indices` tensor to the
-kernel. Each entry in `chunk_indices` is the padded row-start of one valid
-chunk. The kernel still inverts dense `D x D` tiles; the Python harness pads
-inputs before launch and slices the padded rows back away when validating the
-result.
+The standalone example also supports variable-length BSND inputs with the same
+external signature as the Triton reference path: callers provide packed BSND
+data plus `cu_seqlens`, and the PTO kernel derives each chunk row-start and
+tail size internally on NPU. The kernel still inverts dense `D x D` tiles, but
+tail chunks load/store only their valid prefix.
 
 ### Benchmark
 

--- a/examples/jit_cpp/fast_inverse/README.md
+++ b/examples/jit_cpp/fast_inverse/README.md
@@ -22,7 +22,7 @@ The implementation uses a two-phase recursive approach on Ascend cube cores:
 |------|---------|
 | `fast_inverse.cpp` | Thin JIT wrapper: includes the kernel and exposes `call_kernel` |
 | `jit_util_fast_inverse.py` | Compiles the kernel with `bisheng` and loads it via `ctypes` |
-| `run_fast_inverse.py` | Correctness test suite (mirrors the pytest unit tests) |
+| `run_fast_inverse.py` | Correctness test suite, including aligned and varlen BSND coverage |
 
 ### Usage
 
@@ -48,3 +48,12 @@ and batch configurations.
 |-----------------|---------------|
 | `0` (default) | Each matrix stored consecutively in row-major order (`B × … × N × D × D`) |
 | `> 0` | BSND layout: `(B, S, N, D)` where S is chunked into tiles of size D and N heads are interleaved |
+
+### Varlen BSND mode
+
+The standalone example also supports variable-length BSND inputs by padding each
+sequence to the next multiple of `D` and passing a `chunk_indices` tensor to the
+kernel. Each entry in `chunk_indices` is the padded row-start of one valid
+chunk. The kernel still inverts dense `D x D` tiles; the Python harness pads
+inputs before launch and slices the padded rows back away when validating the
+result.

--- a/examples/jit_cpp/fast_inverse/README.md
+++ b/examples/jit_cpp/fast_inverse/README.md
@@ -1,0 +1,50 @@
+## fast_inverse — JIT triangular matrix inverse (recursive unroll)
+
+JIT-compiled example of `kernel_tri_inv_rec_unroll`, which inverts a batch of
+upper-triangular fp16 matrices stored in a multi-dimensional tensor.
+
+### Algorithm
+
+Given an input tensor whose last two dimensions form an n×n upper-triangular
+matrix U (off-diagonal part only; the diagonal is assumed to be all-ones), the
+kernel computes the inverse of (U + I) for every matrix in the batch.
+
+The implementation uses a two-phase recursive approach on Ascend cube cores:
+
+1. **Inv-trick phase** – inverts each 16×16 diagonal fractal block via a
+   Neumann-series expansion (`X = (I − M) + (I − M)·M + …`).
+2. **Unrolled recursion phase** – assembles partial inverses of progressively
+   larger sub-blocks until the full matrix is inverted.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `fast_inverse.cpp` | Thin JIT wrapper: includes the kernel and exposes `call_kernel` |
+| `jit_util_fast_inverse.py` | Compiles the kernel with `bisheng` and loads it via `ctypes` |
+| `run_fast_inverse.py` | Correctness test suite (mirrors the pytest unit tests) |
+
+### Usage
+
+```bash
+export PTO_LIB_PATH=/sources/pto-isa/  # need latest header, not CANN 8.5.0 default
+
+cd examples/jit_cpp/fast_inverse
+python run_fast_inverse.py
+```
+
+The script compiles `fast_inverse.cpp` on first run (takes ~60 s), then
+executes correctness checks across a range of matrix sizes (16, 32, 64, 128)
+and batch configurations.
+
+### Supported matrix sizes
+
+`matrix_size` (last dimension of the input tensor) must be one of: **16, 32,
+64, 128**.
+
+### Layout conventions
+
+| `num_bsnd_heads` | Memory layout |
+|-----------------|---------------|
+| `0` (default) | Each matrix stored consecutively in row-major order (`B × … × N × D × D`) |
+| `> 0` | BSND layout: `(B, S, N, D)` where S is chunked into tiles of size D and N heads are interleaved |

--- a/examples/jit_cpp/fast_inverse/README.md
+++ b/examples/jit_cpp/fast_inverse/README.md
@@ -23,6 +23,7 @@ The implementation uses a two-phase recursive approach on Ascend cube cores:
 | `fast_inverse.cpp` | Thin JIT wrapper: includes the kernel and exposes `call_kernel` |
 | `jit_util_fast_inverse.py` | Compiles the kernel with `bisheng` and loads it via `ctypes` |
 | `run_fast_inverse.py` | Correctness test suite, including aligned and varlen BSND coverage |
+| `run_fast_inverse_varlen_like_triton.py` | Standalone varlen runner that mirrors the Triton `test_solve_tril_varlen` input generation in pure PyTorch |
 | `benchmark_bsnd_fast_inverse.py` | Benchmarks fixed BSND vs varlen-uniform BSND and plots effective bandwidth |
 
 ### Usage
@@ -37,6 +38,23 @@ python run_fast_inverse.py
 The script compiles `fast_inverse.cpp` on first run (takes ~60 s), then
 executes correctness checks across a range of matrix sizes (16, 32, 64, 128)
 and batch configurations.
+
+To run the standalone Triton-like varlen coverage:
+
+```bash
+export PTO_LIB_PATH=/sources/pto-isa/
+
+cd examples/jit_cpp/fast_inverse
+python run_fast_inverse_varlen_like_triton.py
+```
+
+That script:
+
+- uses the same varlen case list and input-generation structure as
+  `flash-linear-attention/tests/ops/test_solve_tril.py::test_solve_tril_varlen`
+- keeps PTO inputs in `float16`
+- emulates `chunk_scaled_dot_kkt_fwd` in PyTorch because Triton is not available
+- prints a simple pytest-like `PASS` / `FAIL` report plus a final summary
 
 ### Supported matrix sizes
 

--- a/examples/jit_cpp/fast_inverse/README.md
+++ b/examples/jit_cpp/fast_inverse/README.md
@@ -23,6 +23,7 @@ The implementation uses a two-phase recursive approach on Ascend cube cores:
 | `fast_inverse.cpp` | Thin JIT wrapper: includes the kernel and exposes `call_kernel` |
 | `jit_util_fast_inverse.py` | Compiles the kernel with `bisheng` and loads it via `ctypes` |
 | `run_fast_inverse.py` | Correctness test suite, including aligned and varlen BSND coverage |
+| `benchmark_bsnd_fast_inverse.py` | Benchmarks fixed BSND vs varlen-uniform BSND and plots effective bandwidth |
 
 ### Usage
 
@@ -57,3 +58,26 @@ kernel. Each entry in `chunk_indices` is the padded row-start of one valid
 chunk. The kernel still inverts dense `D x D` tiles; the Python harness pads
 inputs before launch and slices the padded rows back away when validating the
 result.
+
+### Benchmark
+
+To compare the original fixed-length BSND path against the new varlen path in a
+matched-size sanity check:
+
+```bash
+export PTO_LIB_PATH=/sources/pto-isa/
+
+cd examples/jit_cpp/fast_inverse
+python benchmark_bsnd_fast_inverse.py --chunk-size 64
+```
+
+The benchmark script:
+
+- runs only the PTO-ISA BSND kernel
+- compares `bsnd-fixed` against `bsnd-varlen-uniform`
+- uses uniform `cu_seqlens=[0, T, 2T, ...]` so both paths process the same
+  total data size
+- reports numerical agreement between the two outputs
+- also generates a true-varlen benchmark that plots scattered bandwidth points
+  against aggregated sequence length
+- writes all CSV and PNG artifacts into `examples/jit_cpp/fast_inverse/benchmark_results/`

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -10,7 +10,8 @@
 """
 Benchmark the standalone BSND fast-inverse kernel.
 
-This script only benchmarks the PTO-ISA BSND kernel in two modes:
+This script benchmarks the PTO-ISA BSND kernel in two modes using Triton-unit-
+test-like inputs:
 
 1. `bsnd-fixed`:
    Original aligned BSND layout with shape `(B, T, H, D)`.
@@ -18,9 +19,12 @@ This script only benchmarks the PTO-ISA BSND kernel in two modes:
    The new varlen path using packed shape `(1, B*T, H, D)` with uniform
    `cu_seqlens = [0, T, 2T, ...]`.
 
-The two modes use the same total token count and the same underlying chunk data,
-so their latency / effective bandwidth can be compared directly. The script also
-checks that both modes produce numerically matching results.
+The two modes use the same total token count and the same underlying `k` / `beta`
+inputs. `A` is generated in eager PyTorch with an emulation of
+`chunk_scaled_dot_kkt_fwd`, then each valid chunk is transposed before launch so
+the PTO kernel still sees its expected upper-triangular layout. The script also
+checks that both modes produce numerically matching results after transposing
+outputs back to the lower-triangular convention used by the Triton tests.
 """
 
 from __future__ import annotations
@@ -34,6 +38,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+import torch.nn.functional as F
 import torch_npu  # noqa: F401
 
 from jit_util_fast_inverse import jit_compile
@@ -41,6 +46,7 @@ from jit_util_fast_inverse import jit_compile
 
 DEFAULT_SEQLENS = (512, 1024, 2048, 4096, 8192, 16384)
 DEFAULT_CACHE_SIZE = 256 * 1024 * 1024
+DEFAULT_FEATURE_DIM = 64
 NPU_DEVICE = os.getenv("GDN_TRI_INVERSE_NPU_DEVICE", "npu:0")
 THIS_DIR = Path(__file__).resolve().parent
 RESULTS_DIR = THIS_DIR / "benchmark_results"
@@ -79,35 +85,77 @@ def count_varlen_chunks(
     )
 
 
-def random_chunk_mats(
-    total_chunks: int,
-    num_heads: int,
+def chunk_scaled_dot_kkt_fwd_emulated(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
     chunk_size: int,
-    scale: float,
-    device: str,
 ) -> torch.Tensor:
-    return scale * torch.triu(
-        torch.rand(
-            (total_chunks, num_heads, chunk_size, chunk_size),
-            dtype=torch.half,
-            device=device,
-        ),
-        diagonal=1,
-    )
+    total_tokens = int(cu_seqlens[-1].item())
+    num_heads = k.shape[2]
+    A = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=k.dtype, device=k.device)
+
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        for chunk_start in range(bos, eos, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, eos)
+            actual_size = chunk_end - chunk_start
+            k_chunk = k[:, chunk_start:chunk_end].transpose(1, 2).to(torch.float32)
+            beta_chunk = (
+                beta[:, chunk_start:chunk_end]
+                .transpose(1, 2)
+                .unsqueeze(-1)
+                .to(torch.float32)
+            )
+            scores = torch.matmul(k_chunk, k_chunk.transpose(-1, -2))
+            scores = torch.tril(scores * beta_chunk, diagonal=-1).to(k.dtype)
+            A[:, chunk_start:chunk_end, :, :actual_size] = scores.transpose(1, 2)
+
+    return A
+
+
+def transpose_valid_chunks(
+    A: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    transposed = torch.zeros_like(A)
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        for chunk_start in range(bos, eos, chunk_size):
+            actual_size = min(chunk_size, eos - chunk_start)
+            chunk = A[:, chunk_start : chunk_start + actual_size, :, :actual_size]
+            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = chunk.transpose(
+                1, 3
+            )
+    return transposed
 
 
 def build_fixed_bsnd_input(
-    chunk_mats: torch.Tensor,
     batch_size: int,
     seqlen: int,
     num_heads: int,
     chunk_size: int,
-) -> torch.Tensor:
-    return (
-        chunk_mats.transpose(1, 2)
-        .contiguous()
-        .reshape(batch_size, seqlen, num_heads, chunk_size)
+    feature_dim: int,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    total_tokens = batch_size * seqlen
+    cu_seqlens = torch.arange(
+        0,
+        total_tokens + 1,
+        seqlen,
+        dtype=torch.int32,
+        device=device,
     )
+    k = F.normalize(
+        torch.randn((1, total_tokens, num_heads, feature_dim), dtype=torch.float16, device=device),
+        dim=-1,
+    )
+    beta = torch.randn((1, total_tokens, num_heads), dtype=torch.float16, device=device).sigmoid()
+    A = transpose_valid_chunks(
+        chunk_scaled_dot_kkt_fwd_emulated(k, beta, cu_seqlens, chunk_size),
+        cu_seqlens,
+        chunk_size,
+    )
+    return A.reshape(batch_size, seqlen, num_heads, chunk_size).contiguous(), cu_seqlens
 
 
 def build_uniform_varlen_input(
@@ -152,45 +200,23 @@ def build_true_varlen_input(
     seq_lens: list[int],
     num_heads: int,
     chunk_size: int,
-    scale: float,
+    feature_dim: int,
     device: str,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     cu_seqlens = np.cumsum([0, *seq_lens], dtype=np.int64)
-    num_chunks = sum((seq_len + chunk_size - 1) // chunk_size for seq_len in seq_lens)
-    chunk_mats = random_chunk_mats(
-        total_chunks=num_chunks,
-        num_heads=num_heads,
-        chunk_size=chunk_size,
-        scale=scale,
-        device=device,
+    cu_seqlens_tensor = torch.tensor(cu_seqlens.tolist(), dtype=torch.int32, device=device)
+    total_tokens = int(cu_seqlens[-1])
+    k = F.normalize(
+        torch.randn((1, total_tokens, num_heads, feature_dim), dtype=torch.float16, device=device),
+        dim=-1,
     )
-
-    packed_input = torch.zeros(
-        (1, int(cu_seqlens[-1]), num_heads, chunk_size),
-        dtype=torch.half,
-        device=device,
+    beta = torch.randn((1, total_tokens, num_heads), dtype=torch.float16, device=device).sigmoid()
+    packed_input = transpose_valid_chunks(
+        chunk_scaled_dot_kkt_fwd_emulated(k, beta, cu_seqlens_tensor, chunk_size),
+        cu_seqlens_tensor,
+        chunk_size,
     )
-    chunk_idx = 0
-    token_row = 0
-
-    for seq_len in seq_lens:
-        for local_chunk_start in range(0, seq_len, chunk_size):
-            actual_size = min(chunk_size, seq_len - local_chunk_start)
-            chunk = chunk_mats[chunk_idx]
-            for head_idx in range(num_heads):
-                packed_input[
-                    0,
-                    token_row : token_row + actual_size,
-                    head_idx,
-                    :actual_size,
-                ] = chunk[head_idx, :actual_size, :actual_size]
-            token_row += actual_size
-            chunk_idx += 1
-
-    return (
-        packed_input.contiguous(),
-        torch.tensor(cu_seqlens.tolist(), dtype=torch.int32, device=device),
-    )
+    return packed_input.contiguous(), cu_seqlens_tensor
 
 
 def make_fixed_runner(
@@ -383,6 +409,12 @@ def main() -> None:
     parser.add_argument("--H", type=int, default=4, help="Number of BSND heads.")
     parser.add_argument("--chunk-size", type=int, default=64)
     parser.add_argument(
+        "--feature-dim",
+        type=int,
+        default=DEFAULT_FEATURE_DIM,
+        help="Feature dimension used to generate Triton-like `k` inputs.",
+    )
+    parser.add_argument(
         "--seqlens",
         type=parse_int_list,
         default=DEFAULT_SEQLENS,
@@ -392,7 +424,6 @@ def main() -> None:
             f"(default: {','.join(map(str, DEFAULT_SEQLENS))})"
         ),
     )
-    parser.add_argument("--scale", type=float, default=0.1)
     parser.add_argument(
         "--csv",
         type=str,
@@ -466,26 +497,19 @@ def main() -> None:
             )
             continue
 
-        total_chunks = args.B * seqlen // args.chunk_size
         total_tokens = args.B * seqlen
         print(
             f"Profiling T={seqlen}, total_tokens={total_tokens}, "
-            f"B={args.B}, H={args.H}, chunk_size={args.chunk_size}"
+            f"B={args.B}, H={args.H}, chunk_size={args.chunk_size}, feature_dim={args.feature_dim}"
         )
 
-        chunk_mats = random_chunk_mats(
-            total_chunks=total_chunks,
-            num_heads=args.H,
-            chunk_size=args.chunk_size,
-            scale=args.scale,
-            device=NPU_DEVICE,
-        )
-        fixed_input = build_fixed_bsnd_input(
-            chunk_mats,
+        fixed_input, uniform_cu_seqlens = build_fixed_bsnd_input(
             batch_size=args.B,
             seqlen=seqlen,
             num_heads=args.H,
             chunk_size=args.chunk_size,
+            feature_dim=args.feature_dim,
+            device=NPU_DEVICE,
         )
         varlen_input, cu_seqlens = build_uniform_varlen_input(
             fixed_input,
@@ -507,8 +531,13 @@ def main() -> None:
         varlen_run()
         torch.npu.synchronize()
 
-        packed_fixed_out = fixed_out.reshape(1, total_tokens, args.H, args.chunk_size)
-        max_abs_diff, rel_frob_diff = accuracy_metrics(packed_fixed_out, varlen_out)
+        packed_fixed_out = transpose_valid_chunks(
+            fixed_out.reshape(1, total_tokens, args.H, args.chunk_size),
+            uniform_cu_seqlens,
+            args.chunk_size,
+        )
+        packed_varlen_out = transpose_valid_chunks(varlen_out, cu_seqlens, args.chunk_size)
+        max_abs_diff, rel_frob_diff = accuracy_metrics(packed_fixed_out, packed_varlen_out)
         print(
             f"  accuracy vs fixed: max_abs_diff={max_abs_diff:.3e}, "
             f"rel_frob_diff={rel_frob_diff:.3e}"
@@ -577,7 +606,7 @@ def main() -> None:
                 seq_lens=seq_lens,
                 num_heads=args.H,
                 chunk_size=args.chunk_size,
-                scale=args.scale,
+                feature_dim=args.feature_dim,
                 device=NPU_DEVICE,
             )
             varlen_run_true, _ = make_varlen_runner(

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -60,7 +60,9 @@ def parse_int_list(spec: str) -> tuple[int, ...]:
     try:
         return tuple(int(p, 10) for p in parts)
     except ValueError as exc:
-        raise argparse.ArgumentTypeError(f"invalid integer list {spec!r}: {exc}") from exc
+        raise argparse.ArgumentTypeError(
+            f"invalid integer list {spec!r}: {exc}"
+        ) from exc
 
 
 def make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
@@ -93,9 +95,13 @@ def chunk_scaled_dot_kkt_fwd_emulated(
 ) -> torch.Tensor:
     total_tokens = int(cu_seqlens[-1].item())
     num_heads = k.shape[2]
-    A = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=k.dtype, device=k.device)
+    A = torch.zeros(
+        (1, total_tokens, num_heads, chunk_size), dtype=k.dtype, device=k.device
+    )
 
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+    for bos, eos in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
         for chunk_start in range(bos, eos, chunk_size):
             chunk_end = min(chunk_start + chunk_size, eos)
             actual_size = chunk_end - chunk_start
@@ -119,12 +125,14 @@ def transpose_valid_chunks(
     chunk_size: int,
 ) -> torch.Tensor:
     transposed = torch.zeros_like(A)
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+    for bos, eos in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
         for chunk_start in range(bos, eos, chunk_size):
             actual_size = min(chunk_size, eos - chunk_start)
             chunk = A[:, chunk_start : chunk_start + actual_size, :, :actual_size]
-            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = chunk.transpose(
-                1, 3
+            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = (
+                chunk.transpose(1, 3)
             )
     return transposed
 
@@ -146,10 +154,16 @@ def build_fixed_bsnd_input(
         device=device,
     )
     k = F.normalize(
-        torch.randn((1, total_tokens, num_heads, feature_dim), dtype=torch.float16, device=device),
+        torch.randn(
+            (1, total_tokens, num_heads, feature_dim),
+            dtype=torch.float16,
+            device=device,
+        ),
         dim=-1,
     )
-    beta = torch.randn((1, total_tokens, num_heads), dtype=torch.float16, device=device).sigmoid()
+    beta = torch.randn(
+        (1, total_tokens, num_heads), dtype=torch.float16, device=device
+    ).sigmoid()
     A = transpose_valid_chunks(
         chunk_scaled_dot_kkt_fwd_emulated(k, beta, cu_seqlens, chunk_size),
         cu_seqlens,
@@ -165,7 +179,9 @@ def build_uniform_varlen_input(
     chunk_size: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     total_tokens = batch_size * seqlen
-    packed_input = fixed_input.reshape(1, total_tokens, fixed_input.shape[2], chunk_size).contiguous()
+    packed_input = fixed_input.reshape(
+        1, total_tokens, fixed_input.shape[2], chunk_size
+    ).contiguous()
     cu_seqlens = torch.arange(
         0,
         total_tokens + 1,
@@ -204,13 +220,21 @@ def build_true_varlen_input(
     device: str,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     cu_seqlens = np.cumsum([0, *seq_lens], dtype=np.int64)
-    cu_seqlens_tensor = torch.tensor(cu_seqlens.tolist(), dtype=torch.int32, device=device)
+    cu_seqlens_tensor = torch.tensor(
+        cu_seqlens.tolist(), dtype=torch.int32, device=device
+    )
     total_tokens = int(cu_seqlens[-1])
     k = F.normalize(
-        torch.randn((1, total_tokens, num_heads, feature_dim), dtype=torch.float16, device=device),
+        torch.randn(
+            (1, total_tokens, num_heads, feature_dim),
+            dtype=torch.float16,
+            device=device,
+        ),
         dim=-1,
     )
-    beta = torch.randn((1, total_tokens, num_heads), dtype=torch.float16, device=device).sigmoid()
+    beta = torch.randn(
+        (1, total_tokens, num_heads), dtype=torch.float16, device=device
+    ).sigmoid()
     packed_input = transpose_valid_chunks(
         chunk_scaled_dot_kkt_fwd_emulated(k, beta, cu_seqlens_tensor, chunk_size),
         cu_seqlens_tensor,
@@ -294,14 +318,18 @@ def benchmark_ms(
     return times_ms
 
 
-def add_bandwidth_fields(row: dict[str, float | int | str], input_dtype_bytes: int = 2) -> None:
+def add_bandwidth_fields(
+    row: dict[str, float | int | str], input_dtype_bytes: int = 2
+) -> None:
     size_elems = int(row.get("valid_numel", row["numel"]))
     mem_bytes = size_elems * (input_dtype_bytes + 4)
     row["mem_bytes"] = mem_bytes
     row["bw_gbs"] = (mem_bytes / 1e9) / (float(row["time_us"]) / 1e6)
 
 
-def accuracy_metrics(reference: torch.Tensor, candidate: torch.Tensor) -> tuple[float, float]:
+def accuracy_metrics(
+    reference: torch.Tensor, candidate: torch.Tensor
+) -> tuple[float, float]:
     ref = reference.detach().cpu().to(torch.float64)
     cand = candidate.detach().cpu().to(torch.float64)
     diff = ref - cand
@@ -339,7 +367,13 @@ def write_csv(csv_path: Path, rows: list[dict[str, float | int | str]]) -> None:
             writer.writerow(row)
 
 
-def plot_bandwidth(plot_path: Path, rows: list[dict[str, float | int | str]], batch_size: int, num_heads: int, chunk_size: int) -> None:
+def plot_bandwidth(
+    plot_path: Path,
+    rows: list[dict[str, float | int | str]],
+    batch_size: int,
+    num_heads: int,
+    chunk_size: int,
+) -> None:
     plot_path.parent.mkdir(parents=True, exist_ok=True)
     fixed_rows = [row for row in rows if row["inverse_type"] == "bsnd-fixed"]
     varlen_rows = [row for row in rows if row["inverse_type"] == "bsnd-varlen-uniform"]
@@ -402,7 +436,9 @@ def plot_true_varlen_scatter(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark standalone BSND fast-inverse kernel.")
+    parser = argparse.ArgumentParser(
+        description="Benchmark standalone BSND fast-inverse kernel."
+    )
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--repeats", type=int, default=20)
     parser.add_argument("--B", type=int, default=32, help="Dense BSND batch size.")
@@ -477,12 +513,14 @@ def main() -> None:
     true_varlen_csv_path = (
         Path(args.true_varlen_csv)
         if args.true_varlen_csv
-        else RESULTS_DIR / f"bench_results_bsnd_fast_inverse_true_varlen_{args.chunk_size}.csv"
+        else RESULTS_DIR
+        / f"bench_results_bsnd_fast_inverse_true_varlen_{args.chunk_size}.csv"
     )
     true_varlen_plot_path = (
         Path(args.true_varlen_plot)
         if args.true_varlen_plot
-        else RESULTS_DIR / f"bench_results_bsnd_fast_inverse_true_varlen_bw_{args.chunk_size}.png"
+        else RESULTS_DIR
+        / f"bench_results_bsnd_fast_inverse_true_varlen_bw_{args.chunk_size}.png"
     )
 
     rows: list[dict[str, float | int | str]] = []
@@ -536,8 +574,12 @@ def main() -> None:
             uniform_cu_seqlens,
             args.chunk_size,
         )
-        packed_varlen_out = transpose_valid_chunks(varlen_out, cu_seqlens, args.chunk_size)
-        max_abs_diff, rel_frob_diff = accuracy_metrics(packed_fixed_out, packed_varlen_out)
+        packed_varlen_out = transpose_valid_chunks(
+            varlen_out, cu_seqlens, args.chunk_size
+        )
+        max_abs_diff, rel_frob_diff = accuracy_metrics(
+            packed_fixed_out, packed_varlen_out
+        )
         print(
             f"  accuracy vs fixed: max_abs_diff={max_abs_diff:.3e}, "
             f"rel_frob_diff={rel_frob_diff:.3e}"

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -68,6 +68,39 @@ def make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
     return minus_identity
 
 
+def chunk_metadata_from_cu_seqlens(
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cu_seqlens_np = cu_seqlens.detach().cpu().numpy().astype(np.int64, copy=False)
+    seq_starts = cu_seqlens_np[:-1]
+    seq_lens = cu_seqlens_np[1:] - seq_starts
+    seq_num_chunks = (seq_lens + chunk_size - 1) // chunk_size
+    total_chunks = int(seq_num_chunks.sum())
+
+    chunk_indices = np.empty(total_chunks, dtype=np.int32)
+    chunk_valid_sizes = np.empty(total_chunks, dtype=np.int32)
+    cursor = 0
+    for seq_start, seq_len, num_chunks in zip(seq_starts, seq_lens, seq_num_chunks):
+        num_chunks_int = int(num_chunks)
+        local_offsets = np.arange(num_chunks_int, dtype=np.int64) * chunk_size
+        next_cursor = cursor + num_chunks_int
+        chunk_indices[cursor:next_cursor] = (seq_start + local_offsets).astype(
+            np.int32,
+            copy=False,
+        )
+        chunk_valid_sizes[cursor:next_cursor] = np.minimum(
+            chunk_size,
+            seq_len - local_offsets,
+        ).astype(np.int32, copy=False)
+        cursor = next_cursor
+
+    return (
+        torch.from_numpy(chunk_indices).to(device=cu_seqlens.device),
+        torch.from_numpy(chunk_valid_sizes).to(device=cu_seqlens.device),
+    )
+
+
 def random_chunk_mats(
     total_chunks: int,
     num_heads: int,
@@ -104,7 +137,7 @@ def build_uniform_varlen_input(
     batch_size: int,
     seqlen: int,
     chunk_size: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     total_tokens = batch_size * seqlen
     packed_input = fixed_input.reshape(1, total_tokens, fixed_input.shape[2], chunk_size).contiguous()
     cu_seqlens = torch.arange(
@@ -114,15 +147,7 @@ def build_uniform_varlen_input(
         dtype=torch.int32,
         device=fixed_input.device,
     )
-    chunk_indices = torch.arange(
-        0,
-        total_tokens,
-        chunk_size,
-        dtype=torch.int32,
-        device=fixed_input.device,
-    )
-    chunk_valid_sizes = torch.full_like(chunk_indices, chunk_size)
-    return packed_input, cu_seqlens, chunk_indices, chunk_valid_sizes
+    return packed_input, cu_seqlens
 
 
 def sample_true_varlen_lengths(
@@ -151,7 +176,7 @@ def build_true_varlen_input(
     chunk_size: int,
     scale: float,
     device: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     cu_seqlens = np.cumsum([0, *seq_lens], dtype=np.int64)
     num_chunks = sum((seq_len + chunk_size - 1) // chunk_size for seq_len in seq_lens)
     chunk_mats = random_chunk_mats(
@@ -167,8 +192,6 @@ def build_true_varlen_input(
         dtype=torch.half,
         device=device,
     )
-    chunk_indices: list[int] = []
-    chunk_valid_sizes: list[int] = []
     chunk_idx = 0
     token_row = 0
 
@@ -183,16 +206,12 @@ def build_true_varlen_input(
                     head_idx,
                     :actual_size,
                 ] = chunk[head_idx, :actual_size, :actual_size]
-            chunk_indices.append(token_row)
-            chunk_valid_sizes.append(actual_size)
             token_row += actual_size
             chunk_idx += 1
 
     return (
         packed_input.contiguous(),
         torch.tensor(cu_seqlens.tolist(), dtype=torch.int32, device=device),
-        torch.tensor(chunk_indices, dtype=torch.int32, device=device),
-        torch.tensor(chunk_valid_sizes, dtype=torch.int32, device=device),
     )
 
 
@@ -222,14 +241,19 @@ def make_fixed_runner(
 def make_varlen_runner(
     tri_inv_func,
     tensor_in: torch.Tensor,
-    chunk_indices: torch.Tensor,
-    chunk_valid_sizes: torch.Tensor,
+    cu_seqlens: torch.Tensor,
 ) -> tuple[callable, torch.Tensor]:
     matrix_size = tensor_in.shape[-1]
     num_bsnd_heads = tensor_in.shape[-2]
-    num_matrices = chunk_indices.numel() * num_bsnd_heads
+    seq_lens = cu_seqlens[1:].to(torch.int64) - cu_seqlens[:-1].to(torch.int64)
+    num_chunks = ((seq_lens + matrix_size - 1) // matrix_size).sum().item()
+    num_matrices = int(num_chunks) * num_bsnd_heads
     tensor_out = torch.empty_like(tensor_in, dtype=torch.float32)
     minus_identity = make_minus_identity(matrix_size, str(tensor_in.device))
+    chunk_indices, chunk_valid_sizes = chunk_metadata_from_cu_seqlens(
+        cu_seqlens,
+        matrix_size,
+    )
 
     def run():
         tri_inv_func(
@@ -492,7 +516,7 @@ def main() -> None:
             num_heads=args.H,
             chunk_size=args.chunk_size,
         )
-        varlen_input, cu_seqlens, chunk_indices, chunk_valid_sizes = build_uniform_varlen_input(
+        varlen_input, cu_seqlens = build_uniform_varlen_input(
             fixed_input,
             batch_size=args.B,
             seqlen=seqlen,
@@ -505,8 +529,7 @@ def main() -> None:
         varlen_run, varlen_out = make_varlen_runner(
             tri_inv_func,
             varlen_input,
-            chunk_indices,
-            chunk_valid_sizes,
+            cu_seqlens,
         )
 
         fixed_run()
@@ -579,7 +602,7 @@ def main() -> None:
 
         for sample_idx in range(args.true_varlen_samples):
             seq_lens = sample_true_varlen_lengths(args.B, total_tokens, rng)
-            packed_input, cu_seqlens, chunk_indices, chunk_valid_sizes = build_true_varlen_input(
+            packed_input, cu_seqlens = build_true_varlen_input(
                 seq_lens=seq_lens,
                 num_heads=args.H,
                 chunk_size=args.chunk_size,
@@ -589,8 +612,7 @@ def main() -> None:
             varlen_run_true, _ = make_varlen_runner(
                 tri_inv_func,
                 packed_input,
-                chunk_indices,
-                chunk_valid_sizes,
+                cu_seqlens,
             )
             times_ms = benchmark_ms(
                 varlen_run_true,

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -68,36 +68,14 @@ def make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
     return minus_identity
 
 
-def chunk_metadata_from_cu_seqlens(
+def count_varlen_chunks(
     cu_seqlens: torch.Tensor,
     chunk_size: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    cu_seqlens_np = cu_seqlens.detach().cpu().numpy().astype(np.int64, copy=False)
-    seq_starts = cu_seqlens_np[:-1]
-    seq_lens = cu_seqlens_np[1:] - seq_starts
-    seq_num_chunks = (seq_lens + chunk_size - 1) // chunk_size
-    total_chunks = int(seq_num_chunks.sum())
-
-    chunk_indices = np.empty(total_chunks, dtype=np.int32)
-    chunk_valid_sizes = np.empty(total_chunks, dtype=np.int32)
-    cursor = 0
-    for seq_start, seq_len, num_chunks in zip(seq_starts, seq_lens, seq_num_chunks):
-        num_chunks_int = int(num_chunks)
-        local_offsets = np.arange(num_chunks_int, dtype=np.int64) * chunk_size
-        next_cursor = cursor + num_chunks_int
-        chunk_indices[cursor:next_cursor] = (seq_start + local_offsets).astype(
-            np.int32,
-            copy=False,
-        )
-        chunk_valid_sizes[cursor:next_cursor] = np.minimum(
-            chunk_size,
-            seq_len - local_offsets,
-        ).astype(np.int32, copy=False)
-        cursor = next_cursor
-
-    return (
-        torch.from_numpy(chunk_indices).to(device=cu_seqlens.device),
-        torch.from_numpy(chunk_valid_sizes).to(device=cu_seqlens.device),
+) -> int:
+    cu_seqlens_list = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+    return sum(
+        (cu_seqlens_list[i + 1] - cu_seqlens_list[i] + chunk_size - 1) // chunk_size
+        for i in range(len(cu_seqlens_list) - 1)
     )
 
 
@@ -245,15 +223,9 @@ def make_varlen_runner(
 ) -> tuple[callable, torch.Tensor]:
     matrix_size = tensor_in.shape[-1]
     num_bsnd_heads = tensor_in.shape[-2]
-    seq_lens = cu_seqlens[1:].to(torch.int64) - cu_seqlens[:-1].to(torch.int64)
-    num_chunks = ((seq_lens + matrix_size - 1) // matrix_size).sum().item()
-    num_matrices = int(num_chunks) * num_bsnd_heads
+    num_matrices = count_varlen_chunks(cu_seqlens, matrix_size) * num_bsnd_heads
     tensor_out = torch.empty_like(tensor_in, dtype=torch.float32)
     minus_identity = make_minus_identity(matrix_size, str(tensor_in.device))
-    chunk_indices, chunk_valid_sizes = chunk_metadata_from_cu_seqlens(
-        cu_seqlens,
-        matrix_size,
-    )
 
     def run():
         tri_inv_func(
@@ -263,8 +235,7 @@ def make_varlen_runner(
             matrix_size,
             num_matrices,
             num_bsnd_heads,
-            chunk_indices=chunk_indices,
-            chunk_valid_sizes=chunk_valid_sizes,
+            cu_seqlens=cu_seqlens,
         )
 
     return run, tensor_out

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -39,7 +39,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.nn.functional as F
-import torch_npu  # noqa: F401
+import torch_npu  # noqa
 
 from jit_util_fast_inverse import jit_compile
 

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -104,7 +104,7 @@ def build_uniform_varlen_input(
     batch_size: int,
     seqlen: int,
     chunk_size: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     total_tokens = batch_size * seqlen
     packed_input = fixed_input.reshape(1, total_tokens, fixed_input.shape[2], chunk_size).contiguous()
     cu_seqlens = torch.arange(
@@ -121,7 +121,8 @@ def build_uniform_varlen_input(
         dtype=torch.int32,
         device=fixed_input.device,
     )
-    return packed_input, cu_seqlens, chunk_indices
+    chunk_valid_sizes = torch.full_like(chunk_indices, chunk_size)
+    return packed_input, cu_seqlens, chunk_indices, chunk_valid_sizes
 
 
 def sample_true_varlen_lengths(
@@ -150,7 +151,7 @@ def build_true_varlen_input(
     chunk_size: int,
     scale: float,
     device: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     cu_seqlens = np.cumsum([0, *seq_lens], dtype=np.int64)
     num_chunks = sum((seq_len + chunk_size - 1) // chunk_size for seq_len in seq_lens)
     chunk_mats = random_chunk_mats(
@@ -161,35 +162,37 @@ def build_true_varlen_input(
         device=device,
     )
 
-    padded_total = num_chunks * chunk_size
     packed_input = torch.zeros(
-        (1, padded_total, num_heads, chunk_size),
+        (1, int(cu_seqlens[-1]), num_heads, chunk_size),
         dtype=torch.half,
         device=device,
     )
     chunk_indices: list[int] = []
+    chunk_valid_sizes: list[int] = []
     chunk_idx = 0
-    padded_row = 0
+    token_row = 0
 
     for seq_len in seq_lens:
-        for chunk_start in range(0, seq_len, chunk_size):
-            actual_size = min(chunk_size, seq_len - chunk_start)
+        for local_chunk_start in range(0, seq_len, chunk_size):
+            actual_size = min(chunk_size, seq_len - local_chunk_start)
             chunk = chunk_mats[chunk_idx]
             for head_idx in range(num_heads):
                 packed_input[
                     0,
-                    padded_row : padded_row + actual_size,
+                    token_row : token_row + actual_size,
                     head_idx,
                     :actual_size,
                 ] = chunk[head_idx, :actual_size, :actual_size]
-            chunk_indices.append(padded_row)
-            padded_row += chunk_size
+            chunk_indices.append(token_row)
+            chunk_valid_sizes.append(actual_size)
+            token_row += actual_size
             chunk_idx += 1
 
     return (
         packed_input.contiguous(),
         torch.tensor(cu_seqlens.tolist(), dtype=torch.int32, device=device),
         torch.tensor(chunk_indices, dtype=torch.int32, device=device),
+        torch.tensor(chunk_valid_sizes, dtype=torch.int32, device=device),
     )
 
 
@@ -220,10 +223,11 @@ def make_varlen_runner(
     tri_inv_func,
     tensor_in: torch.Tensor,
     chunk_indices: torch.Tensor,
+    chunk_valid_sizes: torch.Tensor,
 ) -> tuple[callable, torch.Tensor]:
     matrix_size = tensor_in.shape[-1]
     num_bsnd_heads = tensor_in.shape[-2]
-    num_matrices = tensor_in.numel() // (matrix_size * matrix_size)
+    num_matrices = chunk_indices.numel() * num_bsnd_heads
     tensor_out = torch.empty_like(tensor_in, dtype=torch.float32)
     minus_identity = make_minus_identity(matrix_size, str(tensor_in.device))
 
@@ -236,6 +240,7 @@ def make_varlen_runner(
             num_matrices,
             num_bsnd_heads,
             chunk_indices=chunk_indices,
+            chunk_valid_sizes=chunk_valid_sizes,
         )
 
     return run, tensor_out
@@ -487,7 +492,7 @@ def main() -> None:
             num_heads=args.H,
             chunk_size=args.chunk_size,
         )
-        varlen_input, cu_seqlens, chunk_indices = build_uniform_varlen_input(
+        varlen_input, cu_seqlens, chunk_indices, chunk_valid_sizes = build_uniform_varlen_input(
             fixed_input,
             batch_size=args.B,
             seqlen=seqlen,
@@ -497,7 +502,12 @@ def main() -> None:
         print(f"  uniform cu_seqlens: {cu_seqlens.cpu().tolist()}")
 
         fixed_run, fixed_out = make_fixed_runner(tri_inv_func, fixed_input)
-        varlen_run, varlen_out = make_varlen_runner(tri_inv_func, varlen_input, chunk_indices)
+        varlen_run, varlen_out = make_varlen_runner(
+            tri_inv_func,
+            varlen_input,
+            chunk_indices,
+            chunk_valid_sizes,
+        )
 
         fixed_run()
         varlen_run()
@@ -569,7 +579,7 @@ def main() -> None:
 
         for sample_idx in range(args.true_varlen_samples):
             seq_lens = sample_true_varlen_lengths(args.B, total_tokens, rng)
-            packed_input, cu_seqlens, chunk_indices = build_true_varlen_input(
+            packed_input, cu_seqlens, chunk_indices, chunk_valid_sizes = build_true_varlen_input(
                 seq_lens=seq_lens,
                 num_heads=args.H,
                 chunk_size=args.chunk_size,
@@ -580,6 +590,7 @@ def main() -> None:
                 tri_inv_func,
                 packed_input,
                 chunk_indices,
+                chunk_valid_sizes,
             )
             times_ms = benchmark_ms(
                 varlen_run_true,

--- a/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All rights reserved.
+# See LICENSE in the root of the software repository:
+# https://github.com/huawei-csl/pto-kernels/
+# for the full License text.
+# --------------------------------------------------------------------------------
+
+"""
+Benchmark the standalone BSND fast-inverse kernel.
+
+This script only benchmarks the PTO-ISA BSND kernel in two modes:
+
+1. `bsnd-fixed`:
+   Original aligned BSND layout with shape `(B, T, H, D)`.
+2. `bsnd-varlen-uniform`:
+   The new varlen path using packed shape `(1, B*T, H, D)` with uniform
+   `cu_seqlens = [0, T, 2T, ...]`.
+
+The two modes use the same total token count and the same underlying chunk data,
+so their latency / effective bandwidth can be compared directly. The script also
+checks that both modes produce numerically matching results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch_npu  # noqa: F401
+
+from jit_util_fast_inverse import jit_compile
+
+
+DEFAULT_SEQLENS = (512, 1024, 2048, 4096, 8192, 16384)
+DEFAULT_CACHE_SIZE = 256 * 1024 * 1024
+NPU_DEVICE = os.getenv("GDN_TRI_INVERSE_NPU_DEVICE", "npu:0")
+THIS_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = THIS_DIR / "benchmark_results"
+DEFAULT_TRUE_VARLEN_SAMPLES = 6
+
+
+def parse_int_list(spec: str) -> tuple[int, ...]:
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError("expected at least one integer")
+    try:
+        return tuple(int(p, 10) for p in parts)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid integer list {spec!r}: {exc}") from exc
+
+
+def make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
+    minus_identity = torch.zeros(
+        matrix_size,
+        matrix_size,
+        dtype=torch.half,
+        device=device,
+    )
+    minus_identity.fill_diagonal_(-1)
+    return minus_identity
+
+
+def random_chunk_mats(
+    total_chunks: int,
+    num_heads: int,
+    chunk_size: int,
+    scale: float,
+    device: str,
+) -> torch.Tensor:
+    return scale * torch.triu(
+        torch.rand(
+            (total_chunks, num_heads, chunk_size, chunk_size),
+            dtype=torch.half,
+            device=device,
+        ),
+        diagonal=1,
+    )
+
+
+def build_fixed_bsnd_input(
+    chunk_mats: torch.Tensor,
+    batch_size: int,
+    seqlen: int,
+    num_heads: int,
+    chunk_size: int,
+) -> torch.Tensor:
+    return (
+        chunk_mats.transpose(1, 2)
+        .contiguous()
+        .reshape(batch_size, seqlen, num_heads, chunk_size)
+    )
+
+
+def build_uniform_varlen_input(
+    fixed_input: torch.Tensor,
+    batch_size: int,
+    seqlen: int,
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    total_tokens = batch_size * seqlen
+    packed_input = fixed_input.reshape(1, total_tokens, fixed_input.shape[2], chunk_size).contiguous()
+    cu_seqlens = torch.arange(
+        0,
+        total_tokens + 1,
+        seqlen,
+        dtype=torch.int32,
+        device=fixed_input.device,
+    )
+    chunk_indices = torch.arange(
+        0,
+        total_tokens,
+        chunk_size,
+        dtype=torch.int32,
+        device=fixed_input.device,
+    )
+    return packed_input, cu_seqlens, chunk_indices
+
+
+def sample_true_varlen_lengths(
+    batch_size: int,
+    aggregated_tokens: int,
+    rng: np.random.Generator,
+) -> list[int]:
+    if aggregated_tokens < batch_size:
+        raise ValueError("aggregated_tokens must be >= batch_size.")
+
+    remaining = aggregated_tokens - batch_size
+    while True:
+        weights = rng.dirichlet(np.ones(batch_size))
+        extras = np.floor(weights * remaining).astype(np.int64)
+        deficit = remaining - int(extras.sum())
+        if deficit > 0:
+            extras[:deficit] += 1
+        lengths = (extras + 1).tolist()
+        if any(length != lengths[0] for length in lengths):
+            return lengths
+
+
+def build_true_varlen_input(
+    seq_lens: list[int],
+    num_heads: int,
+    chunk_size: int,
+    scale: float,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    cu_seqlens = np.cumsum([0, *seq_lens], dtype=np.int64)
+    num_chunks = sum((seq_len + chunk_size - 1) // chunk_size for seq_len in seq_lens)
+    chunk_mats = random_chunk_mats(
+        total_chunks=num_chunks,
+        num_heads=num_heads,
+        chunk_size=chunk_size,
+        scale=scale,
+        device=device,
+    )
+
+    padded_total = num_chunks * chunk_size
+    packed_input = torch.zeros(
+        (1, padded_total, num_heads, chunk_size),
+        dtype=torch.half,
+        device=device,
+    )
+    chunk_indices: list[int] = []
+    chunk_idx = 0
+    padded_row = 0
+
+    for seq_len in seq_lens:
+        for chunk_start in range(0, seq_len, chunk_size):
+            actual_size = min(chunk_size, seq_len - chunk_start)
+            chunk = chunk_mats[chunk_idx]
+            for head_idx in range(num_heads):
+                packed_input[
+                    0,
+                    padded_row : padded_row + actual_size,
+                    head_idx,
+                    :actual_size,
+                ] = chunk[head_idx, :actual_size, :actual_size]
+            chunk_indices.append(padded_row)
+            padded_row += chunk_size
+            chunk_idx += 1
+
+    return (
+        packed_input.contiguous(),
+        torch.tensor(cu_seqlens.tolist(), dtype=torch.int32, device=device),
+        torch.tensor(chunk_indices, dtype=torch.int32, device=device),
+    )
+
+
+def make_fixed_runner(
+    tri_inv_func,
+    tensor_in: torch.Tensor,
+) -> tuple[callable, torch.Tensor]:
+    matrix_size = tensor_in.shape[-1]
+    num_bsnd_heads = tensor_in.shape[-2]
+    num_matrices = tensor_in.numel() // (matrix_size * matrix_size)
+    tensor_out = torch.empty_like(tensor_in, dtype=torch.float32)
+    minus_identity = make_minus_identity(matrix_size, str(tensor_in.device))
+
+    def run():
+        tri_inv_func(
+            tensor_out,
+            tensor_in,
+            minus_identity,
+            matrix_size,
+            num_matrices,
+            num_bsnd_heads,
+        )
+
+    return run, tensor_out
+
+
+def make_varlen_runner(
+    tri_inv_func,
+    tensor_in: torch.Tensor,
+    chunk_indices: torch.Tensor,
+) -> tuple[callable, torch.Tensor]:
+    matrix_size = tensor_in.shape[-1]
+    num_bsnd_heads = tensor_in.shape[-2]
+    num_matrices = tensor_in.numel() // (matrix_size * matrix_size)
+    tensor_out = torch.empty_like(tensor_in, dtype=torch.float32)
+    minus_identity = make_minus_identity(matrix_size, str(tensor_in.device))
+
+    def run():
+        tri_inv_func(
+            tensor_out,
+            tensor_in,
+            minus_identity,
+            matrix_size,
+            num_matrices,
+            num_bsnd_heads,
+            chunk_indices=chunk_indices,
+        )
+
+    return run, tensor_out
+
+
+def benchmark_ms(
+    fn,
+    warmup_iters: int,
+    benchmark_iters: int,
+    device: str,
+) -> list[float]:
+    start_events = [torch.npu.Event(enable_timing=True) for _ in range(benchmark_iters)]
+    end_events = [torch.npu.Event(enable_timing=True) for _ in range(benchmark_iters)]
+
+    torch.npu.synchronize()
+    for _ in range(warmup_iters):
+        fn()
+    torch.npu.synchronize()
+
+    cache = torch.ones(DEFAULT_CACHE_SIZE, dtype=torch.int8, device=device)
+    times_ms: list[float] = []
+    for idx in range(benchmark_iters):
+        cache.zero_()
+        torch.npu.synchronize()
+        start_events[idx].record()
+        fn()
+        end_events[idx].record()
+        end_events[idx].synchronize()
+        times_ms.append(start_events[idx].elapsed_time(end_events[idx]))
+    return times_ms
+
+
+def add_bandwidth_fields(row: dict[str, float | int | str], input_dtype_bytes: int = 2) -> None:
+    size_elems = int(row.get("valid_numel", row["numel"]))
+    mem_bytes = size_elems * (input_dtype_bytes + 4)
+    row["mem_bytes"] = mem_bytes
+    row["bw_gbs"] = (mem_bytes / 1e9) / (float(row["time_us"]) / 1e6)
+
+
+def accuracy_metrics(reference: torch.Tensor, candidate: torch.Tensor) -> tuple[float, float]:
+    ref = reference.detach().cpu().to(torch.float64)
+    cand = candidate.detach().cpu().to(torch.float64)
+    diff = ref - cand
+    max_abs = diff.abs().max().item()
+    denom = torch.sum(ref * ref).item()
+    rel_frob = 0.0 if denom == 0 else math.sqrt(torch.sum(diff * diff).item() / denom)
+    return max_abs, rel_frob
+
+
+def write_csv(csv_path: Path, rows: list[dict[str, float | int | str]]) -> None:
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "inverse_type",
+        "dtype",
+        "B",
+        "T",
+        "aggregated_T",
+        "padded_T",
+        "H",
+        "numel",
+        "valid_numel",
+        "chunk_size",
+        "time_us",
+        "mem_bytes",
+        "bw_gbs",
+        "max_abs_diff_to_fixed",
+        "rel_frob_diff_to_fixed",
+        "sample_id",
+        "seq_lens",
+    ]
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def plot_bandwidth(plot_path: Path, rows: list[dict[str, float | int | str]], batch_size: int, num_heads: int, chunk_size: int) -> None:
+    plot_path.parent.mkdir(parents=True, exist_ok=True)
+    fixed_rows = [row for row in rows if row["inverse_type"] == "bsnd-fixed"]
+    varlen_rows = [row for row in rows if row["inverse_type"] == "bsnd-varlen-uniform"]
+
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    ax.plot(
+        [int(row["T"]) / 1000.0 for row in fixed_rows],
+        [float(row["bw_gbs"]) for row in fixed_rows],
+        marker="o",
+        linewidth=2,
+        label="BSND fixed",
+    )
+    ax.plot(
+        [int(row["T"]) / 1000.0 for row in varlen_rows],
+        [float(row["bw_gbs"]) for row in varlen_rows],
+        marker="s",
+        linewidth=2,
+        label="BSND varlen-uniform",
+    )
+    ax.set_xlabel("Sequence length T (K)")
+    ax.set_ylabel("Effective bandwidth (GB/s)")
+    ax.set_title(
+        f"Fast inverse BSND bandwidth\n"
+        f"(batch={batch_size}, head={num_heads}, chunk_size={chunk_size})"
+    )
+    ax.set_ylim(bottom=0)
+    ax.grid(alpha=0.25)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(plot_path, dpi=150)
+    plt.close(fig)
+
+
+def plot_true_varlen_scatter(
+    plot_path: Path,
+    rows: list[dict[str, float | int | str]],
+    batch_size: int,
+    num_heads: int,
+    chunk_size: int,
+) -> None:
+    plot_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    ax.scatter(
+        [int(row["aggregated_T"]) for row in rows],
+        [float(row["bw_gbs"]) for row in rows],
+        alpha=0.8,
+        s=32,
+    )
+    ax.set_xlabel("Aggregated sequence length")
+    ax.set_ylabel("Effective bandwidth (GB/s)")
+    ax.set_title(
+        f"Fast inverse true-varlen BSND bandwidth\n"
+        f"(batch={batch_size}, head={num_heads}, chunk_size={chunk_size})"
+    )
+    ax.set_ylim(bottom=0)
+    ax.grid(alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(plot_path, dpi=150)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark standalone BSND fast-inverse kernel.")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--B", type=int, default=32, help="Dense BSND batch size.")
+    parser.add_argument("--H", type=int, default=4, help="Number of BSND heads.")
+    parser.add_argument("--chunk-size", type=int, default=64)
+    parser.add_argument(
+        "--seqlens",
+        type=parse_int_list,
+        default=DEFAULT_SEQLENS,
+        metavar="T[,T,...]",
+        help=(
+            "Comma-separated dense per-sequence lengths to benchmark "
+            f"(default: {','.join(map(str, DEFAULT_SEQLENS))})"
+        ),
+    )
+    parser.add_argument("--scale", type=float, default=0.1)
+    parser.add_argument(
+        "--csv",
+        type=str,
+        default="",
+        help="Optional CSV output path. Defaults to bench_results_bsnd_fast_inverse_<chunk>.csv",
+    )
+    parser.add_argument(
+        "--plot",
+        type=str,
+        default="",
+        help="Optional plot output path. Defaults to bench_results_bsnd_fast_inverse_bw_<chunk>.png",
+    )
+    parser.add_argument(
+        "--true-varlen-csv",
+        type=str,
+        default="",
+        help="Optional CSV path for true-varlen benchmark points.",
+    )
+    parser.add_argument(
+        "--true-varlen-plot",
+        type=str,
+        default="",
+        help="Optional scatter plot path for true-varlen benchmark points.",
+    )
+    parser.add_argument(
+        "--true-varlen-samples",
+        type=int,
+        default=DEFAULT_TRUE_VARLEN_SAMPLES,
+        help="Number of random true-varlen batches per aggregated sequence length.",
+    )
+    args = parser.parse_args()
+
+    torch.npu.set_device(NPU_DEVICE)
+
+    src = THIS_DIR / "fast_inverse.cpp"
+    print(f"Compiling {src} ...")
+    tri_inv_func = jit_compile(str(src))
+    print("Compilation successful.\n")
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    csv_path = (
+        Path(args.csv)
+        if args.csv
+        else RESULTS_DIR / f"bench_results_bsnd_fast_inverse_{args.chunk_size}.csv"
+    )
+    plot_path = (
+        Path(args.plot)
+        if args.plot
+        else RESULTS_DIR / f"bench_results_bsnd_fast_inverse_bw_{args.chunk_size}.png"
+    )
+    true_varlen_csv_path = (
+        Path(args.true_varlen_csv)
+        if args.true_varlen_csv
+        else RESULTS_DIR / f"bench_results_bsnd_fast_inverse_true_varlen_{args.chunk_size}.csv"
+    )
+    true_varlen_plot_path = (
+        Path(args.true_varlen_plot)
+        if args.true_varlen_plot
+        else RESULTS_DIR / f"bench_results_bsnd_fast_inverse_true_varlen_bw_{args.chunk_size}.png"
+    )
+
+    rows: list[dict[str, float | int | str]] = []
+    true_varlen_rows: list[dict[str, float | int | str]] = []
+    rng = np.random.default_rng(42)
+
+    for seqlen in args.seqlens:
+        if seqlen % args.chunk_size != 0:
+            print(
+                f"Skipping T={seqlen}: requires T to be a multiple of chunk_size={args.chunk_size} "
+                "for matched fixed vs uniform-varlen comparison."
+            )
+            continue
+
+        total_chunks = args.B * seqlen // args.chunk_size
+        total_tokens = args.B * seqlen
+        print(
+            f"Profiling T={seqlen}, total_tokens={total_tokens}, "
+            f"B={args.B}, H={args.H}, chunk_size={args.chunk_size}"
+        )
+
+        chunk_mats = random_chunk_mats(
+            total_chunks=total_chunks,
+            num_heads=args.H,
+            chunk_size=args.chunk_size,
+            scale=args.scale,
+            device=NPU_DEVICE,
+        )
+        fixed_input = build_fixed_bsnd_input(
+            chunk_mats,
+            batch_size=args.B,
+            seqlen=seqlen,
+            num_heads=args.H,
+            chunk_size=args.chunk_size,
+        )
+        varlen_input, cu_seqlens, chunk_indices = build_uniform_varlen_input(
+            fixed_input,
+            batch_size=args.B,
+            seqlen=seqlen,
+            chunk_size=args.chunk_size,
+        )
+
+        print(f"  uniform cu_seqlens: {cu_seqlens.cpu().tolist()}")
+
+        fixed_run, fixed_out = make_fixed_runner(tri_inv_func, fixed_input)
+        varlen_run, varlen_out = make_varlen_runner(tri_inv_func, varlen_input, chunk_indices)
+
+        fixed_run()
+        varlen_run()
+        torch.npu.synchronize()
+
+        packed_fixed_out = fixed_out.reshape(1, total_tokens, args.H, args.chunk_size)
+        max_abs_diff, rel_frob_diff = accuracy_metrics(packed_fixed_out, varlen_out)
+        print(
+            f"  accuracy vs fixed: max_abs_diff={max_abs_diff:.3e}, "
+            f"rel_frob_diff={rel_frob_diff:.3e}"
+        )
+
+        fixed_times_ms = benchmark_ms(
+            fixed_run,
+            warmup_iters=args.warmup,
+            benchmark_iters=args.repeats,
+            device=NPU_DEVICE,
+        )
+        varlen_times_ms = benchmark_ms(
+            varlen_run,
+            warmup_iters=args.warmup,
+            benchmark_iters=args.repeats,
+            device=NPU_DEVICE,
+        )
+
+        fixed_row = {
+            "inverse_type": "bsnd-fixed",
+            "dtype": "fp16",
+            "B": args.B,
+            "T": seqlen,
+            "aggregated_T": total_tokens,
+            "padded_T": total_tokens,
+            "H": args.H,
+            "numel": fixed_input.numel(),
+            "valid_numel": fixed_input.numel(),
+            "chunk_size": args.chunk_size,
+            "time_us": int(round(np.mean(fixed_times_ms) * 1000.0)),
+            "max_abs_diff_to_fixed": 0.0,
+            "rel_frob_diff_to_fixed": 0.0,
+            "sample_id": "",
+            "seq_lens": "",
+        }
+        add_bandwidth_fields(fixed_row)
+
+        varlen_row = {
+            "inverse_type": "bsnd-varlen-uniform",
+            "dtype": "fp16",
+            "B": args.B,
+            "T": seqlen,
+            "aggregated_T": total_tokens,
+            "padded_T": total_tokens,
+            "H": args.H,
+            "numel": varlen_input.numel(),
+            "valid_numel": total_tokens * args.H * args.chunk_size,
+            "chunk_size": args.chunk_size,
+            "time_us": int(round(np.mean(varlen_times_ms) * 1000.0)),
+            "max_abs_diff_to_fixed": max_abs_diff,
+            "rel_frob_diff_to_fixed": rel_frob_diff,
+            "sample_id": "",
+            "seq_lens": ",".join([str(seqlen)] * args.B),
+        }
+        add_bandwidth_fields(varlen_row)
+
+        rows.extend([fixed_row, varlen_row])
+        print(
+            f"  fixed: time_us={fixed_row['time_us']}, bw_gbs={fixed_row['bw_gbs']:.2f} | "
+            f"varlen-uniform: time_us={varlen_row['time_us']}, bw_gbs={varlen_row['bw_gbs']:.2f}"
+        )
+
+        for sample_idx in range(args.true_varlen_samples):
+            seq_lens = sample_true_varlen_lengths(args.B, total_tokens, rng)
+            packed_input, cu_seqlens, chunk_indices = build_true_varlen_input(
+                seq_lens=seq_lens,
+                num_heads=args.H,
+                chunk_size=args.chunk_size,
+                scale=args.scale,
+                device=NPU_DEVICE,
+            )
+            varlen_run_true, _ = make_varlen_runner(
+                tri_inv_func,
+                packed_input,
+                chunk_indices,
+            )
+            times_ms = benchmark_ms(
+                varlen_run_true,
+                warmup_iters=args.warmup,
+                benchmark_iters=args.repeats,
+                device=NPU_DEVICE,
+            )
+            row = {
+                "inverse_type": "bsnd-varlen-true",
+                "dtype": "fp16",
+                "B": args.B,
+                "T": seqlen,
+                "aggregated_T": total_tokens,
+                "padded_T": int(packed_input.shape[1]),
+                "H": args.H,
+                "numel": packed_input.numel(),
+                "valid_numel": total_tokens * args.H * args.chunk_size,
+                "chunk_size": args.chunk_size,
+                "time_us": int(round(np.mean(times_ms) * 1000.0)),
+                "max_abs_diff_to_fixed": "",
+                "rel_frob_diff_to_fixed": "",
+                "sample_id": sample_idx,
+                "seq_lens": ",".join(map(str, seq_lens)),
+            }
+            add_bandwidth_fields(row)
+            true_varlen_rows.append(row)
+            print(
+                f"  true-varlen sample={sample_idx}: aggregated_T={total_tokens}, "
+                f"padded_T={row['padded_T']}, bw_gbs={row['bw_gbs']:.2f}"
+            )
+
+    if not rows:
+        raise RuntimeError("No benchmark rows were generated.")
+
+    write_csv(csv_path, rows)
+    plot_bandwidth(
+        plot_path,
+        rows,
+        batch_size=args.B,
+        num_heads=args.H,
+        chunk_size=args.chunk_size,
+    )
+    write_csv(true_varlen_csv_path, true_varlen_rows)
+    plot_true_varlen_scatter(
+        true_varlen_plot_path,
+        true_varlen_rows,
+        batch_size=args.B,
+        num_heads=args.H,
+        chunk_size=args.chunk_size,
+    )
+    print(f"\nWrote CSV: {csv_path}")
+    print(f"Wrote plot: {plot_path}")
+    print(f"Wrote true-varlen CSV: {true_varlen_csv_path}")
+    print(f"Wrote true-varlen plot: {true_varlen_plot_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/jit_cpp/fast_inverse/fast_inverse.cpp
+++ b/examples/jit_cpp/fast_inverse/fast_inverse.cpp
@@ -26,18 +26,15 @@ for the full License text.
  * @param num_matrices  Total number of matrices to invert.
  * @param num_bsnd_heads  0 for standard (B…ND) layout;
  *                        N (number of heads) for BSND layout.
- * @param chunk_indices  Optional int32 pointer used only for varlen BSND. Each
- *                       entry is the absolute row offset of one chunk within the
- *                       unpadded BSND tensor.
- * @param chunk_valid_sizes  Optional int32 pointer used only for varlen BSND.
- *                           Each entry stores the runtime size of that chunk.
+ * @param cu_seqlens  Optional int32 pointer used only for varlen BSND. Matches
+ *                    the Triton-style API and stores cumulative sequence
+ *                    boundaries for the packed BSND tensor.
  */
 extern "C" void call_kernel(uint32_t blockDim, void* stream, void* tensor_out,
                              void* tensor_in, void* minus_identity_in,
                              uint32_t matrix_size, uint32_t num_matrices,
-                             uint32_t num_bsnd_heads, void* chunk_indices,
-                             void* chunk_valid_sizes) {
+                             uint32_t num_bsnd_heads, void* cu_seqlens) {
   tri_inv_rec_unroll_fp16<<<blockDim, nullptr, stream>>>(
       tensor_out, tensor_in, minus_identity_in, matrix_size, num_matrices,
-      num_bsnd_heads, chunk_indices, chunk_valid_sizes);
+      num_bsnd_heads, cu_seqlens);
 }

--- a/examples/jit_cpp/fast_inverse/fast_inverse.cpp
+++ b/examples/jit_cpp/fast_inverse/fast_inverse.cpp
@@ -26,12 +26,15 @@ for the full License text.
  * @param num_matrices  Total number of matrices to invert.
  * @param num_bsnd_heads  0 for standard (B…ND) layout;
  *                        N (number of heads) for BSND layout.
+ * @param chunk_indices  Optional int32 pointer used only for varlen BSND. Each
+ *                       entry is the absolute row offset of one padded D x D
+ *                       chunk within the BSND tensor.
  */
 extern "C" void call_kernel(uint32_t blockDim, void* stream, void* tensor_out,
                              void* tensor_in, void* minus_identity_in,
                              uint32_t matrix_size, uint32_t num_matrices,
-                             uint32_t num_bsnd_heads) {
+                             uint32_t num_bsnd_heads, void* chunk_indices) {
   tri_inv_rec_unroll_fp16<<<blockDim, nullptr, stream>>>(
       tensor_out, tensor_in, minus_identity_in, matrix_size, num_matrices,
-      num_bsnd_heads);
+      num_bsnd_heads, chunk_indices);
 }

--- a/examples/jit_cpp/fast_inverse/fast_inverse.cpp
+++ b/examples/jit_cpp/fast_inverse/fast_inverse.cpp
@@ -27,14 +27,17 @@ for the full License text.
  * @param num_bsnd_heads  0 for standard (B…ND) layout;
  *                        N (number of heads) for BSND layout.
  * @param chunk_indices  Optional int32 pointer used only for varlen BSND. Each
- *                       entry is the absolute row offset of one padded D x D
- *                       chunk within the BSND tensor.
+ *                       entry is the absolute row offset of one chunk within the
+ *                       unpadded BSND tensor.
+ * @param chunk_valid_sizes  Optional int32 pointer used only for varlen BSND.
+ *                           Each entry stores the runtime size of that chunk.
  */
 extern "C" void call_kernel(uint32_t blockDim, void* stream, void* tensor_out,
                              void* tensor_in, void* minus_identity_in,
                              uint32_t matrix_size, uint32_t num_matrices,
-                             uint32_t num_bsnd_heads, void* chunk_indices) {
+                             uint32_t num_bsnd_heads, void* chunk_indices,
+                             void* chunk_valid_sizes) {
   tri_inv_rec_unroll_fp16<<<blockDim, nullptr, stream>>>(
       tensor_out, tensor_in, minus_identity_in, matrix_size, num_matrices,
-      num_bsnd_heads, chunk_indices);
+      num_bsnd_heads, chunk_indices, chunk_valid_sizes);
 }

--- a/examples/jit_cpp/fast_inverse/fast_inverse.cpp
+++ b/examples/jit_cpp/fast_inverse/fast_inverse.cpp
@@ -31,9 +31,9 @@ for the full License text.
  *                    boundaries for the packed BSND tensor.
  */
 extern "C" void call_kernel(uint32_t blockDim, void* stream, void* tensor_out,
-                             void* tensor_in, void* minus_identity_in,
-                             uint32_t matrix_size, uint32_t num_matrices,
-                             uint32_t num_bsnd_heads, void* cu_seqlens) {
+                            void* tensor_in, void* minus_identity_in,
+                            uint32_t matrix_size, uint32_t num_matrices,
+                            uint32_t num_bsnd_heads, void* cu_seqlens) {
   tri_inv_rec_unroll_fp16<<<blockDim, nullptr, stream>>>(
       tensor_out, tensor_in, minus_identity_in, matrix_size, num_matrices,
       num_bsnd_heads, cu_seqlens);

--- a/examples/jit_cpp/fast_inverse/fast_inverse.cpp
+++ b/examples/jit_cpp/fast_inverse/fast_inverse.cpp
@@ -1,0 +1,37 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+
+// Include the triangular inverse kernel implementation.
+// The build script adds csrc/kernel/ to the include path so that
+// kernel_utils.h (included by kernel_tri_inv_rec_unroll.cpp) is found.
+#include "kernel_tri_inv_rec_unroll.cpp"
+
+/**
+ * @brief JIT entry point for the triangular inverse (recursive unroll) kernel.
+ *
+ * @param blockDim   Number of AI-Core blocks to launch.
+ * @param stream     NPU stream handle.
+ * @param tensor_out fp32 output buffer (same element count as tensor_in).
+ * @param tensor_in  fp16 input buffer holding the upper-triangular matrices
+ *                   (diagonal is assumed to be all-ones).
+ * @param minus_identity_in  fp16 buffer of size matrix_size×matrix_size
+ *                           pre-filled with -I (negative identity).
+ * @param matrix_size   Side length of each square matrix (16 / 32 / 64 / 128).
+ * @param num_matrices  Total number of matrices to invert.
+ * @param num_bsnd_heads  0 for standard (B…ND) layout;
+ *                        N (number of heads) for BSND layout.
+ */
+extern "C" void call_kernel(uint32_t blockDim, void* stream, void* tensor_out,
+                             void* tensor_in, void* minus_identity_in,
+                             uint32_t matrix_size, uint32_t num_matrices,
+                             uint32_t num_bsnd_heads) {
+  tri_inv_rec_unroll_fp16<<<blockDim, nullptr, stream>>>(
+      tensor_out, tensor_in, minus_identity_in, matrix_size, num_matrices,
+      num_bsnd_heads);
+}

--- a/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
@@ -86,6 +86,7 @@ def load_lib(lib_path: str):
         ctypes.c_uint32,  # num_matrices
         ctypes.c_uint32,  # num_bsnd_heads
         ctypes.c_void_p,  # chunk_indices (optional int32 metadata)
+        ctypes.c_void_p,  # chunk_valid_sizes (optional int32 metadata)
     ]
     lib.call_kernel.restype = None
 
@@ -97,6 +98,7 @@ def load_lib(lib_path: str):
         num_matrices: int,
         num_bsnd_heads: int = 0,
         chunk_indices: torch.Tensor | None = None,
+        chunk_valid_sizes: torch.Tensor | None = None,
         block_dim: int = BLOCK_DIM,
         stream_ptr=None,
     ):
@@ -107,6 +109,11 @@ def load_lib(lib_path: str):
                 raise TypeError("chunk_indices must be int32.")
             if not chunk_indices.is_contiguous():
                 raise ValueError("chunk_indices must be contiguous.")
+        if chunk_valid_sizes is not None:
+            if chunk_valid_sizes.dtype != torch.int32:
+                raise TypeError("chunk_valid_sizes must be int32.")
+            if not chunk_valid_sizes.is_contiguous():
+                raise ValueError("chunk_valid_sizes must be contiguous.")
         effective_block_dim = min(block_dim, num_matrices)
         lib.call_kernel(
             effective_block_dim,
@@ -119,6 +126,9 @@ def load_lib(lib_path: str):
             num_bsnd_heads,
             _torch_to_ctypes(chunk_indices)
             if chunk_indices is not None
+            else ctypes.c_void_p(),
+            _torch_to_ctypes(chunk_valid_sizes)
+            if chunk_valid_sizes is not None
             else ctypes.c_void_p(),
         )
 

--- a/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
@@ -1,0 +1,128 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All rights reserved.
+# See LICENSE in the root of the software repository:
+# https://github.com/huawei-csl/pto-kernels/
+# for the full License text.
+# --------------------------------------------------------------------------------
+
+import ctypes
+import os
+import subprocess
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Environment / paths
+# ---------------------------------------------------------------------------
+PTO_LIB_PATH = os.environ.get("PTO_LIB_PATH", os.environ["ASCEND_TOOLKIT_HOME"])
+
+# Directory of this file  →  repo-root/examples/jit_cpp/fast_inverse
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+# csrc/kernel lives three levels up from this file
+_CSRC_KERNEL_DIR = os.path.abspath(os.path.join(_THIS_DIR, "../../../csrc/kernel"))
+
+BLOCK_DIM = int(getattr(torch.npu.get_device_properties("npu:0"), "cube_core_num", 20))
+
+
+# ---------------------------------------------------------------------------
+# Compilation
+# ---------------------------------------------------------------------------
+
+def compile_cpp(kernel_cpp: str, verbose: bool = False, timeout: int = 180) -> str:
+    """Compile *kernel_cpp* with bisheng and return the path to the .so."""
+    lib_path = os.path.join(os.path.dirname(kernel_cpp), "fast_inverse_jit.so")
+
+    flags = [
+        "-fPIC",
+        "-shared",
+        "-xcce",
+        "-DMEMORY_BASE",
+        "-O2",
+        "-std=c++17",
+        # Resolve kernel_utils.h (included by kernel_tri_inv_rec_unroll.cpp)
+        f"-I{_CSRC_KERNEL_DIR}",
+        # PTO-ISA headers
+        f"-I{PTO_LIB_PATH}/include",
+        # Target the Ascend 910B cube core
+        "--cce-soc-version=Ascend910B4",
+        "--cce-soc-core-type=CubeCore",
+    ]
+
+    command = ["bisheng", *flags, kernel_cpp, "-o", lib_path]
+    if verbose:
+        print("Compiling fast_inverse kernel:")
+        print(" ", " ".join(command))
+
+    try:
+        subprocess.run(command, timeout=timeout, check=True)
+    except Exception as exc:
+        raise RuntimeError(f"Compilation failed: {exc}") from exc
+
+    if verbose:
+        print(f"Generated: {lib_path}")
+    return lib_path
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def _torch_to_ctypes(tensor: torch.Tensor) -> ctypes.c_void_p:
+    return ctypes.c_void_p(tensor.data_ptr())
+
+
+def load_lib(lib_path: str):
+    """Load the compiled .so and return a Python callable for the kernel."""
+    lib = ctypes.CDLL(os.path.abspath(lib_path))
+
+    lib.call_kernel.argtypes = [
+        ctypes.c_uint32,  # blockDim
+        ctypes.c_void_p,  # stream
+        ctypes.c_void_p,  # tensor_out  (fp32)
+        ctypes.c_void_p,  # tensor_in   (fp16)
+        ctypes.c_void_p,  # minus_identity_in (fp16)
+        ctypes.c_uint32,  # matrix_size
+        ctypes.c_uint32,  # num_matrices
+        ctypes.c_uint32,  # num_bsnd_heads
+    ]
+    lib.call_kernel.restype = None
+
+    def tri_inv_func(
+        tensor_out: torch.Tensor,
+        tensor_in: torch.Tensor,
+        minus_identity: torch.Tensor,
+        matrix_size: int,
+        num_matrices: int,
+        num_bsnd_heads: int = 0,
+        block_dim: int = BLOCK_DIM,
+        stream_ptr=None,
+    ):
+        if stream_ptr is None:
+            stream_ptr = torch.npu.current_stream()._as_parameter_  # noqa
+        effective_block_dim = min(block_dim, num_matrices)
+        lib.call_kernel(
+            effective_block_dim,
+            stream_ptr,
+            _torch_to_ctypes(tensor_out),
+            _torch_to_ctypes(tensor_in),
+            _torch_to_ctypes(minus_identity),
+            matrix_size,
+            num_matrices,
+            num_bsnd_heads,
+        )
+
+    return tri_inv_func
+
+
+# ---------------------------------------------------------------------------
+# Convenience: compile + load in one call
+# ---------------------------------------------------------------------------
+
+def jit_compile(src_path: str, verbose: bool = True, clean_up: bool = False):
+    """Compile *src_path* and return the kernel callable."""
+    lib_path = compile_cpp(src_path, verbose=verbose)
+    func = load_lib(lib_path)
+    if clean_up:
+        os.remove(lib_path)
+    return func

--- a/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
@@ -85,6 +85,7 @@ def load_lib(lib_path: str):
         ctypes.c_uint32,  # matrix_size
         ctypes.c_uint32,  # num_matrices
         ctypes.c_uint32,  # num_bsnd_heads
+        ctypes.c_void_p,  # chunk_indices (optional int32 metadata)
     ]
     lib.call_kernel.restype = None
 
@@ -95,11 +96,17 @@ def load_lib(lib_path: str):
         matrix_size: int,
         num_matrices: int,
         num_bsnd_heads: int = 0,
+        chunk_indices: torch.Tensor | None = None,
         block_dim: int = BLOCK_DIM,
         stream_ptr=None,
     ):
         if stream_ptr is None:
             stream_ptr = torch.npu.current_stream()._as_parameter_  # noqa
+        if chunk_indices is not None:
+            if chunk_indices.dtype != torch.int32:
+                raise TypeError("chunk_indices must be int32.")
+            if not chunk_indices.is_contiguous():
+                raise ValueError("chunk_indices must be contiguous.")
         effective_block_dim = min(block_dim, num_matrices)
         lib.call_kernel(
             effective_block_dim,
@@ -110,6 +117,9 @@ def load_lib(lib_path: str):
             matrix_size,
             num_matrices,
             num_bsnd_heads,
+            _torch_to_ctypes(chunk_indices)
+            if chunk_indices is not None
+            else ctypes.c_void_p(),
         )
 
     return tri_inv_func

--- a/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
@@ -85,8 +85,7 @@ def load_lib(lib_path: str):
         ctypes.c_uint32,  # matrix_size
         ctypes.c_uint32,  # num_matrices
         ctypes.c_uint32,  # num_bsnd_heads
-        ctypes.c_void_p,  # chunk_indices (optional int32 metadata)
-        ctypes.c_void_p,  # chunk_valid_sizes (optional int32 metadata)
+        ctypes.c_void_p,  # cu_seqlens (optional int32 metadata)
     ]
     lib.call_kernel.restype = None
 
@@ -97,23 +96,17 @@ def load_lib(lib_path: str):
         matrix_size: int,
         num_matrices: int,
         num_bsnd_heads: int = 0,
-        chunk_indices: torch.Tensor | None = None,
-        chunk_valid_sizes: torch.Tensor | None = None,
+        cu_seqlens: torch.Tensor | None = None,
         block_dim: int = BLOCK_DIM,
         stream_ptr=None,
     ):
         if stream_ptr is None:
             stream_ptr = torch.npu.current_stream()._as_parameter_  # noqa
-        if chunk_indices is not None:
-            if chunk_indices.dtype != torch.int32:
-                raise TypeError("chunk_indices must be int32.")
-            if not chunk_indices.is_contiguous():
-                raise ValueError("chunk_indices must be contiguous.")
-        if chunk_valid_sizes is not None:
-            if chunk_valid_sizes.dtype != torch.int32:
-                raise TypeError("chunk_valid_sizes must be int32.")
-            if not chunk_valid_sizes.is_contiguous():
-                raise ValueError("chunk_valid_sizes must be contiguous.")
+        if cu_seqlens is not None:
+            if cu_seqlens.dtype != torch.int32:
+                raise TypeError("cu_seqlens must be int32.")
+            if not cu_seqlens.is_contiguous():
+                raise ValueError("cu_seqlens must be contiguous.")
         effective_block_dim = min(block_dim, num_matrices)
         lib.call_kernel(
             effective_block_dim,
@@ -124,11 +117,8 @@ def load_lib(lib_path: str):
             matrix_size,
             num_matrices,
             num_bsnd_heads,
-            _torch_to_ctypes(chunk_indices)
-            if chunk_indices is not None
-            else ctypes.c_void_p(),
-            _torch_to_ctypes(chunk_valid_sizes)
-            if chunk_valid_sizes is not None
+            _torch_to_ctypes(cu_seqlens)
+            if cu_seqlens is not None
             else ctypes.c_void_p(),
         )
 

--- a/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py
@@ -29,6 +29,7 @@ BLOCK_DIM = int(getattr(torch.npu.get_device_properties("npu:0"), "cube_core_num
 # Compilation
 # ---------------------------------------------------------------------------
 
+
 def compile_cpp(kernel_cpp: str, verbose: bool = False, timeout: int = 180) -> str:
     """Compile *kernel_cpp* with bisheng and return the path to the .so."""
     lib_path = os.path.join(os.path.dirname(kernel_cpp), "fast_inverse_jit.so")
@@ -67,6 +68,7 @@ def compile_cpp(kernel_cpp: str, verbose: bool = False, timeout: int = 180) -> s
 # ---------------------------------------------------------------------------
 # Loading
 # ---------------------------------------------------------------------------
+
 
 def _torch_to_ctypes(tensor: torch.Tensor) -> ctypes.c_void_p:
     return ctypes.c_void_p(tensor.data_ptr())
@@ -117,9 +119,11 @@ def load_lib(lib_path: str):
             matrix_size,
             num_matrices,
             num_bsnd_heads,
-            _torch_to_ctypes(cu_seqlens)
-            if cu_seqlens is not None
-            else ctypes.c_void_p(),
+            (
+                _torch_to_ctypes(cu_seqlens)
+                if cu_seqlens is not None
+                else ctypes.c_void_p()
+            ),
         )
 
     return tri_inv_func
@@ -128,6 +132,7 @@ def load_lib(lib_path: str):
 # ---------------------------------------------------------------------------
 # Convenience: compile + load in one call
 # ---------------------------------------------------------------------------
+
 
 def jit_compile(src_path: str, verbose: bool = True, clean_up: bool = False):
     """Compile *src_path* and return the kernel callable."""

--- a/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
+++ b/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
@@ -31,9 +31,12 @@ AICORE inline uint32_t GetBSNDFixedTileOffset(uint32_t tile_id,
   return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
 }
 
+/**
+ * @brief Struct containing starting address and size of a single tile
+ */
 struct BSNDVarlenTileInfo {
-  uint32_t bsnd_offset;
-  uint32_t valid_size;
+  uint32_t bsnd_offset; /**< Contains the starting index in the global tensor */
+  uint32_t valid_size;  /**< This is the size (num_rows/cols) of the tile */
 };
 
 /*
@@ -134,11 +137,14 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
 
+  // For left: copy even blocks 0, 2, 4, ... (starting_block=0)
+  // For right: copy odd blocks 1, 3, 5, ... (starting_block=1)
   const uint32_t starting_block_index = is_left ? 0 : 1;
 
   const uint32_t num_blocks = MatrixSize / block_size;
   const uint32_t num_fractals_per_block = block_size / FractalSize;
 
+  // might need fewer fractals if block_size < FractalSize
   Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
        FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
       fractals[MatrixSize / FractalSize];
@@ -148,9 +154,10 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
     for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
       for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
-        const uint32_t offset = b * (MatrixSize + FractalSize) * block_size +
-                                i * MatrixSize * FractalSize +
-                                j * FractalSize * FractalSize;
+        const uint32_t offset =
+            b * (MatrixSize + FractalSize) * block_size /* block_offset */ +
+            i * MatrixSize * FractalSize /* col_fractal_offset */ +
+            j * FractalSize * FractalSize /* row_fractal_offset */;
         TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
         TEXTRACT(fractals[b], src, b * block_size + i * FractalSize,
                  b * block_size + j * FractalSize);
@@ -179,34 +186,59 @@ template <typename TileL1AB, typename TileL0A, typename TileL0B,
 AICORE inline void PrepareAuxiliaryMatrices(
     TileL1AB I_neg_l1_tile, TileL1AB Zero_l1_tile, TileL1AB I_l1_tile,
     TileL0A a_l0_tile, TileL0B b_l0_tile, TileL0C c_l0_tile) {
-  TMOV(a_l0_tile, I_neg_l1_tile);
-  TMOV(b_l0_tile, I_neg_l1_tile);
+  TMOV(a_l0_tile, I_neg_l1_tile);  // a_l0 initialized with I_neg
+  TMOV(b_l0_tile, I_neg_l1_tile);  // b_l0 initialized with I_neg
   set_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
   wait_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
 
-  TMATMUL(c_l0_tile, a_l0_tile, b_l0_tile);
+  TMATMUL(c_l0_tile, a_l0_tile, b_l0_tile);  // c_l0 contains I
   set_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
   wait_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
 
-  TMOV(I_l1_tile, c_l0_tile);
+  TMOV(I_l1_tile, c_l0_tile);  // I_l1 now contains I
   set_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
   wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
 
-  TMOV(b_l0_tile, I_l1_tile);
+  TMOV(b_l0_tile, I_l1_tile);  // b_l0 contains I
   set_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
   wait_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
 
-  TMATMUL_ACC(c_l0_tile, c_l0_tile, a_l0_tile, b_l0_tile);
+  TMATMUL_ACC(c_l0_tile, c_l0_tile, a_l0_tile,
+              b_l0_tile);  // c_l0 contains zeros
   set_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
   wait_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
 
-  TMOV(Zero_l1_tile, c_l0_tile);
+  TMOV(Zero_l1_tile, c_l0_tile);  // Zeros_l1 now contains zeros
   set_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
   wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
 }
 
 /*
  * @brief: Inverts a single matrix / tile of the global tensor.
+ * The first part of the algorithm inverts the FractalSize * FractalSize
+ * diagonal blocks of the input matrix (inv_trick part). The second phase
+ * assembles the partial inverses using the cube unig (recursive part).
+ *
+ * @tparam InputT The type of the input elements.
+ * @tparam TileL1AB The type of the input tiles in L1.
+ * @tparam TileL0A The type of the input tiles in L0A.
+ * @tparam TileL0B The type of the input tiles in L0B.
+ * @tparam TileL0C The type of the input tiles in L0C.
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam FractalSize Size of matrix fractals.
+ * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
+ * cube iteration.
+ *
+ * @param X_l1_tile Tile in L1 used for intermediate computations.
+ * @param I_l1_tile Tile containing the identity matrix.
+ * @param I_neg_l1_tile Tile containing the negative identity matrix.
+ * @param M_neg_l1_tile Tile containing the negative input matrix.
+ * @param Zero_l1_tile Tile containing the all-zero matrix.
+ * @param Y_l1_tile Tile in L1 used for intermediate computations.
+ * @param a_l0_tile* Array of two tiles in L0A (for double-buffering).
+ * @param b_l0_tile* Array of two tiles in L0B (for double-buffering).
+ * @param c_l0_tile* Tile in L0C for matmuls.
+ * @param tile_id Index of the current tile (used for sync).
  */
 template <typename InputT, typename TileL1AB, typename TileL0A,
           typename TileL0B, typename TileL0C, uint32_t MatrixSize,
@@ -221,8 +253,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   const event_t event_0 = static_cast<event_t>(tile_id);
   const event_t event_1 = static_cast<event_t>(tile_id + NumTilesPerCubeIter);
 
-  TMOV(b_l0_tile[0], Y_l1_tile);
-  TMOV(a_l0_tile[0], I_neg_l1_tile);
+  TMOV(b_l0_tile[0], Y_l1_tile);      // b_l0[0] contains M
+  TMOV(a_l0_tile[0], I_neg_l1_tile);  // a_l0[0] contains I_neg
   set_flag(PIPE_MTE1, PIPE_M, event_0);
   TMOV(a_l0_tile[1], Zero_l1_tile);
   TMOV(b_l0_tile[1], Zero_l1_tile);
@@ -230,55 +262,72 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   wait_flag(PIPE_MTE1, PIPE_M, event_1);
   set_flag(PIPE_M, PIPE_MTE1, event_1);
   wait_flag(PIPE_M, PIPE_MTE1, event_1);
-  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(Y_l1_tile,
-                                                              a_l0_tile[1]);
-  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(Y_l1_tile,
-                                                              b_l0_tile[1]);
+  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, a_l0_tile[1]);  // a_l0[1] = diag_fractals(M)
+  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, b_l0_tile[1]);  // b_l0[1] = diag_fractals(M)
   set_flag(PIPE_MTE1, PIPE_M, event_1);
 
+  /* First Matmul: event_0 */
   wait_flag(PIPE_MTE1, PIPE_M, event_0);
-  TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+  TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] contains M_neg
   set_flag(PIPE_M, PIPE_FIX, event_0);
   set_flag(PIPE_M, PIPE_MTE1, event_0);
 
   wait_flag(PIPE_M, PIPE_FIX, event_0);
-  TMOV(M_neg_l1_tile, c_l0_tile[0]);
+  TMOV(M_neg_l1_tile, c_l0_tile[0]);  // M_neg_l1 now contains M_neg
   set_flag(PIPE_FIX, PIPE_M, event_0);
 
+  /* Second Matmul: event_1 */
   wait_flag(PIPE_MTE1, PIPE_M, event_1);
   set_flag(PIPE_MTE1, PIPE_M, event_1);
-  TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[1]);
+  TMATMUL(c_l0_tile[1], a_l0_tile[1],
+          b_l0_tile[1]);  // c_l0[1] contains diag_fractals(M)^2
   set_flag(PIPE_M, PIPE_FIX, event_1);
   wait_flag(PIPE_M, PIPE_FIX, event_1);
-  TMOV(Y_l1_tile, c_l0_tile[1]);
+  TMOV(Y_l1_tile,
+       c_l0_tile[1]);  // Y_l1 now contains diag_fractals(M)^2
   set_flag(PIPE_FIX, PIPE_M, event_1);
   wait_flag(PIPE_FIX, PIPE_M, event_1);
 
+  /* Third Matmul: event_0*/
   wait_flag(PIPE_M, PIPE_MTE1, event_0);
-  TMOV(b_l0_tile[0], I_neg_l1_tile);
-  TMOV(a_l0_tile[0], I_neg_l1_tile);
+  TMOV(b_l0_tile[0], I_neg_l1_tile);  // b_l0[0] contains I_neg
+  TMOV(a_l0_tile[0], I_neg_l1_tile);  // a_l0[0] contains I_neg
   set_flag(PIPE_MTE1, PIPE_M, event_0);
 
   wait_flag(PIPE_MTE1, PIPE_M, event_0);
   wait_flag(PIPE_FIX, PIPE_M, event_0);
   wait_flag(PIPE_MTE1, PIPE_M, event_1);
-  TMATMUL(c_l0_tile[0], a_l0_tile[1], b_l0_tile[0]);
+  TMATMUL(c_l0_tile[0], a_l0_tile[1],
+          b_l0_tile[0]);  // c_l0[0] = diag_fractals(M_neg)
   set_flag(PIPE_M, PIPE_FIX, event_0);
   wait_flag(PIPE_M, PIPE_FIX, event_0);
   set_flag(PIPE_FIX, PIPE_M, event_0);
   wait_flag(PIPE_FIX, PIPE_M, event_0);
 
-  TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+  TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0],
+              b_l0_tile[0]);  // c_l0[0] has I-diag_fractals(M)
   set_flag(PIPE_M, PIPE_FIX, event_1);
   wait_flag(PIPE_M, PIPE_FIX, event_1);
-  TMOV(X_l1_tile, c_l0_tile[0]);
+  TMOV(X_l1_tile, c_l0_tile[0]);  // X_l1 now contains I-diag_fractals(M)
 
-  set_flag(PIPE_FIX, PIPE_M, event_0);
-  set_flag(PIPE_M, PIPE_MTE1, event_0);
+  /*
+   * Inv Trick part:
+   * X = I - M
+   * Y = M
+   * block_size = 1
+   * while block_size < FractalSize / 2:
+   *     Y = Y @ Y
+   *     X = X + X @ Y
+   *     block_size *= 2
+   */
+  set_flag(PIPE_FIX, PIPE_M, event_0);   // store c
+  set_flag(PIPE_M, PIPE_MTE1, event_0);  // load matrices for matmuls
   set_flag(PIPE_FIX, PIPE_MTE1, event_0);
-  set_flag(PIPE_FIX, PIPE_M, event_1);
-  set_flag(PIPE_M, PIPE_MTE1, event_1);
-  set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  set_flag(PIPE_FIX, PIPE_M, event_1);     // only for update Y
+  set_flag(PIPE_M, PIPE_MTE1, event_1);    // only for update Y
+  set_flag(PIPE_FIX, PIPE_MTE1, event_1);  // only for update Y
   for (uint32_t block_size = 1; block_size < FractalSize / 2; block_size *= 2) {
     wait_flag(PIPE_M, PIPE_MTE1, event_0);
     TMOV(b_l0_tile[0], I_l1_tile);
@@ -290,52 +339,63 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
     TMOV(b_l0_tile[1], Y_l1_tile);
     set_flag(PIPE_MTE1, PIPE_M, event_1);
 
-    wait_flag(PIPE_FIX, PIPE_M, event_0);
-    wait_flag(PIPE_MTE1, PIPE_M, event_0);
-    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+    wait_flag(PIPE_FIX, PIPE_M, event_0);   // from previous iter
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);  // from loading a_l0[0], b_l0[0]
+    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] contains X
     set_flag(PIPE_M, PIPE_FIX, event_0);
     wait_flag(PIPE_M, PIPE_FIX, event_0);
     set_flag(PIPE_FIX, PIPE_M, event_0);
     wait_flag(PIPE_FIX, PIPE_M, event_0);
 
-    if (block_size < FractalSize / 4) {
-      wait_flag(PIPE_M, PIPE_MTE1, event_1);
+    if (block_size < FractalSize / 4) {  // Update Y except in last iteration
+      wait_flag(PIPE_M, PIPE_MTE1, event_1);  // from previous iter
       TMOV(a_l0_tile[1], Y_l1_tile);
       wait_flag(PIPE_MTE1, PIPE_M, event_1);
       set_flag(PIPE_MTE1, PIPE_M, event_1);
 
       wait_flag(PIPE_MTE1, PIPE_M, event_1);
-      wait_flag(PIPE_FIX, PIPE_M, event_1);
+      wait_flag(PIPE_FIX, PIPE_M, event_1);  // from previous iter
       TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[1]);
-      set_flag(PIPE_M, PIPE_MTE1, event_1);
+      set_flag(PIPE_M, PIPE_MTE1, event_1);  // for next iter
       set_flag(PIPE_M, PIPE_FIX, event_1);
       set_flag(PIPE_MTE1, PIPE_M, event_1);
 
       wait_flag(PIPE_M, PIPE_FIX, event_1);
       TMOV(Y_l1_tile, c_l0_tile[1]);
-      set_flag(PIPE_FIX, PIPE_M, event_1);
+      set_flag(PIPE_FIX, PIPE_M, event_1);  // for next iter
     }
-    set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+    set_flag(PIPE_FIX, PIPE_MTE1, event_1);  // for next iter
 
     wait_flag(PIPE_MTE1, PIPE_M, event_1);
-    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0], b_l0_tile[1]);
+    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0],
+                b_l0_tile[1]);  // c_l0[0] has X + X @ Y
     set_flag(PIPE_M, PIPE_MTE1, event_0);
     set_flag(PIPE_M, PIPE_FIX, event_0);
 
     wait_flag(PIPE_M, PIPE_FIX, event_0);
     TMOV(X_l1_tile, c_l0_tile[0]);
-    set_flag(PIPE_FIX, PIPE_M, event_0);
-    set_flag(PIPE_FIX, PIPE_MTE1, event_0);
+    set_flag(PIPE_FIX, PIPE_M, event_0);     // for next iter
+    set_flag(PIPE_FIX, PIPE_MTE1, event_0);  // for next iter
   }
-  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
-  wait_flag(PIPE_M, PIPE_MTE1, event_1);
-  wait_flag(PIPE_FIX, PIPE_M, event_1);
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // only for update Y
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);    // only for update Y
+  wait_flag(PIPE_FIX, PIPE_M, event_1);     // only for update Y
   wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
   wait_flag(PIPE_M, PIPE_MTE1, event_0);
   wait_flag(PIPE_FIX, PIPE_M, event_0);
 
-  TMOV(b_l0_tile[1], M_neg_l1_tile);
-  TMOV(a_l0_tile[0], I_l1_tile);
+  /*
+   * Unrolled recursion part:
+   * block_size = FractalSize
+   * while block_size < MatrixSize:
+   *     LX = even_blocks(X, block_size)
+   *     RX = odd_blocks(X, block_size)
+   *     Y = LX @ (-M) + I
+   *     X = Y @ RX + LX
+   *     block_size *= 2
+   */
+  TMOV(b_l0_tile[1], M_neg_l1_tile);  // b_l0[1] contains M_neg
+  TMOV(a_l0_tile[0], I_l1_tile);      // a_l0[0] contains I
 
   if constexpr (MatrixSize > FractalSize) {
     set_flag(PIPE_FIX, PIPE_M, event_1);
@@ -346,67 +406,88 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   set_flag(PIPE_FIX, PIPE_M, event_0);
   for (uint32_t block_size = FractalSize; block_size < MatrixSize;
        block_size *= 2) {
-    wait_flag(PIPE_M, PIPE_MTE1, event_0);
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for last iter a_l0[1]
     TMOV(a_l0_tile[1], Zero_l1_tile);
 
     wait_flag(PIPE_M, PIPE_MTE1, event_1);
     TMOV(b_l0_tile[0], I_l1_tile);
     set_flag(PIPE_MTE1, PIPE_M, event_0);
 
-    wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Wait to write last X
     CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
-        X_l1_tile, a_l0_tile[1], block_size);
+        X_l1_tile, a_l0_tile[1], block_size);  // a_l0[1] contains LX
     set_flag(PIPE_MTE1, PIPE_M, event_1);
 
     wait_flag(PIPE_MTE1, PIPE_M, event_0);
-    wait_flag(PIPE_FIX, PIPE_M, event_0);
-    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+    wait_flag(PIPE_FIX, PIPE_M, event_0);  // Wait c_l0[0] from previous iter
+    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] has I
 
     wait_flag(PIPE_MTE1, PIPE_M, event_1);
-    wait_flag(PIPE_FIX, PIPE_M, event_1);
-    TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);
-    set_flag(PIPE_M, PIPE_MTE1, event_1);
+    wait_flag(PIPE_FIX, PIPE_M, event_1);  // Wait c_l0[1] from previous iter
+    TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);  // c_l0[1] contains LX
+    set_flag(PIPE_M, PIPE_MTE1, event_1);  // allow to load RX on b_l0[0]
 
-    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[1], b_l0_tile[1]);
+    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[1],
+                b_l0_tile[1]);  // c_l0[0] <- LX * M_neg + I
     set_flag(PIPE_M, PIPE_FIX, event_0);
     set_flag(PIPE_M, PIPE_MTE1, event_0);
 
     wait_flag(PIPE_M, PIPE_FIX, event_0);
-    TMOV(Y_l1_tile, c_l0_tile[0]);
+    TMOV(Y_l1_tile, c_l0_tile[0]);  // Y_l1 contains LX * M_neg + I
     set_flag(PIPE_FIX, PIPE_MTE1, event_0);
     set_flag(PIPE_FIX, PIPE_M, event_0);
 
+    /* Load Odd Blocks Of X In L0B */
     wait_flag(PIPE_M, PIPE_MTE1, event_1);
     TMOV(b_l0_tile[0], Zero_l1_tile);
     CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
-        X_l1_tile, b_l0_tile[0], block_size);
+        X_l1_tile, b_l0_tile[0], block_size);  // b_l0[0] contains RX
 
-    wait_flag(PIPE_M, PIPE_MTE1, event_0);
-    wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
-    TMOV(a_l0_tile[1], Y_l1_tile);
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for previous use of a_l0[1]
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_0);  // Wait for Y_l1
+    TMOV(a_l0_tile[1], Y_l1_tile);            // a_l0[1] contains LX * M_neg + I
     set_flag(PIPE_MTE1, PIPE_M, event_0);
 
     wait_flag(PIPE_MTE1, PIPE_M, event_0);
     TMATMUL_ACC(c_l0_tile[1], c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);
-    set_flag(PIPE_M, PIPE_MTE1, event_0);
-    set_flag(PIPE_M, PIPE_MTE1, event_1);
+    set_flag(PIPE_M, PIPE_MTE1, event_0);  // next iter can read on a_l0[1]
+    set_flag(PIPE_M, PIPE_MTE1, event_1);  // next iter can read on b_l0[0]
     set_flag(PIPE_M, PIPE_FIX, event_0);
     wait_flag(PIPE_M, PIPE_FIX, event_0);
 
-    if (block_size < MatrixSize / 2) {
+    if (block_size < MatrixSize / 2) {  // Update X_l1 except in last iteration
       TMOV(X_l1_tile, c_l0_tile[1]);
-      set_flag(PIPE_FIX, PIPE_M, event_1);
+      set_flag(PIPE_FIX, PIPE_M, event_1);  // release c_l0[1] for next iter
     }
     set_flag(PIPE_FIX, PIPE_MTE1, event_1);
   }
   wait_flag(PIPE_M, PIPE_MTE1, event_0);
   wait_flag(PIPE_M, PIPE_MTE1, event_1);
   wait_flag(PIPE_FIX, PIPE_M, event_0);
-  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Write c_l0[1] to X_l1
 }
 
 /*
  * @brief: Runs the main kernel (inverts all matrices in the tensor)
+ *
+ * @tparam InputT The type of the input elements.
+ * @tparam OutputT The type of the output elements.
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
+ * cube iteration.
+ * @tparam IsBSND If IsBSND is false, then the last two dimensions represent a
+ * 2D triangular matrix in row-major format, while the other dimensions are
+ * batch dimensions. If IsBSND is true, then the dimensions represent in order:
+ * B batch size, S sequence length (which is chunked in tiles of size D), N
+ * number of heads (equivalent to a second batch dimension for this kernel), and
+ * D chunk size. The inverse is over the dimensions S (chunked) and D, row-major
+ * within each tile.
+ *
+ * @param M_inv pointer to the global memory to store the final inverse.
+ * @param M Pointer to the global tensor matrix in global memory.
+ * @param I_neg Pointer to global memory that contains the negative identity.
+ * @param total_tiles The total number of matrices to invert.
+ * @param num_bsnd_heads The number of heads, only for BSND format.
  */
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
           uint32_t NumTilesPerCubeIter, bool IsBSND>
@@ -415,8 +496,10 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          uint32_t total_tiles,
                                          uint32_t num_bsnd_heads = 0,
                                          __gm__ int32_t* cu_seqlens = nullptr) {
+  /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
-  constexpr uint32_t FractalSize = 16;
+  constexpr uint32_t FractalSize = 16;  // fractal size for half
+  constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
   constexpr uint32_t NumL0Buffers = 2;
 
   if (get_block_idx() * NumTilesPerCubeIter >= total_tiles) {
@@ -430,11 +513,10 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileIn =
       GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
-  using GlobalTileDynShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-  using GlobalTileDynStride = Stride<1, 1, 1, DYNAMIC, 1>;
-  using GlobalTileInDyn =
-      GlobalTensor<InputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
-
+  using GlobalTileDynamicShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GlobalTileDynamicStride = Stride<1, 1, 1, DYNAMIC, 1>;
+  using GlobalTileDynamicIn = GlobalTensor<InputT, GlobalTileDynamicShape,
+                                           GlobalTileDynamicStride, Layout::ND>;
   using GlobalTileStridesINeg =
       BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
   using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn,
@@ -447,20 +529,22 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
                                      GlobalTileStridesOut, Layout::ND>;
-  using GlobalTileOutDyn = GlobalTensor<OutputT, GlobalTileDynShape,
-                                        GlobalTileDynStride, Layout::ND>;
-
+  using GlobalTileDynamicOut =
+      GlobalTensor<OutputT, GlobalTileDynamicShape, GlobalTileDynamicStride,
+                   Layout::ND>;
   using TileL1AB =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
            MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
-  using TileL1ABDyn =
+  using TileL1ABDynamic =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
            DYNAMIC, DYNAMIC, SLayout::RowMajor, 512, PadValue::Zero>;
-  using TileL0CDyn = TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
+  // L0 Memory
   using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
   using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
   using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
+  using TileL0CDynamic =
+      TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
   GlobalTileINeg I_neg_global_in(I_neg);
 
@@ -501,9 +585,9 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
   const uint32_t max_iters_per_aic =
       CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
 
+  /* Main iteration - Compute all tiles */
   uint32_t bsnd_tile_offsets[NumTilesPerCubeIter] = {0};
   uint32_t bsnd_tile_valid_sizes[NumTilesPerCubeIter] = {0};
-
   uint32_t next_tile_id_that_waits_for_pipe_fix_pipe_m = 0;
   set_flag(PIPE_FIX, PIPE_M,
            static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
@@ -537,10 +621,10 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
         const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
         if (valid_size < MatrixSize) {
-          TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
+          TileL1ABDynamic Y_dyn_l1_tile(valid_size, valid_size);
           TASSIGN(Y_dyn_l1_tile,
                   0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
-          GlobalTileInDyn M_global_in_dyn(
+          GlobalTileDynamicIn M_global_in_dyn(
               M + bsnd_offset,
               {1, 1, 1, static_cast<int>(valid_size),
                static_cast<int>(valid_size)},
@@ -556,7 +640,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       } else {
         GlobalTileIn M_global_in(M + (global_index + tile_id) * TileLen);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
-        TLOAD(Y_l1_tile[tile_id], M_global_in);
+        TLOAD(Y_l1_tile[tile_id],
+              M_global_in);  // Copies NumTilesPerCubeIter tiles at once
       }
       set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
     }
@@ -565,7 +650,9 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
     for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
+      // Wait for previous cube iter to write result
       wait_flag(PIPE_FIX, PIPE_M, static_cast<event_t>(tile_id));
+      // Wait for loading new matrices from GM
       wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
 
       InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
@@ -573,29 +660,19 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
           X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
           Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id);
 
+      // Allow next cube_iter to proceed for this tile_id
       set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
 
+      /* Store result */
       if constexpr (IsBSND) {
         const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
         const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
         const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
         if (valid_size < MatrixSize) {
-          const event_t event_0 = static_cast<event_t>(tile_id);
-          const event_t event_1 =
-              static_cast<event_t>(tile_id + NumTilesPerCubeIter);
-          TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
+          TileL0CDynamic c_l0_tail_tile(valid_size, valid_size);
           TASSIGN(c_l0_tail_tile,
                   0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
-          if constexpr (final_c_buffer_index == 1) {
-            set_flag(PIPE_M, PIPE_FIX, event_1);
-            wait_flag(PIPE_M, PIPE_FIX, event_1);
-          } else {
-            set_flag(PIPE_M, PIPE_FIX, event_0);
-            wait_flag(PIPE_M, PIPE_FIX, event_0);
-          }
-          set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-          wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-          GlobalTileOutDyn M_inv_global_out_dyn(
+          GlobalTileDynamicOut M_inv_global_out_dyn(
               M_inv + bsnd_offset,
               {1, 1, 1, static_cast<int>(valid_size),
                static_cast<int>(valid_size)},
@@ -625,172 +702,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
 }
 
 /*
- * @brief: Varlen BSND kernel.
- *
- * The input/output tensors stay unpadded. For tail chunks with size
- * `actual_size < MatrixSize`, the kernel:
- * 1. derives the chunk row-start and runtime size from `cu_seqlens`
- * 2. loads only the valid `actual_size x actual_size` prefix via dynamic TLOAD
- * 3. zero-fills the remaining rows/cols in-place via TFILLPAD_INPLACE
- * 4. runs the original dense recursive inverse on the materialized full tile
- * 5. stores only the valid `actual_size x actual_size` prefix back to GM
+ * @brief: Computes the inverses of the blocks of tensor M
  */
-template <typename InputT, typename OutputT, uint32_t MatrixSize,
-          uint32_t NumTilesPerCubeIter>
-AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
-    __gm__ OutputT* M_inv, __gm__ InputT* M, __gm__ InputT* I_neg,
-    uint32_t total_tiles, uint32_t num_bsnd_heads, __gm__ int32_t* cu_seqlens) {
-  constexpr uint32_t TileLen = MatrixSize * MatrixSize;
-  constexpr uint32_t FractalSize = 16;
-  constexpr uint32_t NumL0Buffers = 2;
-
-  if (get_block_idx() * NumTilesPerCubeIter >= total_tiles) {
-    return;
-  }
-
-  using GlobalTileShapeIn =
-      TileShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
-  using GlobalTileStridesIn = Stride<1, 1, 1, -1, 1>;
-  using GlobalTileIn =
-      GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
-
-  using GlobalTileDynShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-  using GlobalTileDynStride = Stride<1, 1, 1, DYNAMIC, 1>;
-  using GlobalTileInDyn =
-      GlobalTensor<InputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
-  using GlobalTileOutDyn = GlobalTensor<OutputT, GlobalTileDynShape,
-                                        GlobalTileDynStride, Layout::ND>;
-
-  using GlobalTileStridesINeg =
-      BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
-  using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn,
-                                      GlobalTileStridesINeg, Layout::ND>;
-
-  using GlobalTileShapeOut =
-      TileShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>;
-  using GlobalTileStridesOut = Stride<1, 1, 1, -1, 1>;
-  using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
-                                     GlobalTileStridesOut, Layout::ND>;
-
-  using TileL1AB =
-      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
-           MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
-  using TileL1ABDyn =
-      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
-           DYNAMIC, DYNAMIC, SLayout::RowMajor, 512, PadValue::Zero>;
-
-  using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
-  using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
-  using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
-  using TileL0CDyn = TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
-
-  GlobalTileINeg I_neg_global_in(I_neg);
-
-  TileL1AB X_l1_tile;
-  TileL1AB I_l1_tile;
-  TileL1AB I_neg_l1_tile;
-  TileL1AB M_neg_l1_tile;
-  TileL1AB Zero_l1_tile;
-  TileL1AB Y_l1_tile[NumTilesPerCubeIter];
-
-  TileL0A a_l0_tile[NumL0Buffers];
-  TileL0B b_l0_tile[NumL0Buffers];
-  TileL0C c_l0_tile[NumL0Buffers];
-
-  TASSIGN(I_l1_tile, 0x0);
-  TASSIGN(I_neg_l1_tile, 0x0 + TileLen * sizeof(InputT));
-  TASSIGN(Zero_l1_tile, 0x0 + 2 * TileLen * sizeof(InputT));
-  TASSIGN(M_neg_l1_tile, 0x0 + 3 * TileLen * sizeof(InputT));
-  TASSIGN(X_l1_tile, 0x0 + 4 * TileLen * sizeof(InputT));
-  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
-    TASSIGN(Y_l1_tile[tile_id], 0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
-  }
-
-  for (uint32_t buffer_num = 0; buffer_num < NumL0Buffers; ++buffer_num) {
-    TASSIGN(a_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
-    TASSIGN(b_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
-    TASSIGN(c_l0_tile[buffer_num],
-            0x0 + buffer_num * TileLen * sizeof(OutputT));
-  }
-  TLOAD(I_neg_l1_tile, I_neg_global_in);
-  set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
-  wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
-
-  PrepareAuxiliaryMatrices<TileL1AB, TileL0A, TileL0B, TileL0C>(
-      I_neg_l1_tile, Zero_l1_tile, I_l1_tile, a_l0_tile[0], b_l0_tile[0],
-      c_l0_tile[0]);
-
-  const uint32_t max_iters_per_aic =
-      CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
-  constexpr uint32_t final_c_buffer_index = MatrixSize > FractalSize ? 1 : 0;
-
-  for (uint32_t cube_iter = 0; cube_iter < max_iters_per_aic; ++cube_iter) {
-    const uint32_t global_index =
-        (cube_iter * get_block_num() + get_block_idx()) * NumTilesPerCubeIter;
-    if (global_index >= total_tiles) {
-      break;
-    }
-
-    for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
-                               (global_index + tile_id < total_tiles);
-         ++tile_id) {
-      const uint32_t global_tile_id = global_index + tile_id;
-      const BSNDVarlenTileInfo tile_info = GetBSNDVarlenTileInfoFromCuSeqlens(
-          global_tile_id, num_bsnd_heads, MatrixSize, cu_seqlens);
-      const uint32_t valid_size = tile_info.valid_size;
-      const uint32_t bsnd_offset = tile_info.bsnd_offset;
-      const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
-
-      if (valid_size == MatrixSize) {
-        GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
-        TLOAD(Y_l1_tile[tile_id], M_global_in);
-        set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
-        wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
-      } else {
-        TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
-        TASSIGN(Y_dyn_l1_tile, 0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
-        GlobalTileInDyn M_global_in_dyn(M + bsnd_offset,
-                                        {1, 1, 1, valid_size, valid_size},
-                                        {1, 1, 1, row_stride, 1});
-        TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
-        set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
-        wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
-        TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
-      }
-
-      InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
-                       FractalSize, NumTilesPerCubeIter>(
-          X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
-          Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id);
-
-      if (valid_size == MatrixSize) {
-        GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {}, {row_stride});
-        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
-      } else {
-        const event_t event_0 = static_cast<event_t>(tile_id);
-        const event_t event_1 =
-            static_cast<event_t>(tile_id + NumTilesPerCubeIter);
-        TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
-        TASSIGN(c_l0_tail_tile,
-                0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
-        if constexpr (final_c_buffer_index == 1) {
-          set_flag(PIPE_M, PIPE_FIX, event_1);
-          wait_flag(PIPE_M, PIPE_FIX, event_1);
-        } else {
-          set_flag(PIPE_M, PIPE_FIX, event_0);
-          wait_flag(PIPE_M, PIPE_FIX, event_0);
-        }
-        set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-        wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-        GlobalTileOutDyn M_inv_global_out_dyn(M_inv + bsnd_offset,
-                                              {1, 1, 1, valid_size, valid_size},
-                                              {1, 1, 1, row_stride, 1});
-        TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
-      }
-    }
-  }
-}
-
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
           uint32_t NumTilesPerCubeIter, bool IsBSND>
 AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
@@ -798,7 +711,8 @@ AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
                                      uint32_t num_bsnd_heads = 0,
                                      __gm__ int32_t* cu_seqlens = nullptr) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
-    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // Cube compilation
+
   TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
                         IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
                                 cu_seqlens);
@@ -813,7 +727,7 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
                                    __gm__ InputT* minus_identity_in,
                                    uint32_t matrix_size, uint32_t num_matrices,
                                    uint32_t num_bsnd_heads,
-                                   __gm__ int32_t* cu_seqlens) {
+                                   __gm__ int32_t* cu_seqlens = nullptr) {
   static_assert(std::is_same_v<InputT, half>,
                 "tri_inv_rec_unroll supports only fp16.");
   switch (matrix_size) {
@@ -840,40 +754,62 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
   }
 }
 
+/*
+ * @brief: Wrapper for the kernel, "half" type (fp16).
+ *
+ * @param tensor_out pointer to the global memory to store the final inverse.
+ * @param tensor_in Pointer to the global tensor matrix in global memory.
+ * @param minus_identity_in Pointer to global memory that contains the negative
+ * identity.
+ * @param matrix_size The size if each individual matrix / tile. Can take
+ * values: {16, 32, 64, 128}.
+ * @param num_matrices The total number of matrices / tiles in the global
+ * tensor.
+ * @param num_bsnd_heads The number of heads, which is only greater than zero
+ * if the matrix is in BSND format, that is, the tiles need to be loaded with
+ * strided accesses. If each tile is stored consecutively (and row-wise) in
+ * memory, then num_bsnd_heads=0.
+ */
 extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
     __gm__ void* tensor_out, __gm__ void* tensor_in,
     __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
     uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
   if (num_bsnd_heads == 0) {
     if (num_matrices <= get_block_num()) {
-      run_tri_inv_rec_unroll<half, 1, false>(
+      run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
           num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
-      run_tri_inv_rec_unroll<half, 2, false>(
+      run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
           num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else {
-      run_tri_inv_rec_unroll<half, 4, false>(
+      run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
+                             false /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
           num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     }
   } else {
     if (num_matrices <= get_block_num()) {
-      run_tri_inv_rec_unroll<half, 1, true>(
+      run_tri_inv_rec_unroll<half, 1 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
           num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
-      run_tri_inv_rec_unroll<half, 2, true>(
+      run_tri_inv_rec_unroll<half, 2 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
           num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else {
-      run_tri_inv_rec_unroll<half, 4, true>(
+      run_tri_inv_rec_unroll<half, 4 /* NumTilesPerCubeIter */,
+                             true /* IsBSND */>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
           num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);

--- a/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
+++ b/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
@@ -398,7 +398,11 @@ template <typename InputT, typename OutputT, uint32_t MatrixSize,
 AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          __gm__ InputT* M, __gm__ InputT* I_neg,
                                          uint32_t total_tiles,
-                                         uint32_t num_bsnd_heads = 0) {
+                                         uint32_t num_bsnd_heads = 0,
+                                         __gm__ int32_t* chunk_indices =
+                                             nullptr,
+                                         __gm__ int32_t* chunk_valid_sizes =
+                                             nullptr) {
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;
   constexpr uint32_t NumL0Buffers = 2;
@@ -414,6 +418,10 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileIn =
       GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
+  using GlobalTileDynShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GlobalTileDynStride = Stride<1, 1, 1, DYNAMIC, 1>;
+  using GlobalTileInDyn =
+      GlobalTensor<InputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
 
   using GlobalTileStridesINeg =
       BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
@@ -427,10 +435,16 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
                                      GlobalTileStridesOut, Layout::ND>;
+  using GlobalTileOutDyn =
+      GlobalTensor<OutputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
 
   using TileL1AB =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
            MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
+  using TileL1ABDyn = Tile<TileType::Mat, InputT, MatrixSize, MatrixSize,
+                           BLayout::ColMajor, DYNAMIC, DYNAMIC,
+                           SLayout::RowMajor, 512, PadValue::Zero>;
+  using TileL0CDyn = TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
   using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
   using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
@@ -491,12 +505,38 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
       if constexpr (IsBSND) {
-        const uint32_t bsnd_offset = GetBSNDFixedTileOffset(
-            global_index + tile_id, num_bsnd_heads, MatrixSize);
-        GlobalTileIn M_global_in(M + bsnd_offset, {},
-                                 {static_cast<int>(MatrixSize * num_bsnd_heads)});
+        const uint32_t global_tile_id = global_index + tile_id;
+        const uint32_t bsnd_offset =
+            chunk_indices != nullptr
+                ? GetBSNDVarlenTileOffset(global_tile_id, num_bsnd_heads,
+                                          MatrixSize, chunk_indices)
+                : GetBSNDFixedTileOffset(global_tile_id, num_bsnd_heads,
+                                         MatrixSize);
+        const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
-        TLOAD(Y_l1_tile[tile_id], M_global_in);
+        if (chunk_valid_sizes != nullptr) {
+          const uint32_t chunk_idx = global_tile_id / num_bsnd_heads;
+          const uint32_t valid_size =
+              static_cast<uint32_t>(chunk_valid_sizes[chunk_idx]);
+          if (valid_size < MatrixSize) {
+            TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
+            TASSIGN(Y_dyn_l1_tile,
+                    0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+            GlobalTileInDyn M_global_in_dyn(
+                M + bsnd_offset, {1, 1, 1, valid_size, valid_size},
+                {1, 1, 1, row_stride, 1});
+            TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
+            set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+            wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+            TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
+          } else {
+            GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
+            TLOAD(Y_l1_tile[tile_id], M_global_in);
+          }
+        } else {
+          GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
+          TLOAD(Y_l1_tile[tile_id], M_global_in);
+        }
       } else {
         GlobalTileIn M_global_in(M + (global_index + tile_id) * TileLen);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
@@ -520,12 +560,48 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
 
       if constexpr (IsBSND) {
-        const uint32_t bsnd_offset = GetBSNDFixedTileOffset(
-            global_index + tile_id, num_bsnd_heads, MatrixSize);
-        GlobalTileOut M_inv_global_out(
-            M_inv + bsnd_offset, {},
-            {static_cast<int>(MatrixSize * num_bsnd_heads)});
-        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+        const uint32_t global_tile_id = global_index + tile_id;
+        const uint32_t bsnd_offset =
+            chunk_indices != nullptr
+                ? GetBSNDVarlenTileOffset(global_tile_id, num_bsnd_heads,
+                                          MatrixSize, chunk_indices)
+                : GetBSNDFixedTileOffset(global_tile_id, num_bsnd_heads,
+                                         MatrixSize);
+        const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
+        if (chunk_valid_sizes != nullptr) {
+          const uint32_t chunk_idx = global_tile_id / num_bsnd_heads;
+          const uint32_t valid_size =
+              static_cast<uint32_t>(chunk_valid_sizes[chunk_idx]);
+          if (valid_size < MatrixSize) {
+            const event_t event_0 = static_cast<event_t>(tile_id);
+            const event_t event_1 =
+                static_cast<event_t>(tile_id + NumTilesPerCubeIter);
+            TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
+            TASSIGN(c_l0_tail_tile,
+                    0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+            if constexpr (final_c_buffer_index == 1) {
+              set_flag(PIPE_M, PIPE_FIX, event_1);
+              wait_flag(PIPE_M, PIPE_FIX, event_1);
+            } else {
+              set_flag(PIPE_M, PIPE_FIX, event_0);
+              wait_flag(PIPE_M, PIPE_FIX, event_0);
+            }
+            set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
+            wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
+            GlobalTileOutDyn M_inv_global_out_dyn(
+                M_inv + bsnd_offset, {1, 1, 1, valid_size, valid_size},
+                {1, 1, 1, row_stride, 1});
+            TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
+          } else {
+            GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {},
+                                           {row_stride});
+            TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+          }
+        } else {
+          GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {},
+                                         {row_stride});
+          TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+        }
       } else {
         GlobalTileOut M_inv_global_out(M_inv +
                                        (global_index + tile_id) * TileLen);
@@ -690,9 +766,20 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
         GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {}, {row_stride});
         TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
       } else {
+        const event_t event_0 = static_cast<event_t>(tile_id);
+        const event_t event_1 = static_cast<event_t>(tile_id + NumTilesPerCubeIter);
         TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
         TASSIGN(c_l0_tail_tile,
                 0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+        if constexpr (final_c_buffer_index == 1) {
+          set_flag(PIPE_M, PIPE_FIX, event_1);
+          wait_flag(PIPE_M, PIPE_FIX, event_1);
+        } else {
+          set_flag(PIPE_M, PIPE_FIX, event_0);
+          wait_flag(PIPE_M, PIPE_FIX, event_0);
+        }
+        set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
+        wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
         GlobalTileOutDyn M_inv_global_out_dyn(
             M_inv + bsnd_offset, {1, 1, 1, valid_size, valid_size},
             {1, 1, 1, row_stride, 1});
@@ -712,21 +799,9 @@ AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
                                          nullptr) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
-  if constexpr (IsBSND) {
-    if (chunk_indices != nullptr && chunk_valid_sizes != nullptr) {
-      TriInvRecUnrollKernelBSNDVarlen<InputT, OutputT, MatrixSize,
-                                      NumTilesPerCubeIter>(
-          M_inv, M, I_neg, total_tiles, num_bsnd_heads, chunk_indices,
-          chunk_valid_sizes);
-    } else {
-      TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
-                            IsBSND>(M_inv, M, I_neg, total_tiles,
-                                    num_bsnd_heads);
-    }
-  } else {
-    TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
-                          IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads);
-  }
+  TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
+                        IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
+                                chunk_indices, chunk_valid_sizes);
 #else
 // Nothing to do on AIV
 #endif

--- a/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
+++ b/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
@@ -1,0 +1,637 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+
+#ifndef MEMORY_BASE
+#define MEMORY_BASE
+#endif
+#include <pto/pto-inst.hpp>
+
+#include "kernel_utils.h"
+
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+using namespace pto;
+using namespace kernel_utils;
+
+#define BSND_OFFSET(tile_id, N, S, D) \
+  (((tile_id) / (N)) * (S) * (N) * (D) + ((tile_id) % (N)) * (D))
+
+/*
+ * For varlen BSND, chunk_indices stores the absolute row offset (within the
+ * padded BSND tensor) of each D x D chunk. Each tile_id still enumerates
+ * chunk-major, then head-major.
+ */
+AICORE inline uint32_t GetBSNDTileOffset(uint32_t tile_id,
+                                         uint32_t num_bsnd_heads,
+                                         uint32_t matrix_size,
+                                         __gm__ int32_t* chunk_indices) {
+  const uint32_t head_idx = tile_id % num_bsnd_heads;
+  if (chunk_indices == nullptr) {
+    return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
+  }
+  const uint32_t chunk_idx = tile_id / num_bsnd_heads;
+  const uint32_t chunk_row_start =
+      static_cast<uint32_t>(chunk_indices[chunk_idx]);
+  return chunk_row_start * num_bsnd_heads * matrix_size +
+         head_idx * matrix_size;
+}
+
+/*
+ * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
+ * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
+ * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
+ * FractalSize from the src matrix to the dst matrix.
+ *
+ * @tparam InputT Input data type (fp16).
+ * @tparam FractalSize Size of each fractal matrix (diagonal block).
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam SrcL1TileT The actual tile type of the src matrix.
+ * @tparam DstL0TileT The actual tile type of the dst matrix.
+ *
+ * @param src Tile in L1 memory.
+ * @param dst Tile in L0A or L0B memory.
+ */
+template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
+          typename SrcL1TileT, typename DstL0TileT>
+AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
+  constexpr uint32_t NumFractals = MatrixSize / FractalSize;
+  constexpr bool is_left =
+      std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
+  constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
+  constexpr SLayout InnerLayout =
+      is_left ? SLayout::RowMajor : SLayout::ColMajor;
+
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
+       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+      fractals[NumFractals];
+  const std::uintptr_t starting_address =
+      reinterpret_cast<std::uintptr_t>(dst.data());
+  for (uint32_t i = 0; i < NumFractals; ++i) {
+    TASSIGN(fractals[i], starting_address + i * FractalSize *
+                                                (MatrixSize + FractalSize) *
+                                                sizeof(InputT));
+    TEXTRACT(fractals[i], src, i * FractalSize, i * FractalSize);
+  }
+}
+
+/*
+ * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each,
+ * and an integer block_size. The src matrix lies in L1, while the dst matrix
+ * either in L0A or L0B. This method copies some of the diagonal blocks from the
+ * input to the output as follows:
+ * - If dst is in L0A (left): copy even diagonal blocks 0, 2, 4, ...
+ * - If dst is in L0B (right): copy odd blocks 1, 3, 5, ...
+ * Important note: the dst matrix should be initialized to all-zeros before
+ * calling this method
+ *
+ * @tparam InputT Input data type (fp16).
+ * @tparam FractalSize Size of each fractal matrix (diagonal block).
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam SrcL1TileT The actual tile type of the src matrix.
+ * @tparam DstL0TileT The actual tile type of the dst matrix.
+ *
+ * @param src Tile in L1 memory.
+ * @param dst Tile in L0A or L0B memory.
+ * @param block_size Size of diagonal blocks. Needs: block_size >= FractalSize.
+ */
+template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
+          typename SrcL1TileT, typename DstL0TileT>
+AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
+                                             uint32_t block_size) {
+  constexpr bool is_left =
+      std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
+  constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
+  constexpr SLayout InnerLayout =
+      is_left ? SLayout::RowMajor : SLayout::ColMajor;
+
+  const uint32_t starting_block_index = is_left ? 0 : 1;
+
+  const uint32_t num_blocks = MatrixSize / block_size;
+  const uint32_t num_fractals_per_block = block_size / FractalSize;
+
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
+       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+      fractals[MatrixSize / FractalSize];
+
+  const std::uintptr_t starting_address =
+      reinterpret_cast<std::uintptr_t>(dst.data());
+  for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
+    for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
+      for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
+        const uint32_t offset =
+            b * (MatrixSize + FractalSize) * block_size +
+            i * MatrixSize * FractalSize +
+            j * FractalSize * FractalSize;
+        TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
+        TEXTRACT(fractals[b], src, b * block_size + i * FractalSize,
+                 b * block_size + j * FractalSize);
+      }
+    }
+  }
+}
+
+/*
+ * @brief: Prepares Identity and Zeros matrix.
+ *
+ * @tparam TileL1AB The type of the input tiles in L1.
+ * @tparam TileL0A The type of the input tiles in L0A.
+ * @tparam TileL0B The type of the input tiles in L0B.
+ * @tparam TileL0C The type of the input tiles in L0C.
+ *
+ * @param I_neg_l1_tile Tile containing the -I (negative identity) matrix.
+ * @param Zero_l1_tile Tile to store the all-zero matrix.
+ * @param I_l1_tile Tile to store the identity matrix.
+ * @param a_l0_tile Tile in L0A for matmuls.
+ * @param b_l0_tile Tile in L0B for matmuls.
+ * @param c_l0_tile Tile in L0C for matmuls.
+ */
+template <typename TileL1AB, typename TileL0A, typename TileL0B,
+          typename TileL0C>
+AICORE inline void PrepareAuxiliaryMatrices(
+    TileL1AB I_neg_l1_tile, TileL1AB Zero_l1_tile, TileL1AB I_l1_tile,
+    TileL0A a_l0_tile, TileL0B b_l0_tile, TileL0C c_l0_tile) {
+  TMOV(a_l0_tile, I_neg_l1_tile);
+  TMOV(b_l0_tile, I_neg_l1_tile);
+  set_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+
+  TMATMUL(c_l0_tile, a_l0_tile, b_l0_tile);
+  set_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+  wait_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+
+  TMOV(I_l1_tile, c_l0_tile);
+  set_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+
+  TMOV(b_l0_tile, I_l1_tile);
+  set_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE1, PIPE_M, static_cast<event_t>(0));
+
+  TMATMUL_ACC(c_l0_tile, c_l0_tile, a_l0_tile, b_l0_tile);
+  set_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+  wait_flag(PIPE_M, PIPE_FIX, static_cast<event_t>(0));
+
+  TMOV(Zero_l1_tile, c_l0_tile);
+  set_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
+}
+
+/*
+ * @brief: Inverts a single matrix / tile of the global tensor.
+ */
+template <typename InputT, typename TileL1AB, typename TileL0A,
+          typename TileL0B, typename TileL0C, uint32_t MatrixSize,
+          uint32_t FractalSize, uint32_t NumTilesPerCubeIter>
+AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
+                                    TileL1AB I_neg_l1_tile,
+                                    TileL1AB M_neg_l1_tile,
+                                    TileL1AB Zero_l1_tile, TileL1AB Y_l1_tile,
+                                    TileL0A* a_l0_tile, TileL0B* b_l0_tile,
+                                    TileL0C* c_l0_tile,
+                                    const uint32_t tile_id) {
+  const event_t event_0 = static_cast<event_t>(tile_id);
+  const event_t event_1 = static_cast<event_t>(tile_id + NumTilesPerCubeIter);
+
+  TMOV(b_l0_tile[0], Y_l1_tile);
+  TMOV(a_l0_tile[0], I_neg_l1_tile);
+  set_flag(PIPE_MTE1, PIPE_M, event_0);
+  TMOV(a_l0_tile[1], Zero_l1_tile);
+  TMOV(b_l0_tile[1], Zero_l1_tile);
+  set_flag(PIPE_MTE1, PIPE_M, event_1);
+  wait_flag(PIPE_MTE1, PIPE_M, event_1);
+  set_flag(PIPE_M, PIPE_MTE1, event_1);
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);
+  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(Y_l1_tile,
+                                                              a_l0_tile[1]);
+  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(Y_l1_tile,
+                                                              b_l0_tile[1]);
+  set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+  wait_flag(PIPE_MTE1, PIPE_M, event_0);
+  TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+  set_flag(PIPE_M, PIPE_FIX, event_0);
+  set_flag(PIPE_M, PIPE_MTE1, event_0);
+
+  wait_flag(PIPE_M, PIPE_FIX, event_0);
+  TMOV(M_neg_l1_tile, c_l0_tile[0]);
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+
+  wait_flag(PIPE_MTE1, PIPE_M, event_1);
+  set_flag(PIPE_MTE1, PIPE_M, event_1);
+  TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[1]);
+  set_flag(PIPE_M, PIPE_FIX, event_1);
+  wait_flag(PIPE_M, PIPE_FIX, event_1);
+  TMOV(Y_l1_tile, c_l0_tile[1]);
+  set_flag(PIPE_FIX, PIPE_M, event_1);
+  wait_flag(PIPE_FIX, PIPE_M, event_1);
+
+  wait_flag(PIPE_M, PIPE_MTE1, event_0);
+  TMOV(b_l0_tile[0], I_neg_l1_tile);
+  TMOV(a_l0_tile[0], I_neg_l1_tile);
+  set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+  wait_flag(PIPE_MTE1, PIPE_M, event_0);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+  wait_flag(PIPE_MTE1, PIPE_M, event_1);
+  TMATMUL(c_l0_tile[0], a_l0_tile[1], b_l0_tile[0]);
+  set_flag(PIPE_M, PIPE_FIX, event_0);
+  wait_flag(PIPE_M, PIPE_FIX, event_0);
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+
+  TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+  set_flag(PIPE_M, PIPE_FIX, event_1);
+  wait_flag(PIPE_M, PIPE_FIX, event_1);
+  TMOV(X_l1_tile, c_l0_tile[0]);
+
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+  set_flag(PIPE_M, PIPE_MTE1, event_0);
+  set_flag(PIPE_FIX, PIPE_MTE1, event_0);
+  set_flag(PIPE_FIX, PIPE_M, event_1);
+  set_flag(PIPE_M, PIPE_MTE1, event_1);
+  set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  for (uint32_t block_size = 1; block_size < FractalSize / 2; block_size *= 2) {
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);
+    TMOV(b_l0_tile[0], I_l1_tile);
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
+    TMOV(a_l0_tile[0], X_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+    TMOV(b_l0_tile[1], Y_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+    wait_flag(PIPE_FIX, PIPE_M, event_0);
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);
+    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+    set_flag(PIPE_FIX, PIPE_M, event_0);
+    wait_flag(PIPE_FIX, PIPE_M, event_0);
+
+    if (block_size < FractalSize / 4) {
+      wait_flag(PIPE_M, PIPE_MTE1, event_1);
+      TMOV(a_l0_tile[1], Y_l1_tile);
+      wait_flag(PIPE_MTE1, PIPE_M, event_1);
+      set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+      wait_flag(PIPE_MTE1, PIPE_M, event_1);
+      wait_flag(PIPE_FIX, PIPE_M, event_1);
+      TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[1]);
+      set_flag(PIPE_M, PIPE_MTE1, event_1);
+      set_flag(PIPE_M, PIPE_FIX, event_1);
+      set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+      wait_flag(PIPE_M, PIPE_FIX, event_1);
+      TMOV(Y_l1_tile, c_l0_tile[1]);
+      set_flag(PIPE_FIX, PIPE_M, event_1);
+    }
+    set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_1);
+    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[0], b_l0_tile[1]);
+    set_flag(PIPE_M, PIPE_MTE1, event_0);
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+    TMOV(X_l1_tile, c_l0_tile[0]);
+    set_flag(PIPE_FIX, PIPE_M, event_0);
+    set_flag(PIPE_FIX, PIPE_MTE1, event_0);
+  }
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);
+  wait_flag(PIPE_FIX, PIPE_M, event_1);
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
+  wait_flag(PIPE_M, PIPE_MTE1, event_0);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+
+  TMOV(b_l0_tile[1], M_neg_l1_tile);
+  TMOV(a_l0_tile[0], I_l1_tile);
+
+  if constexpr (MatrixSize > FractalSize) {
+    set_flag(PIPE_FIX, PIPE_M, event_1);
+  }
+  set_flag(PIPE_M, PIPE_MTE1, event_1);
+  set_flag(PIPE_M, PIPE_MTE1, event_0);
+  set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  set_flag(PIPE_FIX, PIPE_M, event_0);
+  for (uint32_t block_size = FractalSize; block_size < MatrixSize;
+       block_size *= 2) {
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);
+    TMOV(a_l0_tile[1], Zero_l1_tile);
+
+    wait_flag(PIPE_M, PIPE_MTE1, event_1);
+    TMOV(b_l0_tile[0], I_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(X_l1_tile,
+                                                               a_l0_tile[1],
+                                                               block_size);
+    set_flag(PIPE_MTE1, PIPE_M, event_1);
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);
+    wait_flag(PIPE_FIX, PIPE_M, event_0);
+    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_1);
+    wait_flag(PIPE_FIX, PIPE_M, event_1);
+    TMATMUL(c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);
+    set_flag(PIPE_M, PIPE_MTE1, event_1);
+
+    TMATMUL_ACC(c_l0_tile[0], c_l0_tile[0], a_l0_tile[1], b_l0_tile[1]);
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+    set_flag(PIPE_M, PIPE_MTE1, event_0);
+
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+    TMOV(Y_l1_tile, c_l0_tile[0]);
+    set_flag(PIPE_FIX, PIPE_MTE1, event_0);
+    set_flag(PIPE_FIX, PIPE_M, event_0);
+
+    wait_flag(PIPE_M, PIPE_MTE1, event_1);
+    TMOV(b_l0_tile[0], Zero_l1_tile);
+    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(X_l1_tile,
+                                                               b_l0_tile[0],
+                                                               block_size);
+
+    wait_flag(PIPE_M, PIPE_MTE1, event_0);
+    wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
+    TMOV(a_l0_tile[1], Y_l1_tile);
+    set_flag(PIPE_MTE1, PIPE_M, event_0);
+
+    wait_flag(PIPE_MTE1, PIPE_M, event_0);
+    TMATMUL_ACC(c_l0_tile[1], c_l0_tile[1], a_l0_tile[1], b_l0_tile[0]);
+    set_flag(PIPE_M, PIPE_MTE1, event_0);
+    set_flag(PIPE_M, PIPE_MTE1, event_1);
+    set_flag(PIPE_M, PIPE_FIX, event_0);
+    wait_flag(PIPE_M, PIPE_FIX, event_0);
+
+    if (block_size < MatrixSize / 2) {
+      TMOV(X_l1_tile, c_l0_tile[1]);
+      set_flag(PIPE_FIX, PIPE_M, event_1);
+    }
+    set_flag(PIPE_FIX, PIPE_MTE1, event_1);
+  }
+  wait_flag(PIPE_M, PIPE_MTE1, event_0);
+  wait_flag(PIPE_M, PIPE_MTE1, event_1);
+  wait_flag(PIPE_FIX, PIPE_M, event_0);
+  wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
+}
+
+/*
+ * @brief: Runs the main kernel (inverts all matrices in the tensor)
+ *
+ * When chunk_indices is non-null in BSND mode, it maps each chunk index
+ * (tile_id / num_bsnd_heads) to the absolute row offset in the padded BSND
+ * tensor. This lets the kernel support per-sequence padding without changing
+ * the per-tile inverse logic.
+ */
+template <typename InputT, typename OutputT, uint32_t MatrixSize,
+          uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
+                                         __gm__ InputT* M, __gm__ InputT* I_neg,
+                                         uint32_t total_tiles,
+                                         uint32_t num_bsnd_heads = 0,
+                                         __gm__ int32_t* chunk_indices =
+                                             nullptr) {
+  constexpr uint32_t TileLen = MatrixSize * MatrixSize;
+  constexpr uint32_t FractalSize = 16;
+  constexpr uint32_t NumL0Buffers = 2;
+
+  if (get_block_idx() * NumTilesPerCubeIter >= total_tiles) {
+    return;
+  }
+
+  using GlobalTileShapeIn =
+      TileShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileStridesIn = typename std::conditional<
+      !IsBSND, BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>,
+      Stride<1, 1, 1, -1, 1>>::type;
+  using GlobalTileIn =
+      GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
+
+  using GlobalTileStridesINeg =
+      BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn,
+                                      GlobalTileStridesINeg, Layout::ND>;
+
+  using GlobalTileShapeOut =
+      TileShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileStridesOut = typename std::conditional<
+      !IsBSND, BaseShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>,
+      Stride<1, 1, 1, -1, 1>>::type;
+  using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
+                                     GlobalTileStridesOut, Layout::ND>;
+
+  using TileL1AB =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
+
+  using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
+  using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
+  using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
+
+  GlobalTileINeg I_neg_global_in(I_neg);
+
+  TileL1AB X_l1_tile;
+  TileL1AB I_l1_tile;
+  TileL1AB I_neg_l1_tile;
+  TileL1AB M_neg_l1_tile;
+  TileL1AB Zero_l1_tile;
+  TileL1AB Y_l1_tile[NumTilesPerCubeIter];
+
+  TileL0A a_l0_tile[NumL0Buffers];
+  TileL0B b_l0_tile[NumL0Buffers];
+  TileL0C c_l0_tile[NumL0Buffers];
+
+  TASSIGN(I_l1_tile, 0x0);
+  TASSIGN(I_neg_l1_tile, 0x0 + TileLen * sizeof(InputT));
+  TASSIGN(Zero_l1_tile, 0x0 + 2 * TileLen * sizeof(InputT));
+  TASSIGN(M_neg_l1_tile, 0x0 + 3 * TileLen * sizeof(InputT));
+  TASSIGN(X_l1_tile, 0x0 + 4 * TileLen * sizeof(InputT));
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    TASSIGN(Y_l1_tile[tile_id], 0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+  }
+
+  for (uint32_t buffer_num = 0; buffer_num < NumL0Buffers; ++buffer_num) {
+    TASSIGN(a_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
+    TASSIGN(b_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
+    TASSIGN(c_l0_tile[buffer_num],
+            0x0 + buffer_num * TileLen * sizeof(OutputT));
+  }
+  TLOAD(I_neg_l1_tile, I_neg_global_in);
+  set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
+
+  PrepareAuxiliaryMatrices<TileL1AB, TileL0A, TileL0B, TileL0C>(
+      I_neg_l1_tile, Zero_l1_tile, I_l1_tile, a_l0_tile[0], b_l0_tile[0],
+      c_l0_tile[0]);
+
+  const uint32_t max_iters_per_aic =
+      CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
+
+  uint32_t next_tile_id_that_waits_for_pipe_fix_pipe_m = 0;
+  set_flag(PIPE_FIX, PIPE_M,
+           static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+  }
+  for (uint32_t cube_iter = 0; cube_iter < max_iters_per_aic; ++cube_iter) {
+    const uint32_t global_index =
+        (cube_iter * get_block_num() + get_block_idx()) * NumTilesPerCubeIter;
+    if (global_index >= total_tiles) {
+      break;
+    }
+    for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
+                               (global_index + tile_id < total_tiles);
+         ++tile_id) {
+      if constexpr (IsBSND) {
+        const uint32_t bsnd_offset = GetBSNDTileOffset(
+            global_index + tile_id, num_bsnd_heads, MatrixSize, chunk_indices);
+        GlobalTileIn M_global_in(M + bsnd_offset, {},
+                                 {static_cast<int>(MatrixSize * num_bsnd_heads)});
+        wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+        TLOAD(Y_l1_tile[tile_id], M_global_in);
+      } else {
+        GlobalTileIn M_global_in(M + (global_index + tile_id) * TileLen);
+        wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+        TLOAD(Y_l1_tile[tile_id], M_global_in);
+      }
+      set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+    }
+
+    constexpr uint32_t final_c_buffer_index = MatrixSize > FractalSize ? 1 : 0;
+    for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
+                               (global_index + tile_id < total_tiles);
+         ++tile_id) {
+      wait_flag(PIPE_FIX, PIPE_M, static_cast<event_t>(tile_id));
+      wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+
+      InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
+                       FractalSize, NumTilesPerCubeIter>(
+          X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
+          Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id);
+
+      set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+
+      if constexpr (IsBSND) {
+        const uint32_t bsnd_offset = GetBSNDTileOffset(
+            global_index + tile_id, num_bsnd_heads, MatrixSize, chunk_indices);
+        GlobalTileOut M_inv_global_out(
+            M_inv + bsnd_offset, {},
+            {static_cast<int>(MatrixSize * num_bsnd_heads)});
+        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+      } else {
+        GlobalTileOut M_inv_global_out(M_inv +
+                                       (global_index + tile_id) * TileLen);
+        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+      }
+      next_tile_id_that_waits_for_pipe_fix_pipe_m =
+          (tile_id + 1) % NumTilesPerCubeIter;
+      set_flag(
+          PIPE_FIX, PIPE_M,
+          static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
+    }
+  }
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
+  }
+  wait_flag(PIPE_FIX, PIPE_M,
+            static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
+}
+
+template <typename InputT, typename OutputT, uint32_t MatrixSize,
+          uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
+                                     __gm__ InputT* I_neg, uint32_t total_tiles,
+                                     uint32_t num_bsnd_heads = 0,
+                                     __gm__ int32_t* chunk_indices = nullptr) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+
+  TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
+                        IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
+                                chunk_indices);
+#else
+// Nothing to do on AIV
+#endif
+}
+
+template <typename InputT, uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
+                                   __gm__ InputT* tensor_in,
+                                   __gm__ InputT* minus_identity_in,
+                                   uint32_t matrix_size, uint32_t num_matrices,
+                                   uint32_t num_bsnd_heads,
+                                   __gm__ int32_t* chunk_indices) {
+  static_assert(std::is_same_v<InputT, half>,
+                "tri_inv_rec_unroll supports only fp16.");
+  switch (matrix_size) {
+    case 16:
+      runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, chunk_indices);
+      break;
+    case 32:
+      runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, chunk_indices);
+      break;
+    case 64:
+      runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, chunk_indices);
+      break;
+    case 128:
+      runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, chunk_indices);
+      break;
+  }
+}
+
+extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
+    __gm__ void* tensor_out, __gm__ void* tensor_in,
+    __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, __gm__ void* chunk_indices) {
+  if (num_bsnd_heads == 0) {
+    if (num_matrices <= get_block_num()) {
+      run_tri_inv_rec_unroll<half, 1, false>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+    } else if (num_matrices <= 2 * get_block_num()) {
+      run_tri_inv_rec_unroll<half, 2, false>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+    } else {
+      run_tri_inv_rec_unroll<half, 4, false>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+    }
+  } else {
+    if (num_matrices <= get_block_num()) {
+      run_tri_inv_rec_unroll<half, 1, true>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+    } else if (num_matrices <= 2 * get_block_num()) {
+      run_tri_inv_rec_unroll<half, 2, true>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+    } else {
+      run_tri_inv_rec_unroll<half, 4, true>(
+          (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
+          (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+    }
+  }
+}

--- a/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
+++ b/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
@@ -22,18 +22,25 @@ using namespace kernel_utils;
   (((tile_id) / (N)) * (S) * (N) * (D) + ((tile_id) % (N)) * (D))
 
 /*
- * For varlen BSND, chunk_indices stores the absolute row offset (within the
- * padded BSND tensor) of each D x D chunk. Each tile_id still enumerates
- * chunk-major, then head-major.
+ * For aligned BSND, tile_id enumerates chunk-major then head-major and maps to
+ * a fixed-stride address inside the dense BSND tensor.
  */
-AICORE inline uint32_t GetBSNDTileOffset(uint32_t tile_id,
-                                         uint32_t num_bsnd_heads,
-                                         uint32_t matrix_size,
-                                         __gm__ int32_t* chunk_indices) {
+AICORE inline uint32_t GetBSNDFixedTileOffset(uint32_t tile_id,
+                                              uint32_t num_bsnd_heads,
+                                              uint32_t matrix_size) {
+  return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
+}
+
+/*
+ * For varlen BSND, chunk_indices stores the absolute row offset of each chunk
+ * inside the unpadded BSND tensor. Each tile_id still enumerates chunk-major,
+ * then head-major.
+ */
+AICORE inline uint32_t GetBSNDVarlenTileOffset(uint32_t tile_id,
+                                               uint32_t num_bsnd_heads,
+                                               uint32_t matrix_size,
+                                               __gm__ int32_t* chunk_indices) {
   const uint32_t head_idx = tile_id % num_bsnd_heads;
-  if (chunk_indices == nullptr) {
-    return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
-  }
   const uint32_t chunk_idx = tile_id / num_bsnd_heads;
   const uint32_t chunk_row_start =
       static_cast<uint32_t>(chunk_indices[chunk_idx]);
@@ -385,20 +392,13 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
 
 /*
  * @brief: Runs the main kernel (inverts all matrices in the tensor)
- *
- * When chunk_indices is non-null in BSND mode, it maps each chunk index
- * (tile_id / num_bsnd_heads) to the absolute row offset in the padded BSND
- * tensor. This lets the kernel support per-sequence padding without changing
- * the per-tile inverse logic.
  */
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
           uint32_t NumTilesPerCubeIter, bool IsBSND>
 AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          __gm__ InputT* M, __gm__ InputT* I_neg,
                                          uint32_t total_tiles,
-                                         uint32_t num_bsnd_heads = 0,
-                                         __gm__ int32_t* chunk_indices =
-                                             nullptr) {
+                                         uint32_t num_bsnd_heads = 0) {
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;
   constexpr uint32_t NumL0Buffers = 2;
@@ -491,8 +491,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
       if constexpr (IsBSND) {
-        const uint32_t bsnd_offset = GetBSNDTileOffset(
-            global_index + tile_id, num_bsnd_heads, MatrixSize, chunk_indices);
+        const uint32_t bsnd_offset = GetBSNDFixedTileOffset(
+            global_index + tile_id, num_bsnd_heads, MatrixSize);
         GlobalTileIn M_global_in(M + bsnd_offset, {},
                                  {static_cast<int>(MatrixSize * num_bsnd_heads)});
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
@@ -520,8 +520,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
 
       if constexpr (IsBSND) {
-        const uint32_t bsnd_offset = GetBSNDTileOffset(
-            global_index + tile_id, num_bsnd_heads, MatrixSize, chunk_indices);
+        const uint32_t bsnd_offset = GetBSNDFixedTileOffset(
+            global_index + tile_id, num_bsnd_heads, MatrixSize);
         GlobalTileOut M_inv_global_out(
             M_inv + bsnd_offset, {},
             {static_cast<int>(MatrixSize * num_bsnd_heads)});
@@ -545,18 +545,188 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
             static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
 }
 
+/*
+ * @brief: Varlen BSND kernel.
+ *
+ * The input/output tensors stay unpadded. For tail chunks with size
+ * `actual_size < MatrixSize`, the kernel:
+ * 1. loads only the valid `actual_size x actual_size` prefix via dynamic TLOAD
+ * 2. zero-fills the remaining rows/cols in-place via TFILLPAD_INPLACE
+ * 3. runs the original dense recursive inverse on the materialized full tile
+ * 4. stores only the valid `actual_size x actual_size` prefix back to GM
+ */
+template <typename InputT, typename OutputT, uint32_t MatrixSize,
+          uint32_t NumTilesPerCubeIter>
+AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
+    __gm__ OutputT* M_inv, __gm__ InputT* M, __gm__ InputT* I_neg,
+    uint32_t total_tiles, uint32_t num_bsnd_heads, __gm__ int32_t* chunk_indices,
+    __gm__ int32_t* chunk_valid_sizes) {
+  constexpr uint32_t TileLen = MatrixSize * MatrixSize;
+  constexpr uint32_t FractalSize = 16;
+  constexpr uint32_t NumL0Buffers = 2;
+
+  if (get_block_idx() * NumTilesPerCubeIter >= total_tiles) {
+    return;
+  }
+
+  using GlobalTileShapeIn =
+      TileShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileStridesIn = Stride<1, 1, 1, -1, 1>;
+  using GlobalTileIn =
+      GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
+
+  using GlobalTileDynShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GlobalTileDynStride = Stride<1, 1, 1, DYNAMIC, 1>;
+  using GlobalTileInDyn =
+      GlobalTensor<InputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
+  using GlobalTileOutDyn =
+      GlobalTensor<OutputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
+
+  using GlobalTileStridesINeg =
+      BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn,
+                                      GlobalTileStridesINeg, Layout::ND>;
+
+  using GlobalTileShapeOut =
+      TileShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>;
+  using GlobalTileStridesOut = Stride<1, 1, 1, -1, 1>;
+  using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
+                                     GlobalTileStridesOut, Layout::ND>;
+
+  using TileL1AB =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
+  using TileL1ABDyn = Tile<TileType::Mat, InputT, MatrixSize, MatrixSize,
+                           BLayout::ColMajor, DYNAMIC, DYNAMIC,
+                           SLayout::RowMajor, 512, PadValue::Zero>;
+
+  using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
+  using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
+  using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
+  using TileL0CDyn = TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
+
+  GlobalTileINeg I_neg_global_in(I_neg);
+
+  TileL1AB X_l1_tile;
+  TileL1AB I_l1_tile;
+  TileL1AB I_neg_l1_tile;
+  TileL1AB M_neg_l1_tile;
+  TileL1AB Zero_l1_tile;
+  TileL1AB Y_l1_tile[NumTilesPerCubeIter];
+
+  TileL0A a_l0_tile[NumL0Buffers];
+  TileL0B b_l0_tile[NumL0Buffers];
+  TileL0C c_l0_tile[NumL0Buffers];
+
+  TASSIGN(I_l1_tile, 0x0);
+  TASSIGN(I_neg_l1_tile, 0x0 + TileLen * sizeof(InputT));
+  TASSIGN(Zero_l1_tile, 0x0 + 2 * TileLen * sizeof(InputT));
+  TASSIGN(M_neg_l1_tile, 0x0 + 3 * TileLen * sizeof(InputT));
+  TASSIGN(X_l1_tile, 0x0 + 4 * TileLen * sizeof(InputT));
+  for (uint32_t tile_id = 0; tile_id < NumTilesPerCubeIter; ++tile_id) {
+    TASSIGN(Y_l1_tile[tile_id], 0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+  }
+
+  for (uint32_t buffer_num = 0; buffer_num < NumL0Buffers; ++buffer_num) {
+    TASSIGN(a_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
+    TASSIGN(b_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
+    TASSIGN(c_l0_tile[buffer_num],
+            0x0 + buffer_num * TileLen * sizeof(OutputT));
+  }
+  TLOAD(I_neg_l1_tile, I_neg_global_in);
+  set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
+  wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
+
+  PrepareAuxiliaryMatrices<TileL1AB, TileL0A, TileL0B, TileL0C>(
+      I_neg_l1_tile, Zero_l1_tile, I_l1_tile, a_l0_tile[0], b_l0_tile[0],
+      c_l0_tile[0]);
+
+  const uint32_t max_iters_per_aic =
+      CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
+  constexpr uint32_t final_c_buffer_index = MatrixSize > FractalSize ? 1 : 0;
+
+  for (uint32_t cube_iter = 0; cube_iter < max_iters_per_aic; ++cube_iter) {
+    const uint32_t global_index =
+        (cube_iter * get_block_num() + get_block_idx()) * NumTilesPerCubeIter;
+    if (global_index >= total_tiles) {
+      break;
+    }
+
+    for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
+                               (global_index + tile_id < total_tiles);
+         ++tile_id) {
+      const uint32_t global_tile_id = global_index + tile_id;
+      const uint32_t chunk_idx = global_tile_id / num_bsnd_heads;
+      const uint32_t valid_size =
+          static_cast<uint32_t>(chunk_valid_sizes[chunk_idx]);
+      const uint32_t bsnd_offset = GetBSNDVarlenTileOffset(
+          global_tile_id, num_bsnd_heads, MatrixSize, chunk_indices);
+      const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
+
+      if (valid_size == MatrixSize) {
+        GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
+        TLOAD(Y_l1_tile[tile_id], M_global_in);
+        set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+        wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+      } else {
+        TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
+        TASSIGN(Y_dyn_l1_tile,
+                0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+        GlobalTileInDyn M_global_in_dyn(M + bsnd_offset,
+                                        {1, 1, 1, valid_size, valid_size},
+                                        {1, 1, 1, row_stride, 1});
+        TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
+        set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+        wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+        TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
+      }
+
+      InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
+                       FractalSize, NumTilesPerCubeIter>(
+          X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
+          Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id);
+
+      if (valid_size == MatrixSize) {
+        GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {}, {row_stride});
+        TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+      } else {
+        TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
+        TASSIGN(c_l0_tail_tile,
+                0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+        GlobalTileOutDyn M_inv_global_out_dyn(
+            M_inv + bsnd_offset, {1, 1, 1, valid_size, valid_size},
+            {1, 1, 1, row_stride, 1});
+        TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
+      }
+    }
+  }
+}
+
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
           uint32_t NumTilesPerCubeIter, bool IsBSND>
 AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
                                      __gm__ InputT* I_neg, uint32_t total_tiles,
                                      uint32_t num_bsnd_heads = 0,
-                                     __gm__ int32_t* chunk_indices = nullptr) {
+                                     __gm__ int32_t* chunk_indices = nullptr,
+                                     __gm__ int32_t* chunk_valid_sizes =
+                                         nullptr) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
-
-  TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
-                        IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
-                                chunk_indices);
+  if constexpr (IsBSND) {
+    if (chunk_indices != nullptr && chunk_valid_sizes != nullptr) {
+      TriInvRecUnrollKernelBSNDVarlen<InputT, OutputT, MatrixSize,
+                                      NumTilesPerCubeIter>(
+          M_inv, M, I_neg, total_tiles, num_bsnd_heads, chunk_indices,
+          chunk_valid_sizes);
+    } else {
+      TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
+                            IsBSND>(M_inv, M, I_neg, total_tiles,
+                                    num_bsnd_heads);
+    }
+  } else {
+    TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
+                          IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads);
+  }
 #else
 // Nothing to do on AIV
 #endif
@@ -568,29 +738,30 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
                                    __gm__ InputT* minus_identity_in,
                                    uint32_t matrix_size, uint32_t num_matrices,
                                    uint32_t num_bsnd_heads,
-                                   __gm__ int32_t* chunk_indices) {
+                                   __gm__ int32_t* chunk_indices,
+                                   __gm__ int32_t* chunk_valid_sizes) {
   static_assert(std::is_same_v<InputT, half>,
                 "tri_inv_rec_unroll supports only fp16.");
   switch (matrix_size) {
     case 16:
       runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices);
+          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
       break;
     case 32:
       runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices);
+          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
       break;
     case 64:
       runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices);
+          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
       break;
     case 128:
       runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
           tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices);
+          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
       break;
   }
 }
@@ -598,40 +769,47 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
 extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
     __gm__ void* tensor_out, __gm__ void* tensor_in,
     __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
-    uint32_t num_bsnd_heads, __gm__ void* chunk_indices) {
+    uint32_t num_bsnd_heads, __gm__ void* chunk_indices,
+    __gm__ void* chunk_valid_sizes) {
   if (num_bsnd_heads == 0) {
     if (num_matrices <= get_block_num()) {
       run_tri_inv_rec_unroll<half, 1, false>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
+          (__gm__ int32_t*)chunk_valid_sizes);
     } else if (num_matrices <= 2 * get_block_num()) {
       run_tri_inv_rec_unroll<half, 2, false>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
+          (__gm__ int32_t*)chunk_valid_sizes);
     } else {
       run_tri_inv_rec_unroll<half, 4, false>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
+          (__gm__ int32_t*)chunk_valid_sizes);
     }
   } else {
     if (num_matrices <= get_block_num()) {
       run_tri_inv_rec_unroll<half, 1, true>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
+          (__gm__ int32_t*)chunk_valid_sizes);
     } else if (num_matrices <= 2 * get_block_num()) {
       run_tri_inv_rec_unroll<half, 2, true>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
+          (__gm__ int32_t*)chunk_valid_sizes);
     } else {
       run_tri_inv_rec_unroll<half, 4, true>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices);
+          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
+          (__gm__ int32_t*)chunk_valid_sizes);
     }
   }
 }

--- a/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
+++ b/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
@@ -148,10 +148,9 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
     for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
       for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
-        const uint32_t offset =
-            b * (MatrixSize + FractalSize) * block_size +
-            i * MatrixSize * FractalSize +
-            j * FractalSize * FractalSize;
+        const uint32_t offset = b * (MatrixSize + FractalSize) * block_size +
+                                i * MatrixSize * FractalSize +
+                                j * FractalSize * FractalSize;
         TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
         TEXTRACT(fractals[b], src, b * block_size + i * FractalSize,
                  b * block_size + j * FractalSize);
@@ -355,9 +354,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
     set_flag(PIPE_MTE1, PIPE_M, event_0);
 
     wait_flag(PIPE_FIX, PIPE_MTE1, event_1);
-    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(X_l1_tile,
-                                                               a_l0_tile[1],
-                                                               block_size);
+    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+        X_l1_tile, a_l0_tile[1], block_size);
     set_flag(PIPE_MTE1, PIPE_M, event_1);
 
     wait_flag(PIPE_MTE1, PIPE_M, event_0);
@@ -380,9 +378,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
 
     wait_flag(PIPE_M, PIPE_MTE1, event_1);
     TMOV(b_l0_tile[0], Zero_l1_tile);
-    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(X_l1_tile,
-                                                               b_l0_tile[0],
-                                                               block_size);
+    CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+        X_l1_tile, b_l0_tile[0], block_size);
 
     wait_flag(PIPE_M, PIPE_MTE1, event_0);
     wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
@@ -450,15 +447,15 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       Stride<1, 1, 1, -1, 1>>::type;
   using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut,
                                      GlobalTileStridesOut, Layout::ND>;
-  using GlobalTileOutDyn =
-      GlobalTensor<OutputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
+  using GlobalTileOutDyn = GlobalTensor<OutputT, GlobalTileDynShape,
+                                        GlobalTileDynStride, Layout::ND>;
 
   using TileL1AB =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
            MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
-  using TileL1ABDyn = Tile<TileType::Mat, InputT, MatrixSize, MatrixSize,
-                           BLayout::ColMajor, DYNAMIC, DYNAMIC,
-                           SLayout::RowMajor, 512, PadValue::Zero>;
+  using TileL1ABDyn =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           DYNAMIC, DYNAMIC, SLayout::RowMajor, 512, PadValue::Zero>;
   using TileL0CDyn = TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
   using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
@@ -525,13 +522,14 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       if constexpr (IsBSND) {
         const uint32_t global_tile_id = global_index + tile_id;
         if (cu_seqlens != nullptr) {
-          const BSNDVarlenTileInfo tile_info = GetBSNDVarlenTileInfoFromCuSeqlens(
-              global_tile_id, num_bsnd_heads, MatrixSize, cu_seqlens);
+          const BSNDVarlenTileInfo tile_info =
+              GetBSNDVarlenTileInfoFromCuSeqlens(global_tile_id, num_bsnd_heads,
+                                                 MatrixSize, cu_seqlens);
           bsnd_tile_offsets[tile_id] = tile_info.bsnd_offset;
           bsnd_tile_valid_sizes[tile_id] = tile_info.valid_size;
         } else {
-          bsnd_tile_offsets[tile_id] =
-              GetBSNDFixedTileOffset(global_tile_id, num_bsnd_heads, MatrixSize);
+          bsnd_tile_offsets[tile_id] = GetBSNDFixedTileOffset(
+              global_tile_id, num_bsnd_heads, MatrixSize);
           bsnd_tile_valid_sizes[tile_id] = MatrixSize;
         }
         const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
@@ -544,7 +542,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                   0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
           GlobalTileInDyn M_global_in_dyn(
               M + bsnd_offset,
-              {1, 1, 1, static_cast<int>(valid_size), static_cast<int>(valid_size)},
+              {1, 1, 1, static_cast<int>(valid_size),
+               static_cast<int>(valid_size)},
               {1, 1, 1, row_stride, 1});
           TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
           set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
@@ -598,12 +597,12 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
           wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
           GlobalTileOutDyn M_inv_global_out_dyn(
               M_inv + bsnd_offset,
-              {1, 1, 1, static_cast<int>(valid_size), static_cast<int>(valid_size)},
+              {1, 1, 1, static_cast<int>(valid_size),
+               static_cast<int>(valid_size)},
               {1, 1, 1, row_stride, 1});
           TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
         } else {
-          GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {},
-                                         {row_stride});
+          GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {}, {row_stride});
           TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
         }
       } else {
@@ -659,8 +658,8 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
   using GlobalTileDynStride = Stride<1, 1, 1, DYNAMIC, 1>;
   using GlobalTileInDyn =
       GlobalTensor<InputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
-  using GlobalTileOutDyn =
-      GlobalTensor<OutputT, GlobalTileDynShape, GlobalTileDynStride, Layout::ND>;
+  using GlobalTileOutDyn = GlobalTensor<OutputT, GlobalTileDynShape,
+                                        GlobalTileDynStride, Layout::ND>;
 
   using GlobalTileStridesINeg =
       BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
@@ -676,9 +675,9 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
   using TileL1AB =
       Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
            MatrixSize, MatrixSize, SLayout::RowMajor, 512>;
-  using TileL1ABDyn = Tile<TileType::Mat, InputT, MatrixSize, MatrixSize,
-                           BLayout::ColMajor, DYNAMIC, DYNAMIC,
-                           SLayout::RowMajor, 512, PadValue::Zero>;
+  using TileL1ABDyn =
+      Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor,
+           DYNAMIC, DYNAMIC, SLayout::RowMajor, 512, PadValue::Zero>;
 
   using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
   using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
@@ -749,8 +748,7 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
         wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
       } else {
         TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
-        TASSIGN(Y_dyn_l1_tile,
-                0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+        TASSIGN(Y_dyn_l1_tile, 0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
         GlobalTileInDyn M_global_in_dyn(M + bsnd_offset,
                                         {1, 1, 1, valid_size, valid_size},
                                         {1, 1, 1, row_stride, 1});
@@ -770,7 +768,8 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
         TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
       } else {
         const event_t event_0 = static_cast<event_t>(tile_id);
-        const event_t event_1 = static_cast<event_t>(tile_id + NumTilesPerCubeIter);
+        const event_t event_1 =
+            static_cast<event_t>(tile_id + NumTilesPerCubeIter);
         TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
         TASSIGN(c_l0_tail_tile,
                 0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
@@ -783,9 +782,9 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
         }
         set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
         wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-        GlobalTileOutDyn M_inv_global_out_dyn(
-            M_inv + bsnd_offset, {1, 1, 1, valid_size, valid_size},
-            {1, 1, 1, row_stride, 1});
+        GlobalTileOutDyn M_inv_global_out_dyn(M_inv + bsnd_offset,
+                                              {1, 1, 1, valid_size, valid_size},
+                                              {1, 1, 1, row_stride, 1});
         TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
       }
     }
@@ -820,23 +819,23 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
   switch (matrix_size) {
     case 16:
       runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
-          cu_seqlens);
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens);
       break;
     case 32:
       runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
-          cu_seqlens);
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens);
       break;
     case 64:
       runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
-          cu_seqlens);
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens);
       break;
     case 128:
       runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
-          cu_seqlens);
+          tensor_out, tensor_in, minus_identity_in, num_matrices,
+          num_bsnd_heads, cu_seqlens);
       break;
   }
 }

--- a/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
+++ b/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp
@@ -31,21 +31,39 @@ AICORE inline uint32_t GetBSNDFixedTileOffset(uint32_t tile_id,
   return BSND_OFFSET(tile_id, num_bsnd_heads, matrix_size, matrix_size);
 }
 
+struct BSNDVarlenTileInfo {
+  uint32_t bsnd_offset;
+  uint32_t valid_size;
+};
+
 /*
- * For varlen BSND, chunk_indices stores the absolute row offset of each chunk
- * inside the unpadded BSND tensor. Each tile_id still enumerates chunk-major,
- * then head-major.
+ * For cu_seqlens-based varlen BSND, tile_id still enumerates chunk-major then
+ * head-major. We recover the owning sequence by scanning cu_seqlens and
+ * counting chunks per sequence.
  */
-AICORE inline uint32_t GetBSNDVarlenTileOffset(uint32_t tile_id,
-                                               uint32_t num_bsnd_heads,
-                                               uint32_t matrix_size,
-                                               __gm__ int32_t* chunk_indices) {
+AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(
+    uint32_t tile_id, uint32_t num_bsnd_heads, uint32_t matrix_size,
+    __gm__ int32_t* cu_seqlens) {
   const uint32_t head_idx = tile_id % num_bsnd_heads;
   const uint32_t chunk_idx = tile_id / num_bsnd_heads;
-  const uint32_t chunk_row_start =
-      static_cast<uint32_t>(chunk_indices[chunk_idx]);
-  return chunk_row_start * num_bsnd_heads * matrix_size +
-         head_idx * matrix_size;
+
+  uint32_t seq_start = static_cast<uint32_t>(cu_seqlens[0]);
+  uint32_t accumulated_chunks = 0;
+  for (uint32_t seq_idx = 0;; ++seq_idx) {
+    const uint32_t seq_end = static_cast<uint32_t>(cu_seqlens[seq_idx + 1]);
+    const uint32_t seq_len = seq_end - seq_start;
+    const uint32_t seq_num_chunks = CeilDiv(seq_len, matrix_size);
+    if (chunk_idx < accumulated_chunks + seq_num_chunks) {
+      const uint32_t local_chunk_idx = chunk_idx - accumulated_chunks;
+      const uint32_t row_start = seq_start + local_chunk_idx * matrix_size;
+      const uint32_t valid_size =
+          min(static_cast<uint32_t>(seq_end - row_start), matrix_size);
+      return {row_start * num_bsnd_heads * matrix_size + head_idx * matrix_size,
+              valid_size};
+    }
+    accumulated_chunks += seq_num_chunks;
+    seq_start = seq_end;
+  }
 }
 
 /*
@@ -399,10 +417,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          __gm__ InputT* M, __gm__ InputT* I_neg,
                                          uint32_t total_tiles,
                                          uint32_t num_bsnd_heads = 0,
-                                         __gm__ int32_t* chunk_indices =
-                                             nullptr,
-                                         __gm__ int32_t* chunk_valid_sizes =
-                                             nullptr) {
+                                         __gm__ int32_t* cu_seqlens = nullptr) {
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;
   constexpr uint32_t NumL0Buffers = 2;
@@ -489,6 +504,9 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
   const uint32_t max_iters_per_aic =
       CeilDiv(total_tiles, (uint32_t)(NumTilesPerCubeIter * get_block_num()));
 
+  uint32_t bsnd_tile_offsets[NumTilesPerCubeIter] = {0};
+  uint32_t bsnd_tile_valid_sizes[NumTilesPerCubeIter] = {0};
+
   uint32_t next_tile_id_that_waits_for_pipe_fix_pipe_m = 0;
   set_flag(PIPE_FIX, PIPE_M,
            static_cast<event_t>(next_tile_id_that_waits_for_pipe_fix_pipe_m));
@@ -506,33 +524,32 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
          ++tile_id) {
       if constexpr (IsBSND) {
         const uint32_t global_tile_id = global_index + tile_id;
-        const uint32_t bsnd_offset =
-            chunk_indices != nullptr
-                ? GetBSNDVarlenTileOffset(global_tile_id, num_bsnd_heads,
-                                          MatrixSize, chunk_indices)
-                : GetBSNDFixedTileOffset(global_tile_id, num_bsnd_heads,
-                                         MatrixSize);
+        if (cu_seqlens != nullptr) {
+          const BSNDVarlenTileInfo tile_info = GetBSNDVarlenTileInfoFromCuSeqlens(
+              global_tile_id, num_bsnd_heads, MatrixSize, cu_seqlens);
+          bsnd_tile_offsets[tile_id] = tile_info.bsnd_offset;
+          bsnd_tile_valid_sizes[tile_id] = tile_info.valid_size;
+        } else {
+          bsnd_tile_offsets[tile_id] =
+              GetBSNDFixedTileOffset(global_tile_id, num_bsnd_heads, MatrixSize);
+          bsnd_tile_valid_sizes[tile_id] = MatrixSize;
+        }
+        const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
+        const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
         const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
         wait_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
-        if (chunk_valid_sizes != nullptr) {
-          const uint32_t chunk_idx = global_tile_id / num_bsnd_heads;
-          const uint32_t valid_size =
-              static_cast<uint32_t>(chunk_valid_sizes[chunk_idx]);
-          if (valid_size < MatrixSize) {
-            TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
-            TASSIGN(Y_dyn_l1_tile,
-                    0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
-            GlobalTileInDyn M_global_in_dyn(
-                M + bsnd_offset, {1, 1, 1, valid_size, valid_size},
-                {1, 1, 1, row_stride, 1});
-            TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
-            set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
-            wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
-            TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
-          } else {
-            GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
-            TLOAD(Y_l1_tile[tile_id], M_global_in);
-          }
+        if (valid_size < MatrixSize) {
+          TileL1ABDyn Y_dyn_l1_tile(valid_size, valid_size);
+          TASSIGN(Y_dyn_l1_tile,
+                  0x0 + (5 + tile_id) * TileLen * sizeof(InputT));
+          GlobalTileInDyn M_global_in_dyn(
+              M + bsnd_offset,
+              {1, 1, 1, static_cast<int>(valid_size), static_cast<int>(valid_size)},
+              {1, 1, 1, row_stride, 1});
+          TLOAD(Y_dyn_l1_tile, M_global_in_dyn);
+          set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+          wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
+          TFILLPAD(Y_dyn_l1_tile, Y_dyn_l1_tile);
         } else {
           GlobalTileIn M_global_in(M + bsnd_offset, {}, {row_stride});
           TLOAD(Y_l1_tile[tile_id], M_global_in);
@@ -560,43 +577,30 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       set_flag(PIPE_M, PIPE_MTE2, static_cast<event_t>(tile_id));
 
       if constexpr (IsBSND) {
-        const uint32_t global_tile_id = global_index + tile_id;
-        const uint32_t bsnd_offset =
-            chunk_indices != nullptr
-                ? GetBSNDVarlenTileOffset(global_tile_id, num_bsnd_heads,
-                                          MatrixSize, chunk_indices)
-                : GetBSNDFixedTileOffset(global_tile_id, num_bsnd_heads,
-                                         MatrixSize);
+        const uint32_t bsnd_offset = bsnd_tile_offsets[tile_id];
+        const uint32_t valid_size = bsnd_tile_valid_sizes[tile_id];
         const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
-        if (chunk_valid_sizes != nullptr) {
-          const uint32_t chunk_idx = global_tile_id / num_bsnd_heads;
-          const uint32_t valid_size =
-              static_cast<uint32_t>(chunk_valid_sizes[chunk_idx]);
-          if (valid_size < MatrixSize) {
-            const event_t event_0 = static_cast<event_t>(tile_id);
-            const event_t event_1 =
-                static_cast<event_t>(tile_id + NumTilesPerCubeIter);
-            TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
-            TASSIGN(c_l0_tail_tile,
-                    0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
-            if constexpr (final_c_buffer_index == 1) {
-              set_flag(PIPE_M, PIPE_FIX, event_1);
-              wait_flag(PIPE_M, PIPE_FIX, event_1);
-            } else {
-              set_flag(PIPE_M, PIPE_FIX, event_0);
-              wait_flag(PIPE_M, PIPE_FIX, event_0);
-            }
-            set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-            wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
-            GlobalTileOutDyn M_inv_global_out_dyn(
-                M_inv + bsnd_offset, {1, 1, 1, valid_size, valid_size},
-                {1, 1, 1, row_stride, 1});
-            TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
+        if (valid_size < MatrixSize) {
+          const event_t event_0 = static_cast<event_t>(tile_id);
+          const event_t event_1 =
+              static_cast<event_t>(tile_id + NumTilesPerCubeIter);
+          TileL0CDyn c_l0_tail_tile(valid_size, valid_size);
+          TASSIGN(c_l0_tail_tile,
+                  0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+          if constexpr (final_c_buffer_index == 1) {
+            set_flag(PIPE_M, PIPE_FIX, event_1);
+            wait_flag(PIPE_M, PIPE_FIX, event_1);
           } else {
-            GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {},
-                                           {row_stride});
-            TSTORE(M_inv_global_out, c_l0_tile[final_c_buffer_index]);
+            set_flag(PIPE_M, PIPE_FIX, event_0);
+            wait_flag(PIPE_M, PIPE_FIX, event_0);
           }
+          set_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
+          wait_flag(PIPE_FIX, PIPE_MTE3, static_cast<event_t>(tile_id));
+          GlobalTileOutDyn M_inv_global_out_dyn(
+              M_inv + bsnd_offset,
+              {1, 1, 1, static_cast<int>(valid_size), static_cast<int>(valid_size)},
+              {1, 1, 1, row_stride, 1});
+          TSTORE(M_inv_global_out_dyn, c_l0_tail_tile);
         } else {
           GlobalTileOut M_inv_global_out(M_inv + bsnd_offset, {},
                                          {row_stride});
@@ -626,17 +630,17 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
  *
  * The input/output tensors stay unpadded. For tail chunks with size
  * `actual_size < MatrixSize`, the kernel:
- * 1. loads only the valid `actual_size x actual_size` prefix via dynamic TLOAD
- * 2. zero-fills the remaining rows/cols in-place via TFILLPAD_INPLACE
- * 3. runs the original dense recursive inverse on the materialized full tile
- * 4. stores only the valid `actual_size x actual_size` prefix back to GM
+ * 1. derives the chunk row-start and runtime size from `cu_seqlens`
+ * 2. loads only the valid `actual_size x actual_size` prefix via dynamic TLOAD
+ * 3. zero-fills the remaining rows/cols in-place via TFILLPAD_INPLACE
+ * 4. runs the original dense recursive inverse on the materialized full tile
+ * 5. stores only the valid `actual_size x actual_size` prefix back to GM
  */
 template <typename InputT, typename OutputT, uint32_t MatrixSize,
           uint32_t NumTilesPerCubeIter>
 AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
     __gm__ OutputT* M_inv, __gm__ InputT* M, __gm__ InputT* I_neg,
-    uint32_t total_tiles, uint32_t num_bsnd_heads, __gm__ int32_t* chunk_indices,
-    __gm__ int32_t* chunk_valid_sizes) {
+    uint32_t total_tiles, uint32_t num_bsnd_heads, __gm__ int32_t* cu_seqlens) {
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;
   constexpr uint32_t NumL0Buffers = 2;
@@ -732,11 +736,10 @@ AICORE inline void TriInvRecUnrollKernelBSNDVarlen(
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
       const uint32_t global_tile_id = global_index + tile_id;
-      const uint32_t chunk_idx = global_tile_id / num_bsnd_heads;
-      const uint32_t valid_size =
-          static_cast<uint32_t>(chunk_valid_sizes[chunk_idx]);
-      const uint32_t bsnd_offset = GetBSNDVarlenTileOffset(
-          global_tile_id, num_bsnd_heads, MatrixSize, chunk_indices);
+      const BSNDVarlenTileInfo tile_info = GetBSNDVarlenTileInfoFromCuSeqlens(
+          global_tile_id, num_bsnd_heads, MatrixSize, cu_seqlens);
+      const uint32_t valid_size = tile_info.valid_size;
+      const uint32_t bsnd_offset = tile_info.bsnd_offset;
       const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
 
       if (valid_size == MatrixSize) {
@@ -794,14 +797,12 @@ template <typename InputT, typename OutputT, uint32_t MatrixSize,
 AICORE void runKernelTriInvRecUnroll(__gm__ OutputT* M_inv, __gm__ InputT* M,
                                      __gm__ InputT* I_neg, uint32_t total_tiles,
                                      uint32_t num_bsnd_heads = 0,
-                                     __gm__ int32_t* chunk_indices = nullptr,
-                                     __gm__ int32_t* chunk_valid_sizes =
-                                         nullptr) {
+                                     __gm__ int32_t* cu_seqlens = nullptr) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
   TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter,
                         IsBSND>(M_inv, M, I_neg, total_tiles, num_bsnd_heads,
-                                chunk_indices, chunk_valid_sizes);
+                                cu_seqlens);
 #else
 // Nothing to do on AIV
 #endif
@@ -813,30 +814,29 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
                                    __gm__ InputT* minus_identity_in,
                                    uint32_t matrix_size, uint32_t num_matrices,
                                    uint32_t num_bsnd_heads,
-                                   __gm__ int32_t* chunk_indices,
-                                   __gm__ int32_t* chunk_valid_sizes) {
+                                   __gm__ int32_t* cu_seqlens) {
   static_assert(std::is_same_v<InputT, half>,
                 "tri_inv_rec_unroll supports only fp16.");
   switch (matrix_size) {
     case 16:
       runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
+          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
+          cu_seqlens);
       break;
     case 32:
       runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
+          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
+          cu_seqlens);
       break;
     case 64:
       runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
+          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
+          cu_seqlens);
       break;
     case 128:
       runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
-          tensor_out, tensor_in, minus_identity_in, num_matrices,
-          num_bsnd_heads, chunk_indices, chunk_valid_sizes);
+          tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads,
+          cu_seqlens);
       break;
   }
 }
@@ -844,47 +844,40 @@ AICORE void run_tri_inv_rec_unroll(__gm__ float* tensor_out,
 extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
     __gm__ void* tensor_out, __gm__ void* tensor_in,
     __gm__ void* minus_identity_in, uint32_t matrix_size, uint32_t num_matrices,
-    uint32_t num_bsnd_heads, __gm__ void* chunk_indices,
-    __gm__ void* chunk_valid_sizes) {
+    uint32_t num_bsnd_heads, __gm__ void* cu_seqlens) {
   if (num_bsnd_heads == 0) {
     if (num_matrices <= get_block_num()) {
       run_tri_inv_rec_unroll<half, 1, false>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
-          (__gm__ int32_t*)chunk_valid_sizes);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
       run_tri_inv_rec_unroll<half, 2, false>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
-          (__gm__ int32_t*)chunk_valid_sizes);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else {
       run_tri_inv_rec_unroll<half, 4, false>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
-          (__gm__ int32_t*)chunk_valid_sizes);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     }
   } else {
     if (num_matrices <= get_block_num()) {
       run_tri_inv_rec_unroll<half, 1, true>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
-          (__gm__ int32_t*)chunk_valid_sizes);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else if (num_matrices <= 2 * get_block_num()) {
       run_tri_inv_rec_unroll<half, 2, true>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
-          (__gm__ int32_t*)chunk_valid_sizes);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     } else {
       run_tri_inv_rec_unroll<half, 4, true>(
           (__gm__ float*)tensor_out, (__gm__ half*)tensor_in,
           (__gm__ half*)minus_identity_in, matrix_size, num_matrices,
-          num_bsnd_heads, (__gm__ int32_t*)chunk_indices,
-          (__gm__ int32_t*)chunk_valid_sizes);
+          num_bsnd_heads, (__gm__ int32_t*)cu_seqlens);
     }
   }
 }

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -93,38 +93,18 @@ def _make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
     return I_neg
 
 
-def _chunk_metadata_from_cu_seqlens(
+def _count_varlen_chunks(
     cu_seqlens: torch.Tensor | list[int],
     chunk_size: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> int:
     if isinstance(cu_seqlens, torch.Tensor):
-        cu_seqlens_np = cu_seqlens.detach().cpu().numpy().astype(np.int64, copy=False)
+        cu_seqlens_list = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
     else:
-        cu_seqlens_np = np.asarray(cu_seqlens, dtype=np.int64)
-
-    seq_starts = cu_seqlens_np[:-1]
-    seq_lens = cu_seqlens_np[1:] - seq_starts
-    seq_num_chunks = (seq_lens + chunk_size - 1) // chunk_size
-    total_chunks = int(seq_num_chunks.sum())
-
-    chunk_indices = np.empty(total_chunks, dtype=np.int32)
-    chunk_valid_sizes = np.empty(total_chunks, dtype=np.int32)
-    cursor = 0
-    for seq_start, seq_len, num_chunks in zip(seq_starts, seq_lens, seq_num_chunks):
-        num_chunks_int = int(num_chunks)
-        local_offsets = np.arange(num_chunks_int, dtype=np.int64) * chunk_size
-        next_cursor = cursor + num_chunks_int
-        chunk_indices[cursor:next_cursor] = (seq_start + local_offsets).astype(
-            np.int32,
-            copy=False,
-        )
-        chunk_valid_sizes[cursor:next_cursor] = np.minimum(
-            chunk_size,
-            seq_len - local_offsets,
-        ).astype(np.int32, copy=False)
-        cursor = next_cursor
-
-    return torch.from_numpy(chunk_indices), torch.from_numpy(chunk_valid_sizes)
+        cu_seqlens_list = [int(x) for x in cu_seqlens]
+    return sum(
+        (cu_seqlens_list[i + 1] - cu_seqlens_list[i] + chunk_size - 1) // chunk_size
+        for i in range(len(cu_seqlens_list) - 1)
+    )
 
 
 def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
@@ -163,9 +143,7 @@ def _run_kernel_bsnd(
     matrix_size = U_bsnd_fp16.shape[-1]
     num_bsnd_heads = U_bsnd_fp16.shape[-2]
     if cu_seqlens is not None:
-        seq_lens = cu_seqlens[1:].to(torch.int64) - cu_seqlens[:-1].to(torch.int64)
-        num_chunks = ((seq_lens + matrix_size - 1) // matrix_size).sum().item()
-        num_matrices = int(num_chunks) * num_bsnd_heads
+        num_matrices = _count_varlen_chunks(cu_seqlens, matrix_size) * num_bsnd_heads
     else:
         num_matrices = U_bsnd_fp16.numel() // (matrix_size * matrix_size)
     device = U_bsnd_fp16.device
@@ -174,15 +152,6 @@ def _run_kernel_bsnd(
     I_neg = _make_minus_identity(matrix_size, str(device))
     if cu_seqlens is not None:
         cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32).contiguous()
-        chunk_indices, chunk_valid_sizes = _chunk_metadata_from_cu_seqlens(
-            cu_seqlens,
-            matrix_size,
-        )
-        chunk_indices = chunk_indices.to(device=device).contiguous()
-        chunk_valid_sizes = chunk_valid_sizes.to(device=device).contiguous()
-    else:
-        chunk_indices = None
-        chunk_valid_sizes = None
 
     torch.npu.synchronize()
     tri_inv_func(
@@ -192,8 +161,7 @@ def _run_kernel_bsnd(
         matrix_size,
         num_matrices,
         num_bsnd_heads,
-        chunk_indices=chunk_indices,
-        chunk_valid_sizes=chunk_valid_sizes,
+        cu_seqlens=cu_seqlens,
     )
     torch.npu.synchronize()
 

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -104,8 +104,33 @@ def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
     return tensor_out.cpu().to(torch.float64)
 
 
+def _run_kernel_bsnd(tri_inv_func, U_bsnd_fp16: torch.Tensor):
+    """
+    Run the kernel in BSND mode and return fp64 CPU result.
+
+    U_bsnd_fp16 : (B, S, N, D) half tensor on NPU where each (D, D) block
+                  along the S dimension is one matrix to invert.
+    """
+    matrix_size = U_bsnd_fp16.shape[-1]       # D
+    num_bsnd_heads = U_bsnd_fp16.shape[-2]    # N
+    num_matrices = U_bsnd_fp16.numel() // (matrix_size * matrix_size)
+    device = U_bsnd_fp16.device
+
+    tensor_out = torch.zeros_like(U_bsnd_fp16, dtype=torch.float32)
+    I_neg = _make_minus_identity(matrix_size, str(device))
+
+    torch.npu.synchronize()
+    tri_inv_func(
+        tensor_out, U_bsnd_fp16, I_neg,
+        matrix_size, num_matrices, num_bsnd_heads,
+    )
+    torch.npu.synchronize()
+
+    return tensor_out.cpu().to(torch.float64)
+
+
 # ---------------------------------------------------------------------------
-# Single test
+# Single test – standard layout
 # ---------------------------------------------------------------------------
 
 def _test_case(tri_inv_func, U: torch.Tensor, atol: float, rtol: float, ftol: float,
@@ -128,6 +153,39 @@ def _test_case(tri_inv_func, U: torch.Tensor, atol: float, rtol: float, ftol: fl
 
 
 # ---------------------------------------------------------------------------
+# Single test – BSND layout
+# ---------------------------------------------------------------------------
+
+def _test_case_bsnd(tri_inv_func, U: torch.Tensor, B: int, S: int, N: int, D: int,
+                    atol: float, rtol: float, ftol: float, label: str):
+    """
+    U has shape (B*S//D, N, D, D) – the raw generator output.
+    It is converted to (B, S, N, D) before being fed to the kernel, mirroring
+    the original pytest test_tri_inv_rec_unroll_bsnd helper.
+    """
+    U_fp16 = U.to(torch.half)
+    # Compute reference in (B*S//D, N, D, D) space, then reshape to (B, S, N, D)
+    golden = linalg_inv_ref(U_fp16)
+    golden = golden.transpose(1, 2).contiguous().reshape(B, S, N, D)
+
+    # Transform input to BSND layout: (B*S//D, N, D, D) → (B, S, N, D)
+    U_bsnd = U_fp16.transpose(1, 2).contiguous().reshape(B, S, N, D)
+
+    actual = _run_kernel_bsnd(tri_inv_func, U_bsnd.npu())
+
+    frob = torch.sqrt(
+        torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)
+    ).item()
+
+    assert np.allclose(
+        actual.numpy(), golden.numpy(), atol=atol, rtol=rtol
+    ), f"[{label}] allclose failed — shape {U_bsnd.shape}, rtol={rtol}"
+    assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
+
+    print(f"  PASS  {label}  frob={frob:.2e}")
+
+
+# ---------------------------------------------------------------------------
 # Test suite
 # ---------------------------------------------------------------------------
 
@@ -138,11 +196,15 @@ def run_tests(tri_inv_func):
         ("block_random", block_random_triu_matrix,  5e-5, 0.1,  1e-4),
         ("random",       random_triu_matrix,        5e-5, 0.1,  1e-4),
     ]
-    sizes   = [16, 32, 64, 128]
-    x_dims  = [1, 2, 4]
-    y_dims  = [2, 4]
 
     total = passed = 0
+
+    # -- Standard layout tests -----------------------------------------------
+    print("=== Standard layout ===")
+    sizes  = [16, 32, 64, 128]
+    x_dims = [1, 2, 4]
+    y_dims = [2, 4]
+
     for n in sizes:
         for bdx in x_dims:
             for bdy in y_dims:
@@ -155,6 +217,29 @@ def run_tests(tri_inv_func):
                         passed += 1
                     except AssertionError as err:
                         print(f"  FAIL  {label}: {err}")
+
+    # -- BSND layout tests ---------------------------------------------------
+    print("\n=== BSND layout ===")
+    # Keep a representative subset: S must be a multiple of D
+    bsnd_configs = [
+        (B, S, N, D)
+        for B in [1, 4]
+        for S in [128, 256]
+        for N in [4, 8]
+        for D in [16, 32, 64, 128]
+        if S % D == 0
+    ]
+
+    for B, S, N, D in bsnd_configs:
+        for name, gen, atol, rtol, ftol in cases:
+            total += 1
+            label = f"B={B} S={S} N={N} D={D} [{name}]"
+            try:
+                U = gen(D, B * S // D, N)
+                _test_case_bsnd(tri_inv_func, U, B, S, N, D, atol, rtol, ftol, label)
+                passed += 1
+            except AssertionError as err:
+                print(f"  FAIL  {label}: {err}")
 
     print(f"\n{passed}/{total} tests passed.")
     return passed == total

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -8,7 +8,7 @@
 
 """
 Correctness tests for the JIT-compiled triangular inverse (recursive unroll)
-kernel.  Run from the fast_inverse/ directory:
+kernel. Run from the fast_inverse/ directory:
 
     python run_fast_inverse.py
 """
@@ -25,12 +25,15 @@ from jit_util_fast_inverse import jit_compile
 torch.manual_seed(42)
 np.random.seed(42)
 
-# ---------------------------------------------------------------------------
-# Matrix generators  (identical to the unit-test suite)
-# ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Matrix generators (identical to the unit-test suite)
+# ---------------------------------------------------------------------------
 def random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.1):
-    return scale * torch.triu(torch.rand((block_dim_x, block_dim_y, n, n)), diagonal=1)
+    return scale * torch.triu(
+        torch.rand((block_dim_x, block_dim_y, n, n)),
+        diagonal=1,
+    )
 
 
 def ones_triu_matrix(n, block_dim_x, block_dim_y):
@@ -60,24 +63,30 @@ def block_random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.2):
 
 
 # ---------------------------------------------------------------------------
-# Reference implementation  (CPU / numpy)
+# Reference implementation (CPU / numpy)
 # ---------------------------------------------------------------------------
-
 def linalg_inv_ref(U: torch.Tensor) -> torch.Tensor:
     """Invert (U + I) for each matrix in the batch using numpy."""
     n = U.shape[-1]
-    identity = np.triu(np.tril(np.ones((n, n), dtype=np.double)))
-    out = np.zeros(U.shape)
+    identity = np.eye(n, dtype=np.double)
+    out = np.zeros(U.shape, dtype=np.double)
     for x in range(U.shape[0]):
         for y in range(U.shape[1]):
             out[x, y] = np.linalg.inv(U[x, y].numpy().astype(np.double) + identity)
     return torch.from_numpy(out)
 
 
+def invert_single_chunk_ref(U: torch.Tensor) -> torch.Tensor:
+    """Invert one upper-triangular chunk U where U is (..., m, m)."""
+    m = U.shape[-1]
+    return torch.from_numpy(
+        np.linalg.inv(U.numpy().astype(np.double) + np.eye(m, dtype=np.double))
+    )
+
+
 # ---------------------------------------------------------------------------
 # Kernel helpers
 # ---------------------------------------------------------------------------
-
 def _make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
     I_neg = torch.zeros(matrix_size, matrix_size, dtype=torch.half, device=device)
     I_neg.fill_diagonal_(-1)
@@ -104,37 +113,121 @@ def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
     return tensor_out.cpu().to(torch.float64)
 
 
-def _run_kernel_bsnd(tri_inv_func, U_bsnd_fp16: torch.Tensor):
+def _run_kernel_bsnd(
+    tri_inv_func,
+    U_bsnd_fp16: torch.Tensor,
+    chunk_indices: torch.Tensor | None = None,
+):
     """
     Run the kernel in BSND mode and return fp64 CPU result.
 
     U_bsnd_fp16 : (B, S, N, D) half tensor on NPU where each (D, D) block
                   along the S dimension is one matrix to invert.
+    chunk_indices : optional int32 tensor containing the padded row start of
+                    each valid chunk for varlen BSND inputs.
     """
-    matrix_size = U_bsnd_fp16.shape[-1]       # D
-    num_bsnd_heads = U_bsnd_fp16.shape[-2]    # N
+    matrix_size = U_bsnd_fp16.shape[-1]
+    num_bsnd_heads = U_bsnd_fp16.shape[-2]
     num_matrices = U_bsnd_fp16.numel() // (matrix_size * matrix_size)
     device = U_bsnd_fp16.device
 
     tensor_out = torch.zeros_like(U_bsnd_fp16, dtype=torch.float32)
     I_neg = _make_minus_identity(matrix_size, str(device))
+    if chunk_indices is not None:
+        chunk_indices = chunk_indices.to(device=device, dtype=torch.int32).contiguous()
 
     torch.npu.synchronize()
     tri_inv_func(
-        tensor_out, U_bsnd_fp16, I_neg,
-        matrix_size, num_matrices, num_bsnd_heads,
+        tensor_out,
+        U_bsnd_fp16,
+        I_neg,
+        matrix_size,
+        num_matrices,
+        num_bsnd_heads,
+        chunk_indices=chunk_indices,
     )
     torch.npu.synchronize()
 
     return tensor_out.cpu().to(torch.float64)
 
 
+def _build_varlen_bsnd_case(
+    gen,
+    cu_seqlens: list[int],
+    num_heads: int,
+    chunk_size: int,
+):
+    """
+    Build a padded BSND tensor plus reference output for varlen testing.
+
+    Each sequence is padded independently to the next multiple of chunk_size.
+    chunk_indices records the padded row offset of every valid chunk.
+    """
+    seq_lens = [
+        cu_seqlens[i + 1] - cu_seqlens[i]
+        for i in range(len(cu_seqlens) - 1)
+    ]
+    print(
+        f"    varlen sequence lengths: {seq_lens} "
+        f"(chunk_size={chunk_size}, num_heads={num_heads})"
+    )
+
+    total_tokens = cu_seqlens[-1]
+    num_chunks = sum(
+        (cu_seqlens[i + 1] - cu_seqlens[i] + chunk_size - 1) // chunk_size
+        for i in range(len(cu_seqlens) - 1)
+    )
+    chunk_mats = gen(chunk_size, num_chunks, num_heads).to(torch.float64)
+
+    padded_total = num_chunks * chunk_size
+    U_padded = torch.zeros((1, padded_total, num_heads, chunk_size), dtype=torch.float64)
+    golden = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
+
+    chunk_indices: list[int] = []
+    chunk_infos: list[tuple[int, int, int]] = []
+    chunk_idx = 0
+    padded_row = 0
+
+    for seq_idx in range(len(cu_seqlens) - 1):
+        seq_start = cu_seqlens[seq_idx]
+        seq_end = cu_seqlens[seq_idx + 1]
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            actual_size = min(chunk_size, seq_end - chunk_start)
+            chunk = chunk_mats[chunk_idx]
+            for head_idx in range(num_heads):
+                U_valid = chunk[head_idx, :actual_size, :actual_size]
+                U_padded[
+                    0,
+                    padded_row : padded_row + actual_size,
+                    head_idx,
+                    :actual_size,
+                ] = U_valid
+                golden[
+                    0,
+                    chunk_start : chunk_start + actual_size,
+                    head_idx,
+                    :actual_size,
+                ] = invert_single_chunk_ref(U_valid)
+
+            chunk_indices.append(padded_row)
+            chunk_infos.append((padded_row, chunk_start, actual_size))
+            padded_row += chunk_size
+            chunk_idx += 1
+
+    return U_padded, golden, chunk_infos, torch.tensor(chunk_indices, dtype=torch.int32)
+
+
 # ---------------------------------------------------------------------------
 # Single test – standard layout
 # ---------------------------------------------------------------------------
-
-def _test_case(tri_inv_func, U: torch.Tensor, atol: float, rtol: float, ftol: float,
-               label: str):
+def _test_case(
+    tri_inv_func,
+    U: torch.Tensor,
+    atol: float,
+    rtol: float,
+    ftol: float,
+    label: str,
+):
     U_fp16 = U.to(torch.half)
     golden = linalg_inv_ref(U_fp16)
 
@@ -145,7 +238,10 @@ def _test_case(tri_inv_func, U: torch.Tensor, atol: float, rtol: float, ftol: fl
     ).item()
 
     assert np.allclose(
-        actual.numpy(), golden.numpy(), atol=atol, rtol=rtol
+        actual.numpy(),
+        golden.numpy(),
+        atol=atol,
+        rtol=rtol,
     ), f"[{label}] allclose failed — shape {U.shape}, rtol={rtol}"
     assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
 
@@ -155,22 +251,27 @@ def _test_case(tri_inv_func, U: torch.Tensor, atol: float, rtol: float, ftol: fl
 # ---------------------------------------------------------------------------
 # Single test – BSND layout
 # ---------------------------------------------------------------------------
-
-def _test_case_bsnd(tri_inv_func, U: torch.Tensor, B: int, S: int, N: int, D: int,
-                    atol: float, rtol: float, ftol: float, label: str):
+def _test_case_bsnd(
+    tri_inv_func,
+    U: torch.Tensor,
+    B: int,
+    S: int,
+    N: int,
+    D: int,
+    atol: float,
+    rtol: float,
+    ftol: float,
+    label: str,
+):
     """
     U has shape (B*S//D, N, D, D) – the raw generator output.
-    It is converted to (B, S, N, D) before being fed to the kernel, mirroring
-    the original pytest test_tri_inv_rec_unroll_bsnd helper.
+    It is converted to (B, S, N, D) before being fed to the kernel.
     """
     U_fp16 = U.to(torch.half)
-    # Compute reference in (B*S//D, N, D, D) space, then reshape to (B, S, N, D)
     golden = linalg_inv_ref(U_fp16)
     golden = golden.transpose(1, 2).contiguous().reshape(B, S, N, D)
 
-    # Transform input to BSND layout: (B*S//D, N, D, D) → (B, S, N, D)
     U_bsnd = U_fp16.transpose(1, 2).contiguous().reshape(B, S, N, D)
-
     actual = _run_kernel_bsnd(tri_inv_func, U_bsnd.npu())
 
     frob = torch.sqrt(
@@ -178,8 +279,63 @@ def _test_case_bsnd(tri_inv_func, U: torch.Tensor, B: int, S: int, N: int, D: in
     ).item()
 
     assert np.allclose(
-        actual.numpy(), golden.numpy(), atol=atol, rtol=rtol
+        actual.numpy(),
+        golden.numpy(),
+        atol=atol,
+        rtol=rtol,
     ), f"[{label}] allclose failed — shape {U_bsnd.shape}, rtol={rtol}"
+    assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
+
+    print(f"  PASS  {label}  frob={frob:.2e}")
+
+
+def _test_case_bsnd_varlen(
+    tri_inv_func,
+    gen,
+    cu_seqlens: list[int],
+    N: int,
+    D: int,
+    atol: float,
+    rtol: float,
+    ftol: float,
+    label: str,
+):
+    U_padded, golden, chunk_infos, chunk_indices = _build_varlen_bsnd_case(
+        gen,
+        cu_seqlens,
+        N,
+        D,
+    )
+    actual_padded = _run_kernel_bsnd(
+        tri_inv_func,
+        U_padded.to(torch.half).npu(),
+        chunk_indices=chunk_indices.npu(),
+    )
+
+    actual = torch.zeros_like(golden)
+    for padded_row, token_row, actual_size in chunk_infos:
+        actual[
+            :,
+            token_row : token_row + actual_size,
+            :,
+            :actual_size,
+        ] = actual_padded[
+            :,
+            padded_row : padded_row + actual_size,
+            :,
+            :actual_size,
+        ]
+
+    frob = torch.sqrt(
+        torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)
+    ).item()
+
+    assert np.allclose(
+        actual.numpy(),
+        golden.numpy(),
+        atol=atol,
+        rtol=rtol,
+    ), f"[{label}] allclose failed — shape {actual.shape}, rtol={rtol}"
     assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
 
     print(f"  PASS  {label}  frob={frob:.2e}")
@@ -188,20 +344,18 @@ def _test_case_bsnd(tri_inv_func, U: torch.Tensor, B: int, S: int, N: int, D: in
 # ---------------------------------------------------------------------------
 # Test suite
 # ---------------------------------------------------------------------------
-
 def run_tests(tri_inv_func):
     cases = [
-        ("block_ones",   block_ones_triu_matrix,   0,    0,    0),
-        ("ones",         ones_triu_matrix,          0,    0,    0),
-        ("block_random", block_random_triu_matrix,  5e-5, 0.1,  1e-4),
-        ("random",       random_triu_matrix,        5e-5, 0.1,  1e-4),
+        ("block_ones", block_ones_triu_matrix, 0, 0, 0),
+        ("ones", ones_triu_matrix, 0, 0, 0),
+        ("block_random", block_random_triu_matrix, 5e-5, 0.1, 1e-4),
+        ("random", random_triu_matrix, 5e-5, 0.1, 1e-4),
     ]
 
     total = passed = 0
 
-    # -- Standard layout tests -----------------------------------------------
     print("=== Standard layout ===")
-    sizes  = [16, 32, 64, 128]
+    sizes = [16, 32, 64, 128]
     x_dims = [1, 2, 4]
     y_dims = [2, 4]
 
@@ -218,9 +372,7 @@ def run_tests(tri_inv_func):
                     except AssertionError as err:
                         print(f"  FAIL  {label}: {err}")
 
-    # -- BSND layout tests ---------------------------------------------------
     print("\n=== BSND layout ===")
-    # Keep a representative subset: S must be a multiple of D
     bsnd_configs = [
         (B, S, N, D)
         for B in [1, 4]
@@ -241,6 +393,35 @@ def run_tests(tri_inv_func):
             except AssertionError as err:
                 print(f"  FAIL  {label}: {err}")
 
+    print("\n=== BSND varlen layout ===")
+    varlen_configs = [
+        (4, 16, [0, 15]),
+        (4, 32, [0, 256, 500, 1000]),
+        (4, 64, [0, 15, 100, 300, 1200, 2000]),
+        (4, 16, [0, 1, 100, 300, 1200, 2048]),
+        (4, 32, [0, 200, 512, 1200, 2048]),
+    ]
+
+    for N, D, cu_seqlens in varlen_configs:
+        for name, gen, atol, rtol, ftol in cases:
+            total += 1
+            label = f"N={N} D={D} cu={cu_seqlens} [{name}]"
+            try:
+                _test_case_bsnd_varlen(
+                    tri_inv_func,
+                    gen,
+                    cu_seqlens,
+                    N,
+                    D,
+                    atol,
+                    rtol,
+                    ftol,
+                    label,
+                )
+                passed += 1
+            except AssertionError as err:
+                print(f"  FAIL  {label}: {err}")
+
     print(f"\n{passed}/{total} tests passed.")
     return passed == total
 
@@ -248,7 +429,6 @@ def run_tests(tri_inv_func):
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
-
 if __name__ == "__main__":
     import os
 

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -179,10 +179,7 @@ def _build_varlen_bsnd_case(
 
     Each sequence contributes only its true rows in the packed BSND tensor.
     """
-    seq_lens = [
-        cu_seqlens[i + 1] - cu_seqlens[i]
-        for i in range(len(cu_seqlens) - 1)
-    ]
+    seq_lens = [cu_seqlens[i + 1] - cu_seqlens[i] for i in range(len(cu_seqlens) - 1)]
     print(
         f"    varlen sequence lengths: {seq_lens} "
         f"(chunk_size={chunk_size}, num_heads={num_heads})"
@@ -246,9 +243,7 @@ def _test_case(
 
     actual = _run_kernel(tri_inv_func, U_fp16.npu())
 
-    frob = torch.sqrt(
-        torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)
-    ).item()
+    frob = torch.sqrt(torch.sum((golden - actual) ** 2) / torch.sum(golden**2)).item()
 
     assert np.allclose(
         actual.numpy(),
@@ -287,9 +282,7 @@ def _test_case_bsnd(
     U_bsnd = U_fp16.transpose(1, 2).contiguous().reshape(B, S, N, D)
     actual = _run_kernel_bsnd(tri_inv_func, U_bsnd.npu())
 
-    frob = torch.sqrt(
-        torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)
-    ).item()
+    frob = torch.sqrt(torch.sum((golden - actual) ** 2) / torch.sum(golden**2)).item()
 
     assert np.allclose(
         actual.numpy(),
@@ -326,9 +319,7 @@ def _test_case_bsnd_varlen(
     )
     actual = actual_varlen
 
-    frob = torch.sqrt(
-        torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)
-    ).item()
+    frob = torch.sqrt(torch.sum((golden - actual) ** 2) / torch.sum(golden**2)).item()
 
     assert np.allclose(
         actual.numpy(),

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -93,6 +93,40 @@ def _make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
     return I_neg
 
 
+def _chunk_metadata_from_cu_seqlens(
+    cu_seqlens: torch.Tensor | list[int],
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if isinstance(cu_seqlens, torch.Tensor):
+        cu_seqlens_np = cu_seqlens.detach().cpu().numpy().astype(np.int64, copy=False)
+    else:
+        cu_seqlens_np = np.asarray(cu_seqlens, dtype=np.int64)
+
+    seq_starts = cu_seqlens_np[:-1]
+    seq_lens = cu_seqlens_np[1:] - seq_starts
+    seq_num_chunks = (seq_lens + chunk_size - 1) // chunk_size
+    total_chunks = int(seq_num_chunks.sum())
+
+    chunk_indices = np.empty(total_chunks, dtype=np.int32)
+    chunk_valid_sizes = np.empty(total_chunks, dtype=np.int32)
+    cursor = 0
+    for seq_start, seq_len, num_chunks in zip(seq_starts, seq_lens, seq_num_chunks):
+        num_chunks_int = int(num_chunks)
+        local_offsets = np.arange(num_chunks_int, dtype=np.int64) * chunk_size
+        next_cursor = cursor + num_chunks_int
+        chunk_indices[cursor:next_cursor] = (seq_start + local_offsets).astype(
+            np.int32,
+            copy=False,
+        )
+        chunk_valid_sizes[cursor:next_cursor] = np.minimum(
+            chunk_size,
+            seq_len - local_offsets,
+        ).astype(np.int32, copy=False)
+        cursor = next_cursor
+
+    return torch.from_numpy(chunk_indices), torch.from_numpy(chunk_valid_sizes)
+
+
 def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
     """
     Allocate output, build -I, run kernel, return fp64 CPU result.
@@ -116,36 +150,39 @@ def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
 def _run_kernel_bsnd(
     tri_inv_func,
     U_bsnd_fp16: torch.Tensor,
-    chunk_indices: torch.Tensor | None = None,
-    chunk_valid_sizes: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
 ):
     """
     Run the kernel in BSND mode and return fp64 CPU result.
 
     U_bsnd_fp16 : (B, S, N, D) half tensor on NPU where each (D, D) block
                   along the S dimension is one matrix to invert.
-    chunk_indices : optional int32 tensor containing the unpadded row start of
-                    each valid chunk for varlen BSND inputs.
-    chunk_valid_sizes : optional int32 tensor containing the runtime size of
-                        each chunk for varlen BSND inputs.
+    cu_seqlens : optional int32 tensor containing cumulative sequence lengths
+                 for varlen BSND inputs.
     """
     matrix_size = U_bsnd_fp16.shape[-1]
     num_bsnd_heads = U_bsnd_fp16.shape[-2]
-    if chunk_indices is not None and chunk_valid_sizes is not None:
-        num_matrices = chunk_indices.numel() * num_bsnd_heads
+    if cu_seqlens is not None:
+        seq_lens = cu_seqlens[1:].to(torch.int64) - cu_seqlens[:-1].to(torch.int64)
+        num_chunks = ((seq_lens + matrix_size - 1) // matrix_size).sum().item()
+        num_matrices = int(num_chunks) * num_bsnd_heads
     else:
         num_matrices = U_bsnd_fp16.numel() // (matrix_size * matrix_size)
     device = U_bsnd_fp16.device
 
     tensor_out = torch.zeros_like(U_bsnd_fp16, dtype=torch.float32)
     I_neg = _make_minus_identity(matrix_size, str(device))
-    if chunk_indices is not None:
-        chunk_indices = chunk_indices.to(device=device, dtype=torch.int32).contiguous()
-    if chunk_valid_sizes is not None:
-        chunk_valid_sizes = chunk_valid_sizes.to(
-            device=device,
-            dtype=torch.int32,
-        ).contiguous()
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.to(device=device, dtype=torch.int32).contiguous()
+        chunk_indices, chunk_valid_sizes = _chunk_metadata_from_cu_seqlens(
+            cu_seqlens,
+            matrix_size,
+        )
+        chunk_indices = chunk_indices.to(device=device).contiguous()
+        chunk_valid_sizes = chunk_valid_sizes.to(device=device).contiguous()
+    else:
+        chunk_indices = None
+        chunk_valid_sizes = None
 
     torch.npu.synchronize()
     tri_inv_func(
@@ -173,8 +210,6 @@ def _build_varlen_bsnd_case(
     Build an unpadded BSND tensor plus reference output for varlen testing.
 
     Each sequence contributes only its true rows in the packed BSND tensor.
-    chunk_indices records the unpadded row offset of every valid chunk and
-    chunk_valid_sizes stores each chunk's runtime size.
     """
     seq_lens = [
         cu_seqlens[i + 1] - cu_seqlens[i]
@@ -195,9 +230,6 @@ def _build_varlen_bsnd_case(
     U = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
     golden = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
 
-    chunk_indices: list[int] = []
-    chunk_valid_sizes: list[int] = []
-    chunk_infos: list[tuple[int, int, int]] = []
     chunk_idx = 0
 
     for seq_idx in range(len(cu_seqlens) - 1):
@@ -221,17 +253,12 @@ def _build_varlen_bsnd_case(
                     :actual_size,
                 ] = invert_single_chunk_ref(U_valid)
 
-            chunk_indices.append(chunk_start)
-            chunk_valid_sizes.append(actual_size)
-            chunk_infos.append((chunk_start, chunk_start, actual_size))
             chunk_idx += 1
 
     return (
         U,
         golden,
-        chunk_infos,
-        torch.tensor(chunk_indices, dtype=torch.int32),
-        torch.tensor(chunk_valid_sizes, dtype=torch.int32),
+        torch.tensor(cu_seqlens, dtype=torch.int32),
     )
 
 
@@ -318,7 +345,7 @@ def _test_case_bsnd_varlen(
     ftol: float,
     label: str,
 ):
-    U_varlen, golden, chunk_infos, chunk_indices, chunk_valid_sizes = _build_varlen_bsnd_case(
+    U_varlen, golden, cu_seqlens_tensor = _build_varlen_bsnd_case(
         gen,
         cu_seqlens,
         N,
@@ -327,23 +354,9 @@ def _test_case_bsnd_varlen(
     actual_varlen = _run_kernel_bsnd(
         tri_inv_func,
         U_varlen.to(torch.half).npu(),
-        chunk_indices=chunk_indices.npu(),
-        chunk_valid_sizes=chunk_valid_sizes.npu(),
+        cu_seqlens=cu_seqlens_tensor.npu(),
     )
-
-    actual = torch.zeros_like(golden)
-    for input_row, token_row, actual_size in chunk_infos:
-        actual[
-            :,
-            token_row : token_row + actual_size,
-            :,
-            :actual_size,
-        ] = actual_varlen[
-            :,
-            input_row : input_row + actual_size,
-            :,
-            :actual_size,
-        ]
+    actual = actual_varlen
 
     frob = torch.sqrt(
         torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -1,0 +1,178 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All rights reserved.
+# See LICENSE in the root of the software repository:
+# https://github.com/huawei-csl/pto-kernels/
+# for the full License text.
+# --------------------------------------------------------------------------------
+
+"""
+Correctness tests for the JIT-compiled triangular inverse (recursive unroll)
+kernel.  Run from the fast_inverse/ directory:
+
+    python run_fast_inverse.py
+"""
+
+import numpy as np
+import torch
+import torch_npu  # noqa: F401 – registers the NPU backend
+
+from jit_util_fast_inverse import jit_compile
+
+# ---------------------------------------------------------------------------
+# Reproducibility
+# ---------------------------------------------------------------------------
+torch.manual_seed(42)
+np.random.seed(42)
+
+# ---------------------------------------------------------------------------
+# Matrix generators  (identical to the unit-test suite)
+# ---------------------------------------------------------------------------
+
+def random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.1):
+    return scale * torch.triu(torch.rand((block_dim_x, block_dim_y, n, n)), diagonal=1)
+
+
+def ones_triu_matrix(n, block_dim_x, block_dim_y):
+    return torch.triu(torch.ones((block_dim_x, block_dim_y, n, n)), diagonal=1)
+
+
+def block_ones_triu_matrix(n, block_dim_x, block_dim_y):
+    U_ = np.ones((16, 16))
+    n_blocks = n // 16
+    U = np.zeros((block_dim_x, block_dim_y, n, n))
+    for x in range(block_dim_x):
+        for y in range(block_dim_y):
+            for i in range(n_blocks):
+                s, e = i * 16, i * 16 + 16
+                U[x, y, s:e, s:e] = U_
+    return torch.from_numpy(np.triu(U, 1))
+
+
+def block_random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.2):
+    U_ = np.triu(scale * np.random.rand(16, 16), k=1)
+    U = np.zeros((block_dim_x, block_dim_y, n, n))
+    for x in range(block_dim_x):
+        for y in range(block_dim_y):
+            for i in range(0, n, 16):
+                U[x, y, i : i + 16, i : i + 16] = U_.copy()
+    return torch.from_numpy(U)
+
+
+# ---------------------------------------------------------------------------
+# Reference implementation  (CPU / numpy)
+# ---------------------------------------------------------------------------
+
+def linalg_inv_ref(U: torch.Tensor) -> torch.Tensor:
+    """Invert (U + I) for each matrix in the batch using numpy."""
+    n = U.shape[-1]
+    identity = np.triu(np.tril(np.ones((n, n), dtype=np.double)))
+    out = np.zeros(U.shape)
+    for x in range(U.shape[0]):
+        for y in range(U.shape[1]):
+            out[x, y] = np.linalg.inv(U[x, y].numpy().astype(np.double) + identity)
+    return torch.from_numpy(out)
+
+
+# ---------------------------------------------------------------------------
+# Kernel helpers
+# ---------------------------------------------------------------------------
+
+def _make_minus_identity(matrix_size: int, device: str) -> torch.Tensor:
+    I_neg = torch.zeros(matrix_size, matrix_size, dtype=torch.half, device=device)
+    I_neg.fill_diagonal_(-1)
+    return I_neg
+
+
+def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
+    """
+    Allocate output, build -I, run kernel, return fp64 CPU result.
+
+    U_fp16 : (block_dim_x, block_dim_y, n, n) half tensor on NPU.
+    """
+    matrix_size = U_fp16.shape[-1]
+    num_matrices = U_fp16.numel() // (matrix_size * matrix_size)
+    device = U_fp16.device
+
+    tensor_out = torch.zeros_like(U_fp16, dtype=torch.float32)
+    I_neg = _make_minus_identity(matrix_size, str(device))
+
+    torch.npu.synchronize()
+    tri_inv_func(tensor_out, U_fp16, I_neg, matrix_size, num_matrices)
+    torch.npu.synchronize()
+
+    return tensor_out.cpu().to(torch.float64)
+
+
+# ---------------------------------------------------------------------------
+# Single test
+# ---------------------------------------------------------------------------
+
+def _test_case(tri_inv_func, U: torch.Tensor, atol: float, rtol: float, ftol: float,
+               label: str):
+    U_fp16 = U.to(torch.half)
+    golden = linalg_inv_ref(U_fp16)
+
+    actual = _run_kernel(tri_inv_func, U_fp16.npu())
+
+    frob = torch.sqrt(
+        torch.sum((golden - actual) ** 2) / torch.sum(golden ** 2)
+    ).item()
+
+    assert np.allclose(
+        actual.numpy(), golden.numpy(), atol=atol, rtol=rtol
+    ), f"[{label}] allclose failed — shape {U.shape}, rtol={rtol}"
+    assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
+
+    print(f"  PASS  {label}  frob={frob:.2e}")
+
+
+# ---------------------------------------------------------------------------
+# Test suite
+# ---------------------------------------------------------------------------
+
+def run_tests(tri_inv_func):
+    cases = [
+        ("block_ones",   block_ones_triu_matrix,   0,    0,    0),
+        ("ones",         ones_triu_matrix,          0,    0,    0),
+        ("block_random", block_random_triu_matrix,  5e-5, 0.1,  1e-4),
+        ("random",       random_triu_matrix,        5e-5, 0.1,  1e-4),
+    ]
+    sizes   = [16, 32, 64, 128]
+    x_dims  = [1, 2, 4]
+    y_dims  = [2, 4]
+
+    total = passed = 0
+    for n in sizes:
+        for bdx in x_dims:
+            for bdy in y_dims:
+                for name, gen, atol, rtol, ftol in cases:
+                    total += 1
+                    label = f"n={n} x={bdx} y={bdy} [{name}]"
+                    try:
+                        U = gen(n, bdx, bdy)
+                        _test_case(tri_inv_func, U, atol, rtol, ftol, label)
+                        passed += 1
+                    except AssertionError as err:
+                        print(f"  FAIL  {label}: {err}")
+
+    print(f"\n{passed}/{total} tests passed.")
+    return passed == total
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import os
+
+    torch.npu.set_device("npu:0")
+
+    src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fast_inverse.cpp")
+    print(f"Compiling {src} ...")
+    tri_inv_func = jit_compile(src)
+    print("Compilation successful.\n")
+
+    ok = run_tests(tri_inv_func)
+    raise SystemExit(0 if ok else 1)

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -117,24 +117,35 @@ def _run_kernel_bsnd(
     tri_inv_func,
     U_bsnd_fp16: torch.Tensor,
     chunk_indices: torch.Tensor | None = None,
+    chunk_valid_sizes: torch.Tensor | None = None,
 ):
     """
     Run the kernel in BSND mode and return fp64 CPU result.
 
     U_bsnd_fp16 : (B, S, N, D) half tensor on NPU where each (D, D) block
                   along the S dimension is one matrix to invert.
-    chunk_indices : optional int32 tensor containing the padded row start of
+    chunk_indices : optional int32 tensor containing the unpadded row start of
                     each valid chunk for varlen BSND inputs.
+    chunk_valid_sizes : optional int32 tensor containing the runtime size of
+                        each chunk for varlen BSND inputs.
     """
     matrix_size = U_bsnd_fp16.shape[-1]
     num_bsnd_heads = U_bsnd_fp16.shape[-2]
-    num_matrices = U_bsnd_fp16.numel() // (matrix_size * matrix_size)
+    if chunk_indices is not None and chunk_valid_sizes is not None:
+        num_matrices = chunk_indices.numel() * num_bsnd_heads
+    else:
+        num_matrices = U_bsnd_fp16.numel() // (matrix_size * matrix_size)
     device = U_bsnd_fp16.device
 
     tensor_out = torch.zeros_like(U_bsnd_fp16, dtype=torch.float32)
     I_neg = _make_minus_identity(matrix_size, str(device))
     if chunk_indices is not None:
         chunk_indices = chunk_indices.to(device=device, dtype=torch.int32).contiguous()
+    if chunk_valid_sizes is not None:
+        chunk_valid_sizes = chunk_valid_sizes.to(
+            device=device,
+            dtype=torch.int32,
+        ).contiguous()
 
     torch.npu.synchronize()
     tri_inv_func(
@@ -145,6 +156,7 @@ def _run_kernel_bsnd(
         num_matrices,
         num_bsnd_heads,
         chunk_indices=chunk_indices,
+        chunk_valid_sizes=chunk_valid_sizes,
     )
     torch.npu.synchronize()
 
@@ -158,10 +170,11 @@ def _build_varlen_bsnd_case(
     chunk_size: int,
 ):
     """
-    Build a padded BSND tensor plus reference output for varlen testing.
+    Build an unpadded BSND tensor plus reference output for varlen testing.
 
-    Each sequence is padded independently to the next multiple of chunk_size.
-    chunk_indices records the padded row offset of every valid chunk.
+    Each sequence contributes only its true rows in the packed BSND tensor.
+    chunk_indices records the unpadded row offset of every valid chunk and
+    chunk_valid_sizes stores each chunk's runtime size.
     """
     seq_lens = [
         cu_seqlens[i + 1] - cu_seqlens[i]
@@ -179,14 +192,13 @@ def _build_varlen_bsnd_case(
     )
     chunk_mats = gen(chunk_size, num_chunks, num_heads).to(torch.float64)
 
-    padded_total = num_chunks * chunk_size
-    U_padded = torch.zeros((1, padded_total, num_heads, chunk_size), dtype=torch.float64)
+    U = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
     golden = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
 
     chunk_indices: list[int] = []
+    chunk_valid_sizes: list[int] = []
     chunk_infos: list[tuple[int, int, int]] = []
     chunk_idx = 0
-    padded_row = 0
 
     for seq_idx in range(len(cu_seqlens) - 1):
         seq_start = cu_seqlens[seq_idx]
@@ -196,9 +208,9 @@ def _build_varlen_bsnd_case(
             chunk = chunk_mats[chunk_idx]
             for head_idx in range(num_heads):
                 U_valid = chunk[head_idx, :actual_size, :actual_size]
-                U_padded[
+                U[
                     0,
-                    padded_row : padded_row + actual_size,
+                    chunk_start : chunk_start + actual_size,
                     head_idx,
                     :actual_size,
                 ] = U_valid
@@ -209,12 +221,18 @@ def _build_varlen_bsnd_case(
                     :actual_size,
                 ] = invert_single_chunk_ref(U_valid)
 
-            chunk_indices.append(padded_row)
-            chunk_infos.append((padded_row, chunk_start, actual_size))
-            padded_row += chunk_size
+            chunk_indices.append(chunk_start)
+            chunk_valid_sizes.append(actual_size)
+            chunk_infos.append((chunk_start, chunk_start, actual_size))
             chunk_idx += 1
 
-    return U_padded, golden, chunk_infos, torch.tensor(chunk_indices, dtype=torch.int32)
+    return (
+        U,
+        golden,
+        chunk_infos,
+        torch.tensor(chunk_indices, dtype=torch.int32),
+        torch.tensor(chunk_valid_sizes, dtype=torch.int32),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -300,28 +318,29 @@ def _test_case_bsnd_varlen(
     ftol: float,
     label: str,
 ):
-    U_padded, golden, chunk_infos, chunk_indices = _build_varlen_bsnd_case(
+    U_varlen, golden, chunk_infos, chunk_indices, chunk_valid_sizes = _build_varlen_bsnd_case(
         gen,
         cu_seqlens,
         N,
         D,
     )
-    actual_padded = _run_kernel_bsnd(
+    actual_varlen = _run_kernel_bsnd(
         tri_inv_func,
-        U_padded.to(torch.half).npu(),
+        U_varlen.to(torch.half).npu(),
         chunk_indices=chunk_indices.npu(),
+        chunk_valid_sizes=chunk_valid_sizes.npu(),
     )
 
     actual = torch.zeros_like(golden)
-    for padded_row, token_row, actual_size in chunk_infos:
+    for input_row, token_row, actual_size in chunk_infos:
         actual[
             :,
             token_row : token_row + actual_size,
             :,
             :actual_size,
-        ] = actual_padded[
+        ] = actual_varlen[
             :,
-            padded_row : padded_row + actual_size,
+            input_row : input_row + actual_size,
             :,
             :actual_size,
         ]

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse.py
@@ -7,15 +7,18 @@
 # --------------------------------------------------------------------------------
 
 """
-Correctness tests for the JIT-compiled triangular inverse (recursive unroll)
+Sanity-check tests for the JIT-compiled triangular inverse (recursive unroll)
 kernel. Run from the fast_inverse/ directory:
 
     python run_fast_inverse.py
+
+For more detailed test cases see also tests/test_tri_inv_rec_unroll.py
+and tests/test_tri_inv_rec_unroll_variable_sequence_lengths.py
 """
 
 import numpy as np
 import torch
-import torch_npu  # noqa: F401 – registers the NPU backend
+import torch_npu  # noqa
 
 from jit_util_fast_inverse import jit_compile
 
@@ -27,7 +30,7 @@ np.random.seed(42)
 
 
 # ---------------------------------------------------------------------------
-# Matrix generators (identical to the unit-test suite)
+# Matrix generator (identical to the unit-test suite)
 # ---------------------------------------------------------------------------
 def random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.1):
     return scale * torch.triu(
@@ -36,46 +39,9 @@ def random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.1):
     )
 
 
-def ones_triu_matrix(n, block_dim_x, block_dim_y):
-    return torch.triu(torch.ones((block_dim_x, block_dim_y, n, n)), diagonal=1)
-
-
-def block_ones_triu_matrix(n, block_dim_x, block_dim_y):
-    U_ = np.ones((16, 16))
-    n_blocks = n // 16
-    U = np.zeros((block_dim_x, block_dim_y, n, n))
-    for x in range(block_dim_x):
-        for y in range(block_dim_y):
-            for i in range(n_blocks):
-                s, e = i * 16, i * 16 + 16
-                U[x, y, s:e, s:e] = U_
-    return torch.from_numpy(np.triu(U, 1))
-
-
-def block_random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.2):
-    U_ = np.triu(scale * np.random.rand(16, 16), k=1)
-    U = np.zeros((block_dim_x, block_dim_y, n, n))
-    for x in range(block_dim_x):
-        for y in range(block_dim_y):
-            for i in range(0, n, 16):
-                U[x, y, i : i + 16, i : i + 16] = U_.copy()
-    return torch.from_numpy(U)
-
-
 # ---------------------------------------------------------------------------
 # Reference implementation (CPU / numpy)
 # ---------------------------------------------------------------------------
-def linalg_inv_ref(U: torch.Tensor) -> torch.Tensor:
-    """Invert (U + I) for each matrix in the batch using numpy."""
-    n = U.shape[-1]
-    identity = np.eye(n, dtype=np.double)
-    out = np.zeros(U.shape, dtype=np.double)
-    for x in range(U.shape[0]):
-        for y in range(U.shape[1]):
-            out[x, y] = np.linalg.inv(U[x, y].numpy().astype(np.double) + identity)
-    return torch.from_numpy(out)
-
-
 def invert_single_chunk_ref(U: torch.Tensor) -> torch.Tensor:
     """Invert one upper-triangular chunk U where U is (..., m, m)."""
     m = U.shape[-1]
@@ -105,26 +71,6 @@ def _count_varlen_chunks(
         (cu_seqlens_list[i + 1] - cu_seqlens_list[i] + chunk_size - 1) // chunk_size
         for i in range(len(cu_seqlens_list) - 1)
     )
-
-
-def _run_kernel(tri_inv_func, U_fp16: torch.Tensor):
-    """
-    Allocate output, build -I, run kernel, return fp64 CPU result.
-
-    U_fp16 : (block_dim_x, block_dim_y, n, n) half tensor on NPU.
-    """
-    matrix_size = U_fp16.shape[-1]
-    num_matrices = U_fp16.numel() // (matrix_size * matrix_size)
-    device = U_fp16.device
-
-    tensor_out = torch.zeros_like(U_fp16, dtype=torch.float32)
-    I_neg = _make_minus_identity(matrix_size, str(device))
-
-    torch.npu.synchronize()
-    tri_inv_func(tensor_out, U_fp16, I_neg, matrix_size, num_matrices)
-    torch.npu.synchronize()
-
-    return tensor_out.cpu().to(torch.float64)
 
 
 def _run_kernel_bsnd(
@@ -169,7 +115,6 @@ def _run_kernel_bsnd(
 
 
 def _build_varlen_bsnd_case(
-    gen,
     cu_seqlens: list[int],
     num_heads: int,
     chunk_size: int,
@@ -190,7 +135,7 @@ def _build_varlen_bsnd_case(
         (cu_seqlens[i + 1] - cu_seqlens[i] + chunk_size - 1) // chunk_size
         for i in range(len(cu_seqlens) - 1)
     )
-    chunk_mats = gen(chunk_size, num_chunks, num_heads).to(torch.float64)
+    chunk_mats = random_triu_matrix(chunk_size, num_chunks, num_heads).to(torch.float64)
 
     U = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
     golden = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float64)
@@ -228,86 +173,19 @@ def _build_varlen_bsnd_case(
 
 
 # ---------------------------------------------------------------------------
-# Single test – standard layout
+# Single test – BSND varlen layout
 # ---------------------------------------------------------------------------
-def _test_case(
-    tri_inv_func,
-    U: torch.Tensor,
-    atol: float,
-    rtol: float,
-    ftol: float,
-    label: str,
-):
-    U_fp16 = U.to(torch.half)
-    golden = linalg_inv_ref(U_fp16)
-
-    actual = _run_kernel(tri_inv_func, U_fp16.npu())
-
-    frob = torch.sqrt(torch.sum((golden - actual) ** 2) / torch.sum(golden**2)).item()
-
-    assert np.allclose(
-        actual.numpy(),
-        golden.numpy(),
-        atol=atol,
-        rtol=rtol,
-    ), f"[{label}] allclose failed — shape {U.shape}, rtol={rtol}"
-    assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
-
-    print(f"  PASS  {label}  frob={frob:.2e}")
-
-
-# ---------------------------------------------------------------------------
-# Single test – BSND layout
-# ---------------------------------------------------------------------------
-def _test_case_bsnd(
-    tri_inv_func,
-    U: torch.Tensor,
-    B: int,
-    S: int,
-    N: int,
-    D: int,
-    atol: float,
-    rtol: float,
-    ftol: float,
-    label: str,
-):
-    """
-    U has shape (B*S//D, N, D, D) – the raw generator output.
-    It is converted to (B, S, N, D) before being fed to the kernel.
-    """
-    U_fp16 = U.to(torch.half)
-    golden = linalg_inv_ref(U_fp16)
-    golden = golden.transpose(1, 2).contiguous().reshape(B, S, N, D)
-
-    U_bsnd = U_fp16.transpose(1, 2).contiguous().reshape(B, S, N, D)
-    actual = _run_kernel_bsnd(tri_inv_func, U_bsnd.npu())
-
-    frob = torch.sqrt(torch.sum((golden - actual) ** 2) / torch.sum(golden**2)).item()
-
-    assert np.allclose(
-        actual.numpy(),
-        golden.numpy(),
-        atol=atol,
-        rtol=rtol,
-    ), f"[{label}] allclose failed — shape {U_bsnd.shape}, rtol={rtol}"
-    assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
-
-    print(f"  PASS  {label}  frob={frob:.2e}")
 
 
 def _test_case_bsnd_varlen(
     tri_inv_func,
-    gen,
     cu_seqlens: list[int],
     N: int,
     D: int,
-    atol: float,
-    rtol: float,
-    ftol: float,
     label: str,
 ):
+
     U_varlen, golden, cu_seqlens_tensor = _build_varlen_bsnd_case(
-        gen,
         cu_seqlens,
         N,
         D,
@@ -321,12 +199,15 @@ def _test_case_bsnd_varlen(
 
     frob = torch.sqrt(torch.sum((golden - actual) ** 2) / torch.sum(golden**2)).item()
 
+    atol = 5e-5
+    rtol = 5e-2
+    ftol = 1e-4
     assert np.allclose(
         actual.numpy(),
         golden.numpy(),
         atol=atol,
         rtol=rtol,
-    ), f"[{label}] allclose failed — shape {actual.shape}, rtol={rtol}"
+    ), f"[{label}] allclose failed - shape {actual.shape}, rtol={rtol}"
     assert frob <= ftol, f"[{label}] Frobenius error {frob:.2e} > {ftol:.2e}"
 
     print(f"  PASS  {label}  frob={frob:.2e}")
@@ -336,53 +217,8 @@ def _test_case_bsnd_varlen(
 # Test suite
 # ---------------------------------------------------------------------------
 def run_tests(tri_inv_func):
-    cases = [
-        ("block_ones", block_ones_triu_matrix, 0, 0, 0),
-        ("ones", ones_triu_matrix, 0, 0, 0),
-        ("block_random", block_random_triu_matrix, 5e-5, 0.1, 1e-4),
-        ("random", random_triu_matrix, 5e-5, 0.1, 1e-4),
-    ]
 
     total = passed = 0
-
-    print("=== Standard layout ===")
-    sizes = [16, 32, 64, 128]
-    x_dims = [1, 2, 4]
-    y_dims = [2, 4]
-
-    for n in sizes:
-        for bdx in x_dims:
-            for bdy in y_dims:
-                for name, gen, atol, rtol, ftol in cases:
-                    total += 1
-                    label = f"n={n} x={bdx} y={bdy} [{name}]"
-                    try:
-                        U = gen(n, bdx, bdy)
-                        _test_case(tri_inv_func, U, atol, rtol, ftol, label)
-                        passed += 1
-                    except AssertionError as err:
-                        print(f"  FAIL  {label}: {err}")
-
-    print("\n=== BSND layout ===")
-    bsnd_configs = [
-        (B, S, N, D)
-        for B in [1, 4]
-        for S in [128, 256]
-        for N in [4, 8]
-        for D in [16, 32, 64, 128]
-        if S % D == 0
-    ]
-
-    for B, S, N, D in bsnd_configs:
-        for name, gen, atol, rtol, ftol in cases:
-            total += 1
-            label = f"B={B} S={S} N={N} D={D} [{name}]"
-            try:
-                U = gen(D, B * S // D, N)
-                _test_case_bsnd(tri_inv_func, U, B, S, N, D, atol, rtol, ftol, label)
-                passed += 1
-            except AssertionError as err:
-                print(f"  FAIL  {label}: {err}")
 
     print("\n=== BSND varlen layout ===")
     varlen_configs = [
@@ -392,26 +228,20 @@ def run_tests(tri_inv_func):
         (4, 16, [0, 1, 100, 300, 1200, 2048]),
         (4, 32, [0, 200, 512, 1200, 2048]),
     ]
-
     for N, D, cu_seqlens in varlen_configs:
-        for name, gen, atol, rtol, ftol in cases:
-            total += 1
-            label = f"N={N} D={D} cu={cu_seqlens} [{name}]"
-            try:
-                _test_case_bsnd_varlen(
-                    tri_inv_func,
-                    gen,
-                    cu_seqlens,
-                    N,
-                    D,
-                    atol,
-                    rtol,
-                    ftol,
-                    label,
-                )
-                passed += 1
-            except AssertionError as err:
-                print(f"  FAIL  {label}: {err}")
+        total += 1
+        label = f"N={N} D={D} cu={cu_seqlens}"
+        try:
+            _test_case_bsnd_varlen(
+                tri_inv_func,
+                cu_seqlens,
+                N,
+                D,
+                label,
+            )
+            passed += 1
+        except AssertionError as err:
+            print(f"  FAIL  {label}: {err}")
 
     print(f"\n{passed}/{total} tests passed.")
     return passed == total

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse_varlen_like_triton.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse_varlen_like_triton.py
@@ -41,7 +41,9 @@ def _make_minus_identity(matrix_size: int, device: torch.device) -> torch.Tensor
 def _count_varlen_chunks(cu_seqlens: torch.Tensor, chunk_size: int) -> int:
     return sum(
         (int(eos) - int(bos) + chunk_size - 1) // chunk_size
-        for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False)
+        for bos, eos in zip(
+            cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+        )
     )
 
 
@@ -55,7 +57,9 @@ def _chunk_scaled_dot_kkt_fwd_emulated(
     num_heads = k.shape[2]
     A = torch.zeros((1, t_total, num_heads, chunk_size), dtype=k.dtype, device=k.device)
 
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+    for bos, eos in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
         for chunk_start in range(bos, eos, chunk_size):
             chunk_end = min(chunk_start + chunk_size, eos)
             actual_size = chunk_end - chunk_start
@@ -73,16 +77,24 @@ def _chunk_scaled_dot_kkt_fwd_emulated(
     return A
 
 
-def _reference_inverse(A: torch.Tensor, cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+def _reference_inverse(
+    A: torch.Tensor, cu_seqlens: torch.Tensor, chunk_size: int
+) -> torch.Tensor:
     A_cpu = A.cpu().to(torch.float64)
     ref = torch.zeros_like(A_cpu, dtype=torch.float64)
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+    for bos, eos in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
         for chunk_start in range(bos, eos, chunk_size):
             actual_size = min(chunk_size, eos - chunk_start)
-            ref[:, chunk_start : chunk_start + actual_size, :, :actual_size] = torch.inverse(
-                A_cpu[:, chunk_start : chunk_start + actual_size, :, :actual_size].transpose(1, 2)
-                + torch.eye(actual_size, dtype=torch.float64)[None, None, ...]
-            ).transpose(1, 2)
+            ref[:, chunk_start : chunk_start + actual_size, :, :actual_size] = (
+                torch.inverse(
+                    A_cpu[
+                        :, chunk_start : chunk_start + actual_size, :, :actual_size
+                    ].transpose(1, 2)
+                    + torch.eye(actual_size, dtype=torch.float64)[None, None, ...]
+                ).transpose(1, 2)
+            )
     return ref
 
 
@@ -92,17 +104,21 @@ def _transpose_valid_chunks(
     chunk_size: int,
 ) -> torch.Tensor:
     transposed = torch.zeros_like(A)
-    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+    for bos, eos in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
         for chunk_start in range(bos, eos, chunk_size):
             actual_size = min(chunk_size, eos - chunk_start)
             chunk = A[:, chunk_start : chunk_start + actual_size, :, :actual_size]
-            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = chunk.transpose(
-                1, 3
+            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = (
+                chunk.transpose(1, 3)
             )
     return transposed
 
 
-def _run_pto_varlen(tri_inv_func, A: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+def _run_pto_varlen(
+    tri_inv_func, A: torch.Tensor, cu_seqlens: torch.Tensor
+) -> torch.Tensor:
     chunk_size = A.shape[-1]
     num_heads = A.shape[-2]
     num_matrices = _count_varlen_chunks(cu_seqlens, chunk_size) * num_heads
@@ -138,7 +154,9 @@ def _run_case(
     cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int32, device=device)
 
     # Match the Triton varlen test structure, using fp16 instead of bf16.
-    k = F.normalize(torch.randn((1, T, H, D), dtype=torch.float16, device=device), dim=-1)
+    k = F.normalize(
+        torch.randn((1, T, H, D), dtype=torch.float16, device=device), dim=-1
+    )
     beta = torch.randn((1, T, H), dtype=torch.float16, device=device).sigmoid()
     A = _chunk_scaled_dot_kkt_fwd_emulated(
         k=k,
@@ -155,7 +173,7 @@ def _run_case(
     )
     tri = _transpose_valid_chunks(tri, cu_seqlens, chunk_size)
 
-    frob = torch.sqrt(torch.sum((ref - tri) ** 2) / torch.sum(ref ** 2)).item()
+    frob = torch.sqrt(torch.sum((ref - tri) ** 2) / torch.sum(ref**2)).item()
     torch.testing.assert_close(tri, ref, atol=atol, rtol=rtol)
     assert frob <= ftol, f"Frobenius error {frob:.2e} > {ftol:.2e}"
 

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse_varlen_like_triton.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse_varlen_like_triton.py
@@ -1,0 +1,202 @@
+"""
+Standalone varlen BSND correctness runner that mirrors the Triton unit tests:
+https://github.com/fla-org/flash-linear-attention/blob/v0.4.2/tests/ops/test_solve_tril.py
+
+But changes:
+1. uses fp16 inputs because the PTO kernel currently supports fp16 only
+2. emulates `chunk_scaled_dot_kkt_fwd` in PyTorch because Triton is unavailable
+
+Run from the fast_inverse/ directory:
+
+    export PTO_LIB_PATH=/sources/pto-isa
+    python run_fast_inverse_varlen_like_triton.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import torch_npu  # noqa: F401
+
+from jit_util_fast_inverse import jit_compile
+
+
+torch.manual_seed(42)
+np.random.seed(42)
+
+
+def _make_minus_identity(matrix_size: int, device: torch.device) -> torch.Tensor:
+    minus_identity = torch.zeros(
+        (matrix_size, matrix_size),
+        dtype=torch.float16,
+        device=device,
+    )
+    minus_identity.fill_diagonal_(-1)
+    return minus_identity
+
+
+def _count_varlen_chunks(cu_seqlens: torch.Tensor, chunk_size: int) -> int:
+    return sum(
+        (int(eos) - int(bos) + chunk_size - 1) // chunk_size
+        for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False)
+    )
+
+
+def _chunk_scaled_dot_kkt_fwd_emulated(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    t_total = int(cu_seqlens[-1].item())
+    num_heads = k.shape[2]
+    A = torch.zeros((1, t_total, num_heads, chunk_size), dtype=k.dtype, device=k.device)
+
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        for chunk_start in range(bos, eos, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, eos)
+            actual_size = chunk_end - chunk_start
+            k_chunk = k[:, chunk_start:chunk_end].transpose(1, 2).to(torch.float32)
+            beta_chunk = (
+                beta[:, chunk_start:chunk_end]
+                .transpose(1, 2)
+                .unsqueeze(-1)
+                .to(torch.float32)
+            )
+            scores = torch.matmul(k_chunk, k_chunk.transpose(-1, -2))
+            scores = torch.tril(scores * beta_chunk, diagonal=-1).to(k.dtype)
+            A[:, chunk_start:chunk_end, :, :actual_size] = scores.transpose(1, 2)
+
+    return A
+
+
+def _reference_inverse(A: torch.Tensor, cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    A_cpu = A.cpu().to(torch.float64)
+    ref = torch.zeros_like(A_cpu, dtype=torch.float64)
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        for chunk_start in range(bos, eos, chunk_size):
+            actual_size = min(chunk_size, eos - chunk_start)
+            ref[:, chunk_start : chunk_start + actual_size, :, :actual_size] = torch.inverse(
+                A_cpu[:, chunk_start : chunk_start + actual_size, :, :actual_size].transpose(1, 2)
+                + torch.eye(actual_size, dtype=torch.float64)[None, None, ...]
+            ).transpose(1, 2)
+    return ref
+
+
+def _transpose_valid_chunks(
+    A: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    transposed = torch.zeros_like(A)
+    for bos, eos in zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False):
+        for chunk_start in range(bos, eos, chunk_size):
+            actual_size = min(chunk_size, eos - chunk_start)
+            chunk = A[:, chunk_start : chunk_start + actual_size, :, :actual_size]
+            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = chunk.transpose(
+                1, 3
+            )
+    return transposed
+
+
+def _run_pto_varlen(tri_inv_func, A: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+    chunk_size = A.shape[-1]
+    num_heads = A.shape[-2]
+    num_matrices = _count_varlen_chunks(cu_seqlens, chunk_size) * num_heads
+    tensor_out = torch.zeros_like(A, dtype=torch.float32)
+    minus_identity = _make_minus_identity(chunk_size, A.device)
+
+    torch.npu.synchronize()
+    tri_inv_func(
+        tensor_out,
+        A,
+        minus_identity,
+        chunk_size,
+        num_matrices,
+        num_heads,
+        cu_seqlens=cu_seqlens,
+    )
+    torch.npu.synchronize()
+    return tensor_out.cpu().to(torch.float64)
+
+
+def _run_case(
+    tri_inv_func,
+    H: int,
+    D: int,
+    chunk_size: int,
+    cu_seqlens_list: list[int],
+    atol: float = 5e-4,
+    rtol: float = 5e-2,
+    ftol: float = 1e-4,
+) -> None:
+    device = torch.device("npu:0")
+    T = cu_seqlens_list[-1]
+    cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int32, device=device)
+
+    # Match the Triton varlen test structure, using fp16 instead of bf16.
+    k = F.normalize(torch.randn((1, T, H, D), dtype=torch.float16, device=device), dim=-1)
+    beta = torch.randn((1, T, H), dtype=torch.float16, device=device).sigmoid()
+    A = _chunk_scaled_dot_kkt_fwd_emulated(
+        k=k,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+
+    ref = _reference_inverse(A, cu_seqlens, chunk_size)
+    tri = _run_pto_varlen(
+        tri_inv_func,
+        _transpose_valid_chunks(A, cu_seqlens, chunk_size),
+        cu_seqlens,
+    )
+    tri = _transpose_valid_chunks(tri, cu_seqlens, chunk_size)
+
+    frob = torch.sqrt(torch.sum((ref - tri) ** 2) / torch.sum(ref ** 2)).item()
+    torch.testing.assert_close(tri, ref, atol=atol, rtol=rtol)
+    assert frob <= ftol, f"Frobenius error {frob:.2e} > {ftol:.2e}"
+
+
+def main() -> int:
+    if "PTO_LIB_PATH" not in os.environ:
+        fallback = "/sources/pto-isa"
+        if os.path.exists(fallback):
+            os.environ["PTO_LIB_PATH"] = fallback
+
+    torch.npu.set_device("npu:0")
+
+    src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fast_inverse.cpp")
+    print(f"Compiling {src} ...")
+    tri_inv_func = jit_compile(src)
+    print("Compilation successful.\n")
+
+    cases = [
+        (4, 64, 16, [0, 15]),
+        (4, 64, 32, [0, 256, 500, 1000]),
+        (4, 100, 64, [0, 15, 100, 300, 1200, 2000]),
+        (4, 64, 16, [0, 1, 100, 300, 1200, 2048]),
+        (4, 128, 32, [0, 200, 512, 1200, 2048]),
+    ]
+
+    total = 0
+    passed = 0
+    print("=== Varlen Like Triton ===")
+    for H, D, chunk_size, cu_seqlens in cases:
+        total += 1
+        label = f"H={H} D={D} chunk_size={chunk_size} cu_seqlens={cu_seqlens}"
+        try:
+            _run_case(tri_inv_func, H, D, chunk_size, cu_seqlens)
+            print(f"  PASS  {label}")
+            passed += 1
+        except Exception as err:
+            print(f"  FAIL  {label}: {err}")
+
+    print(f"\n{passed}/{total} cases passed.")
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/jit_cpp/fast_inverse/run_fast_inverse_varlen_like_triton.py
+++ b/examples/jit_cpp/fast_inverse/run_fast_inverse_varlen_like_triton.py
@@ -19,7 +19,7 @@ import os
 import numpy as np
 import torch
 import torch.nn.functional as F
-import torch_npu  # noqa: F401
+import torch_npu  # noqa
 
 from jit_util_fast_inverse import jit_compile
 

--- a/tests/test_tri_inv_rec_unroll_variable_sequence_lengths.py
+++ b/tests/test_tri_inv_rec_unroll_variable_sequence_lengths.py
@@ -1,0 +1,241 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All rights reserved.
+# See LICENSE in the root of the software repository:
+# https://github.com/huawei-csl/pto-kernels/
+# for the full License text.
+# --------------------------------------------------------------------------------
+
+
+import torch
+import torch.nn.functional as torch_functional
+import pytest
+import numpy as np
+import random
+from pto_kernels import pto_tri_inv_rec_unroll
+
+random.seed(42)
+torch.manual_seed(42)
+np.random.seed(42)
+
+
+def generate_random_sequence_lengths(
+    num_sequences: int, total_tokens: int
+) -> list[int]:
+    """
+    Generates a list of num_sequences integers in the range (1, total_tokens).
+    These integers denote the index where each "input sequence" ends.
+    """
+    if total_tokens < num_sequences:
+        raise ValueError("total_tokens must be >= num_sequences.")
+
+    # num_sequences-1 sorted random integers in the range [1,...,total_tokens-1]
+    cummulative_lengths = sorted(
+        list(np.random.choice(total_tokens - 2, num_sequences - 1, replace=False) + 1)
+    )
+    cummulative_lengths = [0] + cummulative_lengths
+    cummulative_lengths.append(total_tokens)
+    return [
+        cummulative_lengths[i + 1] - cummulative_lengths[i]
+        for i in range(len(cummulative_lengths) - 1)
+    ]
+
+
+def transpose_valid_chunks(
+    A: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    transposed = torch.zeros_like(A)
+    for seq_start, seq_end in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            actual_size = min(chunk_size, seq_end - chunk_start)
+            chunk = A[:, chunk_start : chunk_start + actual_size, :, :actual_size]
+            transposed[:, chunk_start : chunk_start + actual_size, :, :actual_size] = (
+                chunk.transpose(1, 3)
+            )
+    return transposed
+
+
+def chunk_scaled_dot_kkt_fwd_emulated(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    total_tokens = int(cu_seqlens[-1].item())
+    num_heads = k.shape[2]
+    A = torch.zeros(
+        (1, total_tokens, num_heads, chunk_size), dtype=k.dtype, device=k.device
+    )
+
+    for seq_start, seq_end in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_end)
+            actual_size = chunk_end - chunk_start
+            k_chunk = (
+                k[:, chunk_start:chunk_end].transpose(1, 2).to(torch.float32).npu()
+            )
+            beta_chunk = (
+                beta[:, chunk_start:chunk_end]
+                .transpose(1, 2)
+                .unsqueeze(-1)
+                .to(torch.float32)
+                .npu()
+            )
+            scores = torch.matmul(k_chunk, k_chunk.transpose(-1, -2))
+            scores = torch.tril(scores * beta_chunk, diagonal=-1)  # .to(k.dtype)
+            scores = torch.tril(torch.ones(scores.shape), diagonal=-1).to(k.dtype).npu()
+            A[:, chunk_start:chunk_end, :, :actual_size] = scores.transpose(1, 2)
+
+    return A
+
+
+def all_ones_varlen_triangular_tensor(
+    cu_seqlens: torch.Tensor, chunk_size: int, num_heads: int, feature_dim: int
+) -> torch.Tensor:
+    total_tokens = int(cu_seqlens[-1].item())
+    A = torch.zeros((1, total_tokens, num_heads, chunk_size), dtype=torch.float16)
+    ones_tensor = torch.ones(
+        (1, total_tokens, num_heads, feature_dim),
+        dtype=torch.float16,
+    )
+    for seq_start, seq_end in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_end)
+            actual_size = chunk_end - chunk_start
+            chunk_shape = list(
+                ones_tensor[:, chunk_start:chunk_end].transpose(1, 2).shape
+            )
+            chunk_shape[-1] = chunk_shape[-2]
+            chunk = torch.tril(torch.ones(chunk_shape), diagonal=-1)  # .to(k.dtype)
+            A[:, chunk_start:chunk_end, :, :actual_size] = chunk.transpose(1, 2)
+
+    return A
+
+
+def build_variable_len_input(
+    seq_lens: list[int],
+    num_heads: int,
+    chunk_size: int,
+    feature_dim: int,
+    matrix_type: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cu_seqlens = np.cumsum([0, *seq_lens], dtype=np.int64)
+    cu_seqlens_tensor = torch.tensor(cu_seqlens.tolist(), dtype=torch.int32)
+    total_tokens = int(cu_seqlens[-1])
+    if matrix_type == "ones":
+        packed_input = transpose_valid_chunks(
+            all_ones_varlen_triangular_tensor(
+                cu_seqlens_tensor, chunk_size, num_heads, feature_dim
+            ),
+            cu_seqlens_tensor,
+            chunk_size,
+        )
+    elif matrix_type == "random":
+        k = torch_functional.normalize(
+            torch.randn(
+                (1, total_tokens, num_heads, feature_dim),
+                dtype=torch.float16,
+            ),
+            dim=-1,
+        )
+        beta = torch.randn((1, total_tokens, num_heads), dtype=torch.float16).sigmoid()
+        packed_input = transpose_valid_chunks(
+            chunk_scaled_dot_kkt_fwd_emulated(k, beta, cu_seqlens_tensor, chunk_size),
+            cu_seqlens_tensor,
+            chunk_size,
+        )
+    else:
+        raise RuntimeError(f"unknown matrix type to test: {matrix_type}")
+    return packed_input.contiguous().npu(), cu_seqlens_tensor.npu()
+
+
+def _reference_inverse(
+    A: torch.Tensor, cu_seqlens: torch.Tensor, chunk_size: int
+) -> torch.Tensor:
+    A_cpu = A.cpu().to(torch.float64)
+    ref = torch.zeros_like(A_cpu, dtype=torch.float64)
+    for seq_start, seq_end in zip(
+        cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist(), strict=False
+    ):
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            actual_size = min(chunk_size, seq_end - chunk_start)
+            mat_to_invert = (
+                A_cpu[
+                    :, chunk_start : chunk_start + actual_size, :, :actual_size
+                ].transpose(1, 2)
+                + torch.eye(actual_size, dtype=torch.float64)[None, None, ...]
+            ).numpy()
+            ref[:, chunk_start : chunk_start + actual_size, :, :actual_size] = (
+                torch.tensor(np.linalg.inv(mat_to_invert)).transpose(1, 2)
+            )
+    return ref
+
+
+def _test_inverse_accuracy(
+    A: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int,
+    atol: float,
+    rtol: float,
+    ftol: float,
+):
+
+    ref = _reference_inverse(A, cu_seqlens, chunk_size)
+    tri = pto_tri_inv_rec_unroll(A, True, cu_seqlens)
+    torch.npu.synchronize()
+    tri = tri.cpu().to(torch.float64)
+    torch.npu.synchronize()
+
+    assert torch.allclose(tri, ref, atol=atol, rtol=rtol)
+    frob_error = torch.sqrt(torch.sum((ref - tri) ** 2) / torch.sum(ref**2)).item()
+    assert frob_error <= ftol
+
+
+@pytest.mark.parametrize("B", [1, 2, 7, 17, 32, 93])
+@pytest.mark.parametrize("N", [4])
+@pytest.mark.parametrize(
+    "chunk_size", [32, 64, 128]
+)  # Equal to matrix size for inversion
+@pytest.mark.parametrize("total_tokens", [1024, 3031, 10937])
+@pytest.mark.parametrize(
+    "matrix_type,atol,rtol,ftol", [("ones", 0, 0, 0), ("random", 1e-5, 5e-2, 1e-2)]
+)
+def test_tri_inv_rec_unroll_variable_length(
+    B: int,
+    N: int,
+    chunk_size: int,
+    total_tokens: int,
+    matrix_type: str,
+    atol: float,
+    rtol: float,
+    ftol: float,
+):
+    """
+    Args:
+        B: Number of sequences
+        N: Number of BSND heads
+        chunk_size: Equal to matrix size for inversion
+        total_tokens: Total number of tokens (sum of sequence lengths)
+        matrix_type: Type of matrix to test
+        atol: Max abs tolerance for torch.allclose
+        rtol: Max rel tolerance for torch.allclose
+        ftol: Frobenius norm-wise relative error tolerance
+    """
+    default_feature_dim = 64
+    seq_lens = generate_random_sequence_lengths(B, total_tokens)
+    packed_input, cu_seqlens = build_variable_len_input(
+        seq_lens=seq_lens,
+        num_heads=N,
+        chunk_size=chunk_size,
+        feature_dim=default_feature_dim,
+        matrix_type=matrix_type,
+    )
+    _test_inverse_accuracy(packed_input, cu_seqlens, chunk_size, atol, rtol, ftol)


### PR DESCRIPTION
Solves #67

# Performance

Produced by `examples/jit_cpp/fast_inverse/benchmark_bsnd_fast_inverse.py`

Sanity check by storing "uniform seq batch" as "varlen format" (i.e. `cu_seqlens` has uniform stepping), the effective BW agrees with previous fixed-length kernel:

<img width="1125" height="750" alt="bench_results_bsnd_fast_inverse_bw_64" src="https://github.com/user-attachments/assets/9635b04f-e480-44b1-83d9-7037a9c6da4a" />

<img width="1125" height="750" alt="bench_results_bsnd_fast_inverse_bw_128" src="https://github.com/user-attachments/assets/23f62b2d-508c-4e02-b33b-763abcfcdcbf" />

The effective BW using true-varying-length input data also looks good:

<img width="1125" height="750" alt="bench_results_bsnd_fast_inverse_true_varlen_bw_64" src="https://github.com/user-attachments/assets/31ef0b27-5823-458a-91c3-3230bd8c7268" />

<img width="1125" height="750" alt="bench_results_bsnd_fast_inverse_true_varlen_bw_128" src="https://github.com/user-attachments/assets/6995f920-c564-423f-adce-903a51fde876" />

# Correctness

```bash
export PTO_LIB_PATH=/sources/pto-isa/  # need latest header, not CANN 8.5.0 default
cd examples/jit_cpp/fast_inverse
python ./run_fast_inverse_varlen_like_triton.py
python ./run_fast_inverse.py
```

```
=== Varlen Like Triton ===
  PASS  H=4 D=64 chunk_size=16 cu_seqlens=[0, 15]
  PASS  H=4 D=64 chunk_size=32 cu_seqlens=[0, 256, 500, 1000]
  PASS  H=4 D=100 chunk_size=64 cu_seqlens=[0, 15, 100, 300, 1200, 2000]
  PASS  H=4 D=64 chunk_size=16 cu_seqlens=[0, 1, 100, 300, 1200, 2048]
  PASS  H=4 D=128 chunk_size=32 cu_seqlens=[0, 200, 512, 1200, 2048]

5/5 cases passed.
```

Outputs:
```
... (older tests still pass)
=== BSND varlen layout ===
    varlen sequence lengths: [15] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 15] [block_ones]  frob=0.00e+00
    varlen sequence lengths: [15] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 15] [ones]  frob=0.00e+00
    varlen sequence lengths: [15] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 15] [block_random]  frob=8.73e-05
    varlen sequence lengths: [15] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 15] [random]  frob=4.47e-05
    varlen sequence lengths: [256, 244, 500] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 256, 500, 1000] [block_ones]  frob=0.00e+00
    varlen sequence lengths: [256, 244, 500] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 256, 500, 1000] [ones]  frob=0.00e+00
    varlen sequence lengths: [256, 244, 500] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 256, 500, 1000] [block_random]  frob=9.88e-05
    varlen sequence lengths: [256, 244, 500] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 256, 500, 1000] [random]  frob=6.39e-05
    varlen sequence lengths: [15, 85, 200, 900, 800] (chunk_size=64, num_heads=4)
  PASS  N=4 D=64 cu=[0, 15, 100, 300, 1200, 2000] [block_ones]  frob=0.00e+00
    varlen sequence lengths: [15, 85, 200, 900, 800] (chunk_size=64, num_heads=4)
  PASS  N=4 D=64 cu=[0, 15, 100, 300, 1200, 2000] [ones]  frob=0.00e+00
    varlen sequence lengths: [15, 85, 200, 900, 800] (chunk_size=64, num_heads=4)
  PASS  N=4 D=64 cu=[0, 15, 100, 300, 1200, 2000] [block_random]  frob=9.71e-05
    varlen sequence lengths: [15, 85, 200, 900, 800] (chunk_size=64, num_heads=4)
  PASS  N=4 D=64 cu=[0, 15, 100, 300, 1200, 2000] [random]  frob=9.00e-05
    varlen sequence lengths: [1, 99, 200, 900, 848] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 1, 100, 300, 1200, 2048] [block_ones]  frob=0.00e+00
    varlen sequence lengths: [1, 99, 200, 900, 848] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 1, 100, 300, 1200, 2048] [ones]  frob=0.00e+00
    varlen sequence lengths: [1, 99, 200, 900, 848] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 1, 100, 300, 1200, 2048] [block_random]  frob=9.74e-05
    varlen sequence lengths: [1, 99, 200, 900, 848] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 1, 100, 300, 1200, 2048] [random]  frob=4.76e-05
    varlen sequence lengths: [200, 312, 688, 848] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 200, 512, 1200, 2048] [block_ones]  frob=0.00e+00
    varlen sequence lengths: [200, 312, 688, 848] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 200, 512, 1200, 2048] [ones]  frob=0.00e+00
    varlen sequence lengths: [200, 312, 688, 848] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 200, 512, 1200, 2048] [block_random]  frob=9.03e-05
    varlen sequence lengths: [200, 312, 688, 848] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 200, 512, 1200, 2048] [random]  frob=6.46e-05

244/244 tests passed.
```

# Varlen BSND `cu_seqlens` Support For `tri_inv_rec_unroll`

## Summary

This change adds a standalone varlen-capable BSND path for the JIT
`fast_inverse` example that matches the Triton-style external API:
varlen callers now provide packed BSND data plus `cu_seqlens`, and the PTO
kernel derives chunk row-starts and tail sizes internally on NPU.

The original BSND implementation assumes aligned sequence length:

- input layout is `(B, S, N, D)`
- each `D x D` chunk is stored at a fixed stride
- tile addressing is derived directly from `tile_id`
- this only works when all sequences are effectively chunk-aligned in a single
  dense BSND tensor

The new varlen version keeps the same per-tile inverse math, but changes how a
BSND tile is located in memory for packed varlen inputs.

## What Changed

- Copied the kernel into the standalone example:
  `examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp`
- Changed the standalone JIT ABI so varlen BSND uses optional `cu_seqlens`
  metadata instead of caller-built `chunk_indices` / `chunk_valid_sizes`
- Updated `run_fast_inverse.py` to validate the varlen path with only
  `cu_seqlens`
- Added `run_fast_inverse_varlen_like_triton.py`, a standalone runner modeled
  after `flash-linear-attention/tests/ops/test_solve_tril.py::test_solve_tril_varlen`
- Reran standalone benchmarks for `chunk_size=64` and `chunk_size=128`

## PTO-ISA Implementation Details

The PTO-ISA implementation now supports unpadded varlen BSND inputs directly.
The kernel handles tile lookup and tail chunks from `cu_seqlens` inside the NPU
kernel, so the host no longer pays the per-launch metadata materialization cost.

### Original BSND Addressing

In the original kernel, BSND tile addressing is fixed-stride:

- `tile_id` identifies one `(chunk, head)` pair
- the GM address is computed with `BSND_OFFSET(tile_id, N, S, D)`
- this assumes chunks are laid out uniformly inside a dense `(B, S, N, D)`
  tensor

That is correct for aligned BSND, but not for varlen batches where different
sequences end at different positions.

### New Varlen Addressing

The new varlen path uses one optional GM metadata pointer:

- `cu_seqlens[i]` stores the cumulative token offset of sequence `i`
- `chunk_idx = tile_id / num_bsnd_heads`
- `head_idx = tile_id % num_bsnd_heads`
- the kernel scans `cu_seqlens` to find which sequence owns `chunk_idx`
- it derives:
  - `row_start = seq_start + local_chunk_idx * D`
  - `valid_size = min(seq_end - row_start, D)`
  - `gm_offset = row_start * num_bsnd_heads * D + head_idx * D`

This means:

- the external varlen API now matches the Triton reference test shape
- callers do not need to precompute chunk metadata in eager PyTorch
- the aligned BSND path still works unchanged when `cu_seqlens` is omitted

### In-Kernel Tail Handling

The recursive inverse implementation still expects a dense `D x D` tile for the
cube path. Tail chunks therefore use a small setup sequence inside the same
kernel:

- derive `row_start` and `valid_size` from `cu_seqlens`
- `TLOAD` only the valid `actual_size x actual_size` prefix into a dynamic L1
  tile
- call `TFILLPAD` on that L1 tile so the remaining rows/cols are zeroed on-chip
- run the unchanged recursive inverse on the now-materialized full tile
- `TSTORE` only the valid prefix back to the unpadded BSND output

This avoids host-side eager padding and avoids a second standalone padding
kernel launch.

## Difference vs Original BSND Version

Original BSND version:

- assumes a globally aligned dense BSND tensor
- uses fixed-stride chunk addressing
- has no extra metadata input
- assumes every chunk is a full `D x D` tile

Varlen BSND version:

- supports unpadded packed BSND inputs
- uses `cu_seqlens` metadata for tile lookup and tail shape
- performs partial `TLOAD` / `TFILLPAD` / partial `TSTORE` inside the kernel
- preserves the existing recursive inverse implementation for each chunk
- keeps the core inverse math unchanged after tail materialization

## Testing

The standalone example now validates:

- standard dense layout
- original aligned BSND layout
- varlen BSND layout using representative `cu_seqlens` cases
- a standalone Triton-like varlen input-generation path

`run_fast_inverse.py` varlen harness:

- prints derived sequence lengths for inspection
- builds unpadded packed BSND input
- computes a reference inverse only over each sequence's valid chunk region
- launches the PTO-ISA kernel with `cu_seqlens`

`run_fast_inverse_varlen_like_triton.py`:

- uses the same varlen case list as the Triton `test_solve_tril_varlen`
- prepares `k`, `beta`, and `A` with the same structure as the Triton test
- replaces `chunk_scaled_dot_kkt_fwd` with a pure PyTorch emulation
- transposes each valid chunk to PTO's upper-triangular convention before launch
- prints a pytest-like `PASS` / `FAIL` summary

Current standalone verification:

- `PTO_LIB_PATH=/sources/pto-isa python run_fast_inverse.py`
- result: `244/244 tests passed`
- `PTO_LIB_PATH=/sources/pto-isa python run_fast_inverse_varlen_like_triton.py`
- result: `5/5 cases passed`

## Performance

Before optimization, eager host-side metadata construction was significant:

- `chunk_size=64`: about `25%` of kernel time
- `chunk_size=128`: about `12%` of kernel time

After moving metadata derivation into the kernel and rerunning the benchmark:

- `chunk_size=64`, `T=16384`, `bsnd-varlen-uniform`:
  `199.14 -> 198.20 GB/s`
- `chunk_size=128`, `T=16384`, `bsnd-varlen-uniform`:
  `200.72 -> 200.90 GB/s`

## Notes

- This is intentionally isolated to the standalone JIT example
- the original kernel under `csrc/kernel/` is unchanged

