### PR TITLE
Fix compile error for examples/jit_cpp/fast_inverse

### DIFF
--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -10,6 +10,7 @@ for the full License text.
 
 #define MEMORY_BASE
 #include <pto/pto-inst.hpp>
+#include <type_traits>
 
 namespace kernel_utils {
 /**


### PR DESCRIPTION
Otherwise getting compile error for `python ./run_fast_inverse.py`:

```
Compiling /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp ...
Compiling fast_inverse kernel:
  bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 -I/workdir/pto-kernels/csrc/kernel -I/sources/pto-isa//include --cce-soc-version=Ascend910B4 --cce-soc-core-type=CubeCore /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp -o /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:39:20: error: use of undeclared identifier 'std'
          typename std::enable_if<std::is_integral<T1>::value &&
                   ^
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:39:34: error: expected ',' or '>' in template-parameter-list
          typename std::enable_if<std::is_integral<T1>::value &&
                                 ^
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:39:57: error: no type named 'value' in the global namespace
          typename std::enable_if<std::is_integral<T1>::value &&
                                                      ~~^
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:40:39: error: use of undeclared identifier 'std'
                                      std::is_integral<T2>::value,
                                      ^
1 warning and 4 errors generated.
Traceback (most recent call last):
  File "/workdir/pto-kernels/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py", line 59, in compile_cpp
    subprocess.run(command, timeout=timeout, check=True)
  File "/usr/local/python3.11.14/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['bisheng', '-fPIC', '-shared', '-xcce', '-DMEMORY_BASE', '-O2', '-std=c++17', '-I/workdir/pto-kernels/csrc/kernel', '-I/sources/pto-isa//include', '--cce-soc-version=Ascend910B4', '--cce-soc-core-type=CubeCore', '/workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp', '-o', '/workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workdir/pto-kernels/examples/jit_cpp/fast_inverse/./run_fast_inverse.py", line 260, in <module>
    tri_inv_func = jit_compile(src)
                   ^^^^^^^^^^^^^^^^
  File "/workdir/pto-kernels/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py", line 139, in jit_compile
    lib_path = compile_cpp(src_path, verbose=verbose)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workdir/pto-kernels/examples/jit_cpp/fast_inverse/jit_util_fast_inverse.py", line 61, in compile_cpp
    raise RuntimeError(f"Compilation failed: {exc}") from exc
RuntimeError: Compilation failed: Command '['bisheng', '-fPIC', '-shared', '-xcce', '-DMEMORY_BASE', '-O2', '-std=c++17', '-I/workdir/pto-kernels/csrc/kernel', '-I/sources/pto-isa//include', '--cce-soc-version=Ascend910B4', '--cce-soc-core-type=CubeCore', '/workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp', '-o', '/workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so']' returned non-zero exit status 1.
[ERROR] 2026-04-15-07:45:46 (PID:2143, Device:0, RankID:-1) ERR99999 UNKNOWN applicaiton exception
```

Fix the fix, everything runs fine now:

```$
python ./run_fast_inverse.py 
Compiling /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp ...
Compiling fast_inverse kernel:
  bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 -I/workdir/pto-kernels/csrc/kernel -I/sources/pto-isa//include --cce-soc-version=Ascend910B4 --cce-soc-core-type=CubeCore /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp -o /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
Generated: /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so
Compilation successful.


=== BSND varlen layout ===
    varlen sequence lengths: [15] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 15]  frob=4.23e-05
    varlen sequence lengths: [256, 244, 500] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 256, 500, 1000]  frob=6.50e-05
    varlen sequence lengths: [15, 85, 200, 900, 800] (chunk_size=64, num_heads=4)
  PASS  N=4 D=64 cu=[0, 15, 100, 300, 1200, 2000]  frob=8.98e-05
    varlen sequence lengths: [1, 99, 200, 900, 848] (chunk_size=16, num_heads=4)
  PASS  N=4 D=16 cu=[0, 1, 100, 300, 1200, 2048]  frob=4.75e-05
    varlen sequence lengths: [200, 312, 688, 848] (chunk_size=32, num_heads=4)
  PASS  N=4 D=32 cu=[0, 200, 512, 1200, 2048]  frob=6.43e-05
```

```
$ python ./run_fast_inverse_varlen_like_triton.py 
Compiling /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp ...
Compiling fast_inverse kernel:
  bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 -I/workdir/pto-kernels/csrc/kernel -I/sources/pto-isa//include --cce-soc-version=Ascend910B4 --cce-soc-core-type=CubeCore /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp -o /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse.cpp:13:
In file included from /workdir/pto-kernels/examples/jit_cpp/fast_inverse/kernel_tri_inv_rec_unroll.cpp:15:
/workdir/pto-kernels/csrc/kernel/kernel_utils.h:11:9: warning: 'MEMORY_BASE' macro redefined [-Wmacro-redefined]
#define MEMORY_BASE
        ^
<command line>:1:9: note: previous definition is here
#define MEMORY_BASE 1
        ^
1 warning generated.
Generated: /workdir/pto-kernels/examples/jit_cpp/fast_inverse/fast_inverse_jit.so
Compilation successful.

=== Varlen Like Triton ===
  PASS  H=4 D=64 chunk_size=16 cu_seqlens=[0, 15]
  PASS  H=4 D=64 chunk_size=32 cu_seqlens=[0, 256, 500, 1000]
  PASS  H=4 D=100 chunk_size=64 cu_seqlens=[0, 15, 100, 300, 1200, 2000]
  PASS  H=4 D=64 chunk_size=16 cu_seqlens=[0, 1, 100, 300, 1200, 2048]
  PASS  H=4 D=128 chunk_size=32 cu_seqlens=[0, 200, 512, 1200, 2048]

5/5 cases passed.
```