### PR TITLE
Refactor include and defines using kernel_utils.h

### DIFF
--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -7,13 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-#define MEMORY_BASE
-
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 
@@ -113,14 +107,25 @@ AICORE void runTAbs(__gm__ T* x, __gm__ T* z, uint32_t total_size) {
 
 extern "C" __global__ AICORE void vabs_fp16(GM_ADDR x, GM_ADDR z,
                                             uint32_t in_length) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
   constexpr uint32_t TILE_LEN = 128;
   runTAbs<half, TILE_LEN>((__gm__ half*)x, (__gm__ half*)z, in_length);
+#else
+  (void)x;
+  (void)z;
+  (void)in_length;
+#endif
 }
 
 extern "C" __global__ AICORE void vabs_fp32(GM_ADDR x, GM_ADDR z,
                                             uint32_t in_length) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
   constexpr uint32_t TILE_LEN = 128;
   runTAbs<float, TILE_LEN>((__gm__ float*)x, (__gm__ float*)z, in_length);
-}
-
+#else
+  (void)x;
+  (void)z;
+  (void)in_length;
 #endif
+}

--- a/csrc/kernel/kernel_batch_matrix_square.cpp
+++ b/csrc/kernel/kernel_batch_matrix_square.cpp
@@ -7,18 +7,12 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#define MEMORY_BASE
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 
 template <typename InputT, typename OutputT, uint32_t MatrixSize>
 AICORE void runKernelBatchMatrixSquare(__gm__ OutputT* z, __gm__ InputT* x) {
-#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
-    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // Cube compilation
-
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   const uint32_t global_index = get_block_idx() * TileLen;
 
@@ -79,9 +73,6 @@ AICORE void runKernelBatchMatrixSquare(__gm__ OutputT* z, __gm__ InputT* x) {
   wait_flag(PIPE_M, PIPE_FIX,
             EVENT_ID0);  // FIX pipe waits for M pipe to set flag
   TSTORE(z_global_out, c_l0_tile);
-#else
-// Nothing to do on AIV
-#endif
 }
 
 template <typename InputT>
@@ -110,11 +101,28 @@ AICORE void run_batch_matrix_square(__gm__ float* z, __gm__ InputT* x,
 
 extern "C" __global__ AICORE void batch_matrix_square_fp16(
     __gm__ void* z, __gm__ void* x, uint32_t matrix_size) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // AIC
   run_batch_matrix_square<half>((__gm__ float*)z, (__gm__ half*)x, matrix_size);
+#else
+  // Nothing to do on AIV
+  (void)z;
+  (void)x;
+  (void)matrix_size;
+#endif
 }
 
 extern "C" __global__ AICORE void batch_matrix_square_fp32(
     __gm__ void* z, __gm__ void* x, uint32_t matrix_size) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // AIC
+
   run_batch_matrix_square<float>((__gm__ float*)z, (__gm__ float*)x,
                                  matrix_size);
+#else
+  // Nothing to do on AIV
+  (void)z;
+  (void)x;
+  (void)matrix_size;
+#endif
 }

--- a/csrc/kernel/kernel_csr_gather.cpp
+++ b/csrc/kernel/kernel_csr_gather.cpp
@@ -7,13 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-#define MEMORY_BASE
-
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 
@@ -212,22 +206,26 @@ extern "C" __global__ AICORE void csr_gather_fp16(GM_ADDR values,
                                                   GM_ADDR indices, GM_ADDR x,
                                                   GM_ADDR z, uint32_t x_size,
                                                   uint32_t indices_size) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
   constexpr uint32_t TILE_SIZE = 512;
   constexpr uint32_t TILE_SIZE_X = 40960;
   runTCsrGather<half, TILE_SIZE, TILE_SIZE_X>(
       (__gm__ half*)values, (__gm__ int32_t*)indices, (__gm__ half*)x,
       (__gm__ half*)z, x_size, indices_size);
