### PR TITLE
fix: tri inv column sweep

### DIFF
--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -114,6 +114,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       }
 
       TASSIGN(A_k, j * S * sizeof(T));
+      TMULS(diff, A_k, static_cast<T>(1));
       set_flag(PIPE_V, PIPE_S, EVENT_ID1);
 
       pipe_barrier(PIPE_V);


### PR DESCRIPTION
Every outer iteration we copy UB tile `A_k` into UB tile `diff`

<img width="1005" height="365" alt="image" src="https://github.com/user-attachments/assets/d613e31f-6cbe-43d2-b1a4-82c0838031db" />
