### PR TITLE
Fix tile iteration bound in abs kernel

### DIFF
--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -54,10 +54,12 @@ AICORE void runTAbs(__gm__ T* x, __gm__ T* z, uint32_t total_size) {
   set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
   set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
 
-  // Loop for full size tiles
-  for (uint32_t inner_offset = global_offset; inner_offset < total_size;
+  // Loop over tiles
+  const uint32_t offset_end =
+      min(global_offset + TILE_SIZE * num_tiles_per_block, total_size);
+  for (uint32_t inner_offset = global_offset; inner_offset < offset_end;
        inner_offset += TILE_SIZE) {
-    const uint32_t remainder_size = total_size - inner_offset;
+    const uint32_t remainder_size = offset_end - inner_offset;
     const int32_t remaining_elements =
         remainder_size > TILE_SIZE ? TILE_SIZE : remainder_size;
 


### PR DESCRIPTION
This PR fixes the tile iteration bound in the abs kernel (thanks @Mocchibird for spotting the bug in another kernel).