+#endif
 }
 
 extern "C" __global__ AICORE void csr_gather_fp32(GM_ADDR values,
                                                   GM_ADDR indices, GM_ADDR x,
                                                   GM_ADDR z, uint32_t x_size,
                                                   uint32_t indices_size) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
   constexpr uint32_t TILE_SIZE = 512;
   constexpr uint32_t TILE_SIZE_X = 40960;
   runTCsrGather<float, TILE_SIZE, TILE_SIZE_X>(
       (__gm__ float*)values, (__gm__ int32_t*)indices, (__gm__ float*)x,
       (__gm__ float*)z, x_size, indices_size);
-}
-
 #endif
+}

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -6,35 +6,8 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-#if defined __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
 
-// Placeholder for VEC compilation (the real kernel is CUBE-only).
-#define MEMORY_BASE
-#include <pto/common/type.hpp>
-
-extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
-                                                     uint32_t matrix_size) {}
-
-extern "C" __global__ AICORE void simple_matmul_bf16(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
-                                                     uint32_t matrix_size) {}
-
-extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
-                                                     uint32_t matrix_size) {}
-
-#elif (__CHECK_FEATURE_AT_PRECOMPILE) || \
-    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
-
-#define MEMORY_BASE
-
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 
@@ -156,24 +129,31 @@ extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
                                                      __gm__ void* b,
                                                      __gm__ void* c,
                                                      uint32_t matrix_size) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
   run_simple_matmul<half>((__gm__ half*)a, (__gm__ half*)b, (__gm__ float*)c,
                           matrix_size);
+#endif
 }
 
 extern "C" __global__ AICORE void simple_matmul_bf16(__gm__ void* a,
                                                      __gm__ void* b,
                                                      __gm__ void* c,
                                                      uint32_t matrix_size) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
   run_simple_matmul<bfloat16_t>((__gm__ bfloat16_t*)a, (__gm__ bfloat16_t*)b,
                                 (__gm__ float*)c, matrix_size);
+#endif
 }
 
 extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
                                                      __gm__ void* b,
                                                      __gm__ void* c,
                                                      uint32_t matrix_size) {
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
   run_simple_matmul<float>((__gm__ float*)a, (__gm__ float*)b, (__gm__ float*)c,
                            matrix_size);
-}
-
 #endif
+}

--- a/csrc/kernel/kernel_swiglu.cpp
+++ b/csrc/kernel/kernel_swiglu.cpp
@@ -7,13 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#define MEMORY_BASE
-
-#include <pto/pto-inst.hpp>
-
-// clang-format off: so it does not get wrongfully flagged by linter
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
-// clang-format on
+#include "kernel_utils.h"
 
 using namespace pto;
 
@@ -132,8 +126,8 @@ AICORE inline TileConfig makeTileConfig(uint32_t batch, uint32_t output_n,
   };
 }
 
