### PR TITLE
(simple_matmul) add bf16 support

### DIFF
--- a/csrc/host/torch_simple_matmul.h
+++ b/csrc/host/torch_simple_matmul.h
@@ -30,9 +30,10 @@ at::Tensor run_simple_matmul(const at::Tensor& a, const at::Tensor& b) {
   const auto dtype = a.options().dtype();
   const auto dtype_out = at::kFloat;
 
-  if (!(dtype == at::kHalf or dtype == at::kFloat)) {
+  if (!(dtype == at::kHalf or dtype == at::kFloat or dtype == at::kBFloat16)) {
     throw std::runtime_error(
-        "Unsupported dtype for simple_matmul kernel. Supports only fp16/fp32");
+        "Unsupported dtype for simple_matmul kernel. Supports only "
+        "fp16/bf16/fp32");
   }
 
   const uint32_t matrix_size = static_cast<uint32_t>(a.size(-1));
@@ -48,7 +49,7 @@ at::Tensor run_simple_matmul(const at::Tensor& a, const at::Tensor& b) {
 
   if (dtype == at::kHalf) {
     EXEC_KERNEL_CMD(simple_matmul_fp16, block_dim, a, b, c, matrix_size);
-  } else if (dtype == at::KBFloat16) {
+  } else if (dtype == at::kBFloat16) {
     EXEC_KERNEL_CMD(simple_matmul_bf16, block_dim, a, b, c, matrix_size);
   } else if (dtype == at::kFloat) {
     EXEC_KERNEL_CMD(simple_matmul_fp32, block_dim, a, b, c, matrix_size);

--- a/csrc/host/torch_simple_matmul.h
+++ b/csrc/host/torch_simple_matmul.h
@@ -11,6 +11,7 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
+#include "aclrtlaunch_simple_matmul_bf16.h"
 #include "aclrtlaunch_simple_matmul_fp16.h"
 #include "aclrtlaunch_simple_matmul_fp32.h"
 #include "utils.h"
@@ -47,6 +48,8 @@ at::Tensor run_simple_matmul(const at::Tensor& a, const at::Tensor& b) {
 
   if (dtype == at::kHalf) {
     EXEC_KERNEL_CMD(simple_matmul_fp16, block_dim, a, b, c, matrix_size);
+  } else if (dtype == at::KBFloat16) {
+    EXEC_KERNEL_CMD(simple_matmul_bf16, block_dim, a, b, c, matrix_size);
   } else if (dtype == at::kFloat) {
     EXEC_KERNEL_CMD(simple_matmul_fp32, block_dim, a, b, c, matrix_size);
   }

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -17,6 +17,11 @@ extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
                                                      __gm__ void* c,
                                                      uint32_t matrix_size) {}
 
+extern "C" __global__ AICORE void simple_matmul_bf16(__gm__ void* a,
+                                                     __gm__ void* b,
+                                                     __gm__ void* c,
+                                                     uint32_t matrix_size) {}
+
 extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
                                                      __gm__ void* b,
                                                      __gm__ void* c,
@@ -121,8 +126,9 @@ AICORE void runKernelSimpleMatMul(__gm__ InputT* a, __gm__ InputT* b,
 template <typename T>
 AICORE void run_simple_matmul(__gm__ T* a, __gm__ T* b, __gm__ float* c,
                               uint32_t matrix_size) {
-  static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
-                "simple_matmul supports only fp16/fp32.");
+  static_assert(std::is_same_v<T, half> or std::is_same_v<T, bfloat16_t> or
+                    std::is_same_v<T, float>,
+                "simple_matmul supports only fp16/bf16/fp32.");
 
   switch (matrix_size) {
     case 16:
@@ -152,6 +158,14 @@ extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
                                                      uint32_t matrix_size) {
   run_simple_matmul<half>((__gm__ half*)a, (__gm__ half*)b, (__gm__ float*)c,
                           matrix_size);
+}
+
+extern "C" __global__ AICORE void simple_matmul_bf16(__gm__ void* a,
+                                                     __gm__ void* b,
+                                                     __gm__ void* c,
+                                                     uint32_t matrix_size) {
+  run_simple_matmul<half>((__gm__ bfloat16_t*)a, (__gm__ bfloat16_t*)b,
+                          (__gm__ float*)c, matrix_size);
 }
 
 extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -164,8 +164,8 @@ extern "C" __global__ AICORE void simple_matmul_bf16(__gm__ void* a,
                                                      __gm__ void* b,
                                                      __gm__ void* c,
                                                      uint32_t matrix_size) {
-  run_simple_matmul<half>((__gm__ bfloat16_t*)a, (__gm__ bfloat16_t*)b,
-                          (__gm__ float*)c, matrix_size);
+  run_simple_matmul<bfloat16_t>((__gm__ bfloat16_t*)a, (__gm__ bfloat16_t*)b,
+                                (__gm__ float*)c, matrix_size);
 }
 
 extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,

--- a/tests/test_simple_matmul.py
+++ b/tests/test_simple_matmul.py
@@ -12,7 +12,7 @@ from pto_kernels import pto_simple_matmul
 
 
 @pytest.mark.parametrize("matrix_size", [16, 32, 64, 96, 128])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=str)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32], ids=str)
 def test_pto_simple_matmul(matrix_size: int, dtype: torch.dtype):
     m, k, n = matrix_size, matrix_size, matrix_size
     a = torch.rand((m, k), device="cpu", dtype=dtype)

--- a/tests/test_simple_matmul.py
+++ b/tests/test_simple_matmul.py
@@ -12,7 +12,9 @@ from pto_kernels import pto_simple_matmul
 
 
 @pytest.mark.parametrize("matrix_size", [16, 32, 64, 96, 128])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32], ids=str)
+@pytest.mark.parametrize(
+    "dtype", [torch.float16, torch.bfloat16, torch.float32], ids=str
+)
 def test_pto_simple_matmul(matrix_size: int, dtype: torch.dtype):
     m, k, n = matrix_size, matrix_size, matrix_size
     a = torch.rand((m, k), device="cpu", dtype=dtype)


### PR DESCRIPTION
Add support for bf16 on simple matrix multiplication example.


## Test

```
pytest -v tests/test_simple_matmul.py
============================================ test session starts ============================================
platform linux -- Python 3.10.12, pytest-8.3.4, pluggy-1.6.0 -- /home/zouzias/github-repos/pto-kernels/venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/zouzias/github-repos/pto-kernels
configfile: pytest.ini
collected 15 items

tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float16-16] PASSED                          [  6%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float16-32] PASSED                          [ 13%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float16-64] PASSED                          [ 20%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float16-96] PASSED                          [ 26%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float16-128] PASSED                         [ 33%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.bfloat16-16] PASSED                         [ 40%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.bfloat16-32] PASSED                         [ 46%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.bfloat16-64] PASSED                         [ 53%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.bfloat16-96] PASSED                         [ 60%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.bfloat16-128] PASSED                        [ 66%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float32-16] PASSED                          [ 73%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float32-32] PASSED                          [ 80%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float32-64] PASSED                          [ 86%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float32-96] PASSED                          [ 93%]
tests/test_simple_matmul.py::test_pto_simple_matmul[torch.float32-128] PASSED                         [100%]

============================================ 15 passed in 0.10s =============================================
```