-AICORE inline bool preferTileConfig(const TileConfig &cand,
-                                    const TileConfig &best) {
+AICORE inline bool preferTileConfig(const TileConfig& cand,
+                                    const TileConfig& best) {
   if (cand.meets_target != best.meets_target) {
     return cand.meets_target;
   }
@@ -187,8 +181,8 @@ AICORE inline TileWork makeTileWork(uint32_t global_tile_idx,
 }
 
 template <typename TileData, typename T>
-AICORE inline void computeSwiGLUTile(TileData &x0Tile, TileData &x1Tile,
-                                     TileData &yTile) {
+AICORE inline void computeSwiGLUTile(TileData& x0Tile, TileData& x1Tile,
+                                     TileData& yTile) {
   TMULS(yTile, x0Tile, (T)-1);
   pipe_barrier(PIPE_V);
   TEXP(yTile, yTile);
@@ -204,8 +198,8 @@ AICORE inline void computeSwiGLUTile(TileData &x0Tile, TileData &x1Tile,
 // col_count is padded for UB tile sizing; col_count_store is the actual GM
 // element count so tail columns never read past the tensor end.
 template <typename T, uint32_t kTileRows, uint32_t kTileCols>
-AICORE void issueTLoad(__gm__ T *x, uint32_t input_n, uint32_t output_n,
-                       const TileWork &tile, unsigned x0_base, unsigned x1_base,
+AICORE void issueTLoad(__gm__ T* x, uint32_t input_n, uint32_t output_n,
+                       const TileWork& tile, unsigned x0_base, unsigned x1_base,
                        event_t ev) {
   using TileShapeND = TileShape2D<T, DYNAMIC, DYNAMIC, Layout::ND>;
   using DynStrideND = Stride<1, 1, 1, DYNAMIC, 1>;
@@ -235,7 +229,7 @@ AICORE void issueTLoad(__gm__ T *x, uint32_t input_n, uint32_t output_n,
 // col_count is padded for UB tile sizing; col_count_store is the actual GM
 // element count so tail columns never write past the tensor end.
 template <typename T, uint32_t kTileRows, uint32_t kTileCols>
-AICORE void issueTStore(__gm__ T *y, uint32_t output_n, const TileWork &tile,
+AICORE void issueTStore(__gm__ T* y, uint32_t output_n, const TileWork& tile,
                         unsigned y_base, event_t ev) {
   using TileShapeND = TileShape2D<T, DYNAMIC, DYNAMIC, Layout::ND>;
   using DynStrideND = Stride<1, 1, 1, DYNAMIC, 1>;
@@ -259,7 +253,7 @@ AICORE void issueTStore(__gm__ T *y, uint32_t output_n, const TileWork &tile,
 }
 
 template <uint32_t kTileCols, typename T>
-AICORE void runTSwiGLUTiled(__gm__ T *x, __gm__ T *y, uint32_t batch,
+AICORE void runTSwiGLUTiled(__gm__ T* x, __gm__ T* y, uint32_t batch,
                             uint32_t input_n, uint32_t num_cores, uint32_t vid,
                             uint32_t row_tile_len) {
 #if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
@@ -341,7 +335,7 @@ AICORE void runTSwiGLUTiled(__gm__ T *x, __gm__ T *y, uint32_t batch,
 }
 
 template <typename T>
-AICORE void runTSwiGLUMainTiled(__gm__ T *x, __gm__ T *y, uint32_t batch,
+AICORE void runTSwiGLUMainTiled(__gm__ T* x, __gm__ T* y, uint32_t batch,
                                 uint32_t input_n, uint32_t num_cores,
                                 uint32_t vid) {
 #if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
@@ -372,7 +366,7 @@ AICORE void runTSwiGLUMainTiled(__gm__ T *x, __gm__ T *y, uint32_t batch,
 }
 
 template <typename T>
-AICORE void runTSwiGLU(__gm__ T *x, __gm__ T *y, uint32_t batch,
+AICORE void runTSwiGLU(__gm__ T* x, __gm__ T* y, uint32_t batch,
                        uint32_t input_n, uint32_t num_cores, uint32_t vid) {
 #if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
   set_mask_norm();
@@ -406,8 +400,8 @@ extern "C" __global__ AICORE void swiglu_fp16(GM_ADDR x, GM_ADDR y,
 #if defined(__DAV_VEC__)
   const uint32_t num_cores = get_block_num() * get_subblockdim();
   const uint32_t vid = get_block_idx() * get_subblockdim() + get_subblockid();
-  runTSwiGLU<half>((__gm__ half *)x, (__gm__ half *)y, batch, input_n,
-                   num_cores, vid);
+  runTSwiGLU<half>((__gm__ half*)x, (__gm__ half*)y, batch, input_n, num_cores,
+                   vid);
 #else
   (void)x;
   (void)y;
@@ -416,8 +410,8 @@ extern "C" __global__ AICORE void swiglu_fp16(GM_ADDR x, GM_ADDR y,
 #endif
 }
 
-extern "C" void call_swiglu_kernel(uint32_t blockDim, void *stream, uint8_t *x,
-                                   uint8_t *y, uint32_t batch,
+extern "C" void call_swiglu_kernel(uint32_t blockDim, void* stream, uint8_t* x,
+                                   uint8_t* y, uint32_t batch,
                                    uint32_t input_n) {
   swiglu_fp16<<<blockDim * 2, nullptr, stream>>>(x, y, batch, input_n);
 }

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -7,15 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-#define MEMORY_BASE
-
-#include <pto/pto-inst.hpp>
-
 #include "kernel_utils.h"
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
 
 using namespace pto;
 
@@ -164,6 +156,8 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
 
 extern "C" __global__ AICORE void triv_inv_col_sweep_fp16(
     GM_ADDR x, GM_ADDR z, uint32_t in_length, uint32_t matrix_size) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
   if (matrix_size == 16) {
     runTTriInv<half, 16>((__gm__ half*)x, (__gm__ half*)z, in_length);
   } else if (matrix_size == 32) {
@@ -173,10 +167,13 @@ extern "C" __global__ AICORE void triv_inv_col_sweep_fp16(
   } else if (matrix_size == 128) {
     runTTriInv<half, 128>((__gm__ half*)x, (__gm__ half*)z, in_length);
   }
+#endif
 }
 
 extern "C" __global__ AICORE void triv_inv_col_sweep_fp32(
     GM_ADDR x, GM_ADDR z, uint32_t in_length, uint32_t matrix_size) {
+#if __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
   if (matrix_size == 16) {
     runTTriInv<float, 16>((__gm__ float*)x, (__gm__ float*)z, in_length);
   } else if (matrix_size == 32) {
@@ -186,6 +183,5 @@ extern "C" __global__ AICORE void triv_inv_col_sweep_fp32(
   } else if (matrix_size == 128) {
     runTTriInv<float, 128>((__gm__ float*)x, (__gm__ float*)z, in_length);
   }
-}
-
 #endif
+}

--- a/csrc/kernel/kernel_tri_inv_ns.cpp
+++ b/csrc/kernel/kernel_tri_inv_ns.cpp
@@ -7,12 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#ifndef MEMORY_BASE
-#define MEMORY_BASE
-#endif
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -7,16 +7,10 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#ifndef MEMORY_BASE
-#define MEMORY_BASE
-#endif
-#include <pto/pto-inst.hpp>
-
 #include "kernel_utils.h"
 
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
-using namespace pto;
 using namespace kernel_utils;
+using namespace pto;
 
 /*
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.

--- a/csrc/kernel/kernel_tri_inv_trick.cpp
+++ b/csrc/kernel/kernel_tri_inv_trick.cpp
@@ -7,10 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#define MEMORY_BASE
-#include <pto/pto-inst.hpp>
-
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -9,7 +9,7 @@ for the full License text.
 #pragma once
 
 // FIXME(zouzias): Current development is based on A2/A3 architectures.
-#ifndef MEMORY_BASE && !defined(REGISTER_BASE)
+#if !defined(MEMORY_BASE) && !defined(REGISTER_BASE)
 #define MEMORY_BASE
 #endif
 #include <pto/pto-inst.hpp>

--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -8,9 +8,18 @@ for the full License text.
 */
 #pragma once
 
+// FIXME(zouzias): Current development is based on A2/A3 architectures.
+#ifndef MEMORY_BASE && !defined(REGISTER_BASE)
 #define MEMORY_BASE
+#endif
 #include <pto/pto-inst.hpp>
 #include <type_traits>
+
+// clang-format off: so it does not get wrongfully flagged by linter
+#ifndef GM_ADDR
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#endif
+// clang-format on
 
 namespace kernel_utils {
 /**


### PR DESCRIPTION
Refactor the `MEMORY_BASE` define, pto-isa includes and `GM_ADDR` inside `kernel_utils.h`

## Test log

```
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-7-96] PASSED              [ 99%] 
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-7-128] PASSED             [ 99%] 
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-16-16] PASSED             [ 99%] 
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-16-32] PASSED             [ 99%] 
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-16-64] PASSED             [ 99%] 
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-16-96] PASSED             [ 99%] 
tests/test_tri_inv_trick.py::test_tri_inv_trick_ones[block_random_matrix-5e-05-0.1-0.0001-16-16-128] PASSED            [100%] 
                                                                                                                              
============================================== 1668 passed in 124.34s (0:02:04) ==============================================
(venv) zouzias@bz-vnl-910b:~/github-repos/pto-kernels$ date                                                                   
Mon Apr 20 06:38:51 AM UTC 2026                                                                                               
(venv) zouzias@bz-vnl-910b:~/github-repos/pto-kernels$ git rev-parse HEAD                                                     
f8fefd5da2666ed537b8bcc1c8c54965d515e441                 
```