### PR TITLE
Prefix sum (scan) implementation - cube only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ ascendc_library(
   csrc/kernel/kernel_tri_inv_col_sweep.cpp
   csrc/kernel/kernel_abs.cpp
   csrc/kernel/kernel_csr_gather.cpp
+  csrc/kernel/kernel_scan_ul1.cpp
   csrc/kernel/kernel_simple_matmul.cpp
   csrc/kernel/kernel_batch_matrix_square.cpp
   csrc/kernel/kernel_tri_inv_ns.cpp

--- a/csrc/host/pybind11.cpp
+++ b/csrc/host/pybind11.cpp
@@ -12,6 +12,7 @@ for the full License text.
 #include "torch_abs.h"
 #include "torch_batch_matrix_square.h"
 #include "torch_csr_gather.h"
+#include "torch_scan_ul1.h"
 #include "torch_simple_matmul.h"
 #include "torch_swiglu.h"
 #include "torch_tri_inv.h"

--- a/csrc/host/pybind11.cpp
+++ b/csrc/host/pybind11.cpp
@@ -39,6 +39,7 @@ PYBIND11_MODULE(pto_kernels_ops, m) {
   m.def("pto_abs", &pto_isa_ops::run_abs);
   m.def("pto_batch_matrix_square", &pto_isa_ops::run_batch_matrix_square);
   m.def("pto_csr_gather", &pto_isa_ops::run_csr_gather);
+  m.def("pto_scan_ul1", &pto_isa_ops::run_scan_ul1);
   m.def("pto_simple_matmul", &pto_isa_ops::run_simple_matmul);
   m.def("pto_swiglu", &pto_isa_ops::run_swiglu, py::arg("x"),
         py::arg("dim") = -1);

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -53,7 +53,7 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
   // Lower triangular matrix
   const at::Tensor l = torch::tril(
       torch::ones({matrix_size, matrix_size},
-                  at::TensorOptions().dtype(dtype_out).device(device)));
+                  at::TensorOptions().dtype(dtype_out).device(device)), -1);
   // Ones matrix
   const at::Tensor o = torch::ones({matrix_size, matrix_size},
                                   at::TensorOptions().dtype(dtype).device(device)); 

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -45,18 +45,20 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
 
   const uint32_t matrix_size = ceil(sqrt(scan_size));
 
-  // FIXME: use vector or scalar cores to generate O, U and L directly on the device
-  // Upper triangular matrix
-  const at::Tensor u = torch::triu(
-      torch::ones({matrix_size, matrix_size},
-                  at::TensorOptions().dtype(dtype).device(device)));
+  // FIXME: use vector or scalar cores to generate O, U and L directly on the
+  // device Upper triangular matrix
+  const at::Tensor u =
+      torch::triu(torch::ones({matrix_size, matrix_size},
+                              at::TensorOptions().dtype(dtype).device(device)));
   // Lower triangular matrix
   const at::Tensor l = torch::tril(
       torch::ones({matrix_size, matrix_size},
-                  at::TensorOptions().dtype(dtype_out).device(device)), -1);
+                  at::TensorOptions().dtype(dtype_out).device(device)),
+      -1);
   // Ones matrix
-  const at::Tensor o = torch::ones({matrix_size, matrix_size},
-                                  at::TensorOptions().dtype(dtype).device(device)); 
+  const at::Tensor o =
+      torch::ones({matrix_size, matrix_size},
+                  at::TensorOptions().dtype(dtype).device(device));
 
   if (dtype == at::kHalf) {
     EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, o, u, l, scan, matrix_size);

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -34,22 +34,31 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
   }
 
   const uint32_t scan_size = static_cast<uint32_t>(x.size(-1));
-  if ( x.dim() != 1) {
+  if (x.dim() != 1) {
     throw std::runtime_error("Only 1D scan is supported.\n");
   }
 
   constexpr uint32_t block_dim = 1;
 
-  const at::Tensor scan =
-      at::zeros({scan_size},
-               at::TensorOptions().dtype(dtype_out).device(device));
+  const at::Tensor scan = at::zeros(
+      {scan_size}, at::TensorOptions().dtype(dtype_out).device(device));
 
   const uint32_t matrix_size = ceil(sqrt(scan_size));
 
+  // FIXME: use vector or scalar cores to generate U and L on device
+  // Upper triangular matrix
+  const at::Tensor u = torch::triu(
+      torch::ones({matrix_size, matrix_size},
+                  at::TensorOptions().dtype(dtype_out).device(device)));
+  // Lower triangular matrix
+  const at::Tensor l = torch::tril(
+      torch::ones({matrix_size, matrix_size},
+                  at::TensorOptions().dtype(dtype_out).device(device)));
+
   if (dtype == at::kHalf) {
-    EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, scan, matrix_size);
+    EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, u, l, scan, matrix_size);
   } else if (dtype == at::kFloat) {
-    EXEC_KERNEL_CMD(scan_ul1_fp32, block_dim, x, scan, matrix_size);
+    EXEC_KERNEL_CMD(scan_ul1_fp32, block_dim, x, u, l, scan, matrix_size);
   }
 
   return scan;

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -11,46 +11,47 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_simple_matmul_fp16.h"
-#include "aclrtlaunch_simple_matmul_fp32.h"
+#include "aclrtlaunch_scan_ul1_fp16.h"
+#include "aclrtlaunch_scan_ul1_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {
 
 /**
- * @brief Simple matrix multiplication A @ B.
+ * @brief Single Cube scan
  *
- * @param [in] a Input left martrix
- * @param [in] b Input right matrix
- * @return at::Tensor Matrix multiplication result of a @ b.
+ * @param [in] x Input vector
+ * @return at::Tensor vector result of the scan operation.
  */
-at::Tensor run_simple_matmul(const at::Tensor& a, const at::Tensor& b) {
-  const at::Device device = a.options().device();
-  const auto dtype = a.options().dtype();
+at::Tensor run_scan_ul1(const at::Tensor& x) {
+  const at::Device device = x.options().device();
+  const auto dtype = x.options().dtype();
   const auto dtype_out = at::kFloat;
 
   if (!(dtype == at::kHalf or dtype == at::kFloat)) {
     throw std::runtime_error(
-        "Unsupported dtype for simple_matmul kernel. Supports only fp16/fp32");
+        "Unsupported dtype for scan_ul1 kernel. Supports only fp16/fp32");
   }
 
-  const uint32_t matrix_size = static_cast<uint32_t>(a.size(-1));
-  if (matrix_size != a.size(-2)) {
-    throw std::runtime_error("Only square matrices are supported.\n");
+  const uint32_t scan_size = static_cast<uint32_t>(x.size(-1));
+  if ( x.dim() != 1) {
+    throw std::runtime_error("Only 1D scan is supported.\n");
   }
 
   constexpr uint32_t block_dim = 1;
 
-  const at::Tensor c =
-      at::ones({matrix_size, matrix_size},
+  const at::Tensor scan =
+      at::zeros({scan_size},
                at::TensorOptions().dtype(dtype_out).device(device));
 
+  const uint32_t matrix_size = ceil(sqrt(scan_size));
+
   if (dtype == at::kHalf) {
-    EXEC_KERNEL_CMD(simple_matmul_fp16, block_dim, a, b, c, matrix_size);
+    EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, scan, matrix_size);
   } else if (dtype == at::kFloat) {
-    EXEC_KERNEL_CMD(simple_matmul_fp32, block_dim, a, b, c, matrix_size);
+    EXEC_KERNEL_CMD(scan_ul1_fp32, block_dim, x, scan, matrix_size);
   }
 
-  return c;
+  return scan;
 }
 }  // namespace pto_isa_ops

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -53,19 +53,17 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
   }
 
   // FIXME: use vector or scalar cores to generate O, U and L directly on the
-  // device Upper triangular matrix
-  const at::Tensor u =
-      torch::triu(torch::ones({matrix_size, matrix_size},
-                              at::TensorOptions().dtype(dtype).device(device)));
-  // Lower triangular matrix
-  const at::Tensor l =
-      torch::tril(torch::ones({matrix_size, matrix_size},
-                              at::TensorOptions().dtype(dtype).device(device)),
-                  -1);
+  // device
+  
   // Ones matrix
   const at::Tensor o =
       torch::ones({matrix_size, matrix_size},
                   at::TensorOptions().dtype(dtype).device(device));
+  // Upper triangular matrix
+  const at::Tensor u = torch::triu(o);
+  // Lower triangular matrix
+  const at::Tensor l =
+      torch::tril(o, -1);
 
   if (dtype == at::kHalf) {
     EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, o, u, l, scan, matrix_size);

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -45,16 +45,23 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
 
   const uint32_t matrix_size = ceil(sqrt(scan_size));
 
+  // FIXME: pad to support other sizes
+  if (matrix_size % 16 != 0) {
+    throw std::runtime_error(
+        "Matrix size must be a multiple of 16. Matrix size: " +
+        std::to_string(matrix_size));
+  }
+
   // FIXME: use vector or scalar cores to generate O, U and L directly on the
   // device Upper triangular matrix
   const at::Tensor u =
       torch::triu(torch::ones({matrix_size, matrix_size},
                               at::TensorOptions().dtype(dtype).device(device)));
   // Lower triangular matrix
-  const at::Tensor l = torch::tril(
-      torch::ones({matrix_size, matrix_size},
-                  at::TensorOptions().dtype(dtype_out).device(device)),
-      -1);
+  const at::Tensor l =
+      torch::tril(torch::ones({matrix_size, matrix_size},
+                              at::TensorOptions().dtype(dtype).device(device)),
+                  -1);
   // Ones matrix
   const at::Tensor o =
       torch::ones({matrix_size, matrix_size},

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -45,20 +45,23 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
 
   const uint32_t matrix_size = ceil(sqrt(scan_size));
 
-  // FIXME: use vector or scalar cores to generate U and L on device
+  // FIXME: use vector or scalar cores to generate O, U and L directly on the device
   // Upper triangular matrix
   const at::Tensor u = torch::triu(
       torch::ones({matrix_size, matrix_size},
-                  at::TensorOptions().dtype(dtype_out).device(device)));
+                  at::TensorOptions().dtype(dtype).device(device)));
   // Lower triangular matrix
   const at::Tensor l = torch::tril(
       torch::ones({matrix_size, matrix_size},
                   at::TensorOptions().dtype(dtype_out).device(device)));
+  // Ones matrix
+  const at::Tensor o = torch::ones({matrix_size, matrix_size},
+                                  at::TensorOptions().dtype(dtype).device(device)); 
 
   if (dtype == at::kHalf) {
-    EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, u, l, scan, matrix_size);
+    EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, o, u, l, scan, matrix_size);
   } else if (dtype == at::kFloat) {
-    EXEC_KERNEL_CMD(scan_ul1_fp32, block_dim, x, u, l, scan, matrix_size);
+    EXEC_KERNEL_CMD(scan_ul1_fp32, block_dim, x, o, u, l, scan, matrix_size);
   }
 
   return scan;

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -54,7 +54,7 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
 
   // FIXME: use vector or scalar cores to generate O, U and L directly on the
   // device
-  
+
   // Ones matrix
   const at::Tensor o =
       torch::ones({matrix_size, matrix_size},
@@ -62,8 +62,7 @@ at::Tensor run_scan_ul1(const at::Tensor& x) {
   // Upper triangular matrix
   const at::Tensor u = torch::triu(o);
   // Lower triangular matrix
-  const at::Tensor l =
-      torch::tril(o, -1);
+  const at::Tensor l = torch::tril(o, -1);
 
   if (dtype == at::kHalf) {
     EXEC_KERNEL_CMD(scan_ul1_fp16, block_dim, x, o, u, l, scan, matrix_size);

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -1,0 +1,56 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+#pragma once
+
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include "aclrtlaunch_simple_matmul_fp16.h"
+#include "aclrtlaunch_simple_matmul_fp32.h"
+#include "utils.h"
+
+namespace pto_isa_ops {
+
+/**
+ * @brief Simple matrix multiplication A @ B.
+ *
+ * @param [in] a Input left martrix
+ * @param [in] b Input right matrix
+ * @return at::Tensor Matrix multiplication result of a @ b.
+ */
+at::Tensor run_simple_matmul(const at::Tensor& a, const at::Tensor& b) {
+  const at::Device device = a.options().device();
+  const auto dtype = a.options().dtype();
+  const auto dtype_out = at::kFloat;
+
+  if (!(dtype == at::kHalf or dtype == at::kFloat)) {
+    throw std::runtime_error(
+        "Unsupported dtype for simple_matmul kernel. Supports only fp16/fp32");
+  }
+
+  const uint32_t matrix_size = static_cast<uint32_t>(a.size(-1));
+  if (matrix_size != a.size(-2)) {
+    throw std::runtime_error("Only square matrices are supported.\n");
+  }
+
+  constexpr uint32_t block_dim = 1;
+
+  const at::Tensor c =
+      at::ones({matrix_size, matrix_size},
+               at::TensorOptions().dtype(dtype_out).device(device));
+
+  if (dtype == at::kHalf) {
+    EXEC_KERNEL_CMD(simple_matmul_fp16, block_dim, a, b, c, matrix_size);
+  } else if (dtype == at::kFloat) {
+    EXEC_KERNEL_CMD(simple_matmul_fp32, block_dim, a, b, c, matrix_size);
+  }
+
+  return c;
+}
+}  // namespace pto_isa_ops

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -104,8 +104,9 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   // Move C1 from L0C to L1
   // TMOV_FLOAT(c1L1, sL0);
 
-  // Move C1 from L0C to GM  in the float case
-  // we cannot move to L1 because of downcasting
+  // Move C1 from L0C to GM, in the float case,
+  // we cannot move to L1 directly
+  // because of downcasting
   TSTORE(c1GM, sL0);
 
   // Wait for FP
@@ -126,7 +127,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   pipe_barrier(PIPE_M);
   TMATMUL(sL0, xL0, uL0);
 
-  // // >>>> DEBUG 
+  // // >>>> DEBUG
   // //For debugging: store C2 to GM
   // set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
   // wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
@@ -166,7 +167,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   pipe_barrier(PIPE_M);
   TMATMUL_ACC(sL0, sL0, lL0, c1L0);
 
-  // // >>>> DEBUG 
+  // // >>>> DEBUG
   // TMATMUL(sL0, lL0, c1L0);
   // // For debugging: store L @ C1 to GM
   // set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
@@ -213,10 +214,8 @@ AICORE void run_scan_ul1(__gm__ T* x, __gm__ T* o, __gm__ T* u, __gm__ float* l,
   }
 }
 
-extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void*
-o,
-                                                __gm__ void* u, __gm__ void*
-                                                l,
+extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void* o,
+                                                __gm__ void* u, __gm__ void* l,
                                                 __gm__ void* s,
                                                 uint32_t matrix_size) {
   run_scan_ul1<half>((__gm__ half*)x, (__gm__ half*)o, (__gm__ half*)u,

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -1,0 +1,165 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+#if defined __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
+
+// Placeholder for VEC compilation (the real kernel is CUBE-only).
+#define MEMORY_BASE
+#include <pto/common/type.hpp>
+
+extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
+                                                     __gm__ void* b,
+                                                     __gm__ void* c,
+                                                     uint32_t matrix_size) {}
+
+extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
+                                                     __gm__ void* b,
+                                                     __gm__ void* c,
+                                                     uint32_t matrix_size) {}
+
+#elif (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+
+#define MEMORY_BASE
+
+#include <pto/pto-inst.hpp>
+
+#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+
+using namespace pto;
+
+constexpr unsigned NUM_BLOCKS = 20;    // number of AICs
+constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
+
+template <pipe_t SrcPipe, pipe_t DstPipe>
+AICORE inline void SetFlag(uint32_t id) {
+  set_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+}
+template <pipe_t SrcPipe, pipe_t DstPipe>
+AICORE inline void WaitFlag(uint32_t id) {
+  wait_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+}
+
+template <typename InputT, typename OutputT, uint32_t matrix_size>
+AICORE void runKernelSimpleMatMul(__gm__ InputT* a, __gm__ InputT* b,
+                                  __gm__ OutputT* c) {
+  constexpr uint32_t tile_len = matrix_size * matrix_size;
+
+  /* Global Memory / Tensors */
+  using TensorShapeIn =
+      TileShape2D<InputT, matrix_size, matrix_size, Layout::ND>;
+  using TensorStridesIn =
+      BaseShape2D<InputT, matrix_size, matrix_size, Layout::ND>;
+  using GlobalTensorIn =
+      GlobalTensor<InputT, TensorShapeIn, TensorStridesIn, Layout::ND>;
+
+  using TensorShapeOut =
+      TileShape2D<OutputT, matrix_size, matrix_size, Layout::ND>;
+  using TensorStridesOut =
+      BaseShape2D<OutputT, matrix_size, matrix_size, Layout::ND>;
+  using GlobalTensorOut =
+      GlobalTensor<OutputT, TensorShapeOut, TensorStridesOut, Layout::ND>;
+
+  /* L1 Memory */
+  using TileL1AB =
+      Tile<TileType::Mat, InputT, matrix_size, matrix_size, BLayout::ColMajor,
+           matrix_size, matrix_size, SLayout::RowMajor, 512>;
+
+  /* L0 Memory */
+  using TileL0A = TileLeft<InputT, matrix_size, matrix_size>;
+  using TileL0B = TileRight<InputT, matrix_size, matrix_size>;
+  using TileL0C = TileAcc<OutputT, matrix_size, matrix_size>;
+
+  GlobalTensorIn a_global_in(a);
+  GlobalTensorIn b_global_in(b);
+  GlobalTensorOut c_global_out(c);
+  TASSIGN(a_global_in, a);
+  TASSIGN(b_global_in, b);
+  TASSIGN(c_global_out, c);
+
+  TileL1AB a_l1_tile;
+  TileL1AB b_l1_tile;
+  TASSIGN(a_l1_tile, 0x0);
+  TASSIGN(b_l1_tile, 0x0 + tile_len * sizeof(InputT));
+
+  TileL0A a_l0_tile;
+  TileL0B b_l0_tile;
+  TileL0C c_l0_tile;
+  // L0A/L0B/L0C are distinct scratchpads
+  TASSIGN(a_l0_tile, 0x0);
+  TASSIGN(b_l0_tile, 0x0);
+  TASSIGN(c_l0_tile, 0x0);
+
+  // LOAD matrix A from GM -> L1 (MTE2)
+  TLOAD(a_l1_tile, a_global_in);
+  TLOAD(b_l1_tile, b_global_in);
+  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+
+  // Copy A from L1 -> L0 (MTE1)
+  // MatMul unit waits (using id:0) for MTE1 to load matrices into L0A/B
+  TMOV(a_l0_tile, a_l1_tile);
+  // Copy B from L1 -> L0B
+  // MatMul unit waits (using id:1) for MTE1 to load matrices into L0A/B
+  TMOV(b_l0_tile, b_l1_tile);
+  SetFlag<PIPE_MTE1, PIPE_M>(0);   // MTE1 pipe sets flag for MM pipe
+  WaitFlag<PIPE_MTE1, PIPE_M>(0);  // MM pipe waits for MTE1 pipe to set flag
+
+  // MATMUL (M)
+  TMATMUL(c_l0_tile, a_l0_tile, b_l0_tile);
+  pipe_barrier(PIPE_ALL);
+  SetFlag<PIPE_M, PIPE_FIX>(0);   // M pipe sets flag for FIX pipe
+  WaitFlag<PIPE_M, PIPE_FIX>(0);  // FIX pipe waits for M pipe to set flag
+  TSTORE(c_global_out, c_l0_tile);
+}
+
+template <typename T>
+AICORE void run_simple_matmul(__gm__ T* a, __gm__ T* b, __gm__ float* c,
+                              uint32_t matrix_size) {
+  static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
+                "simple_matmul supports only fp16/fp32.");
+
+  switch (matrix_size) {
+    case 16:
+      runKernelSimpleMatMul<T, float, 16>(a, b, c);
+      break;
+    case 32:
+      runKernelSimpleMatMul<T, float, 32>(a, b, c);
+      break;
+
+    case 64:
+      runKernelSimpleMatMul<T, float, 64>(a, b, c);
+      break;
+
+    case 96:
+      runKernelSimpleMatMul<T, float, 96>(a, b, c);
+      break;
+
+    case 128:
+      runKernelSimpleMatMul<T, float, 128>(a, b, c);
+      break;
+  }
+}
+
+extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
+                                                     __gm__ void* b,
+                                                     __gm__ void* c,
+                                                     uint32_t matrix_size) {
+  run_simple_matmul<half>((__gm__ half*)a, (__gm__ half*)b, (__gm__ float*)c,
+                          matrix_size);
+}
+
+extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
+                                                     __gm__ void* b,
+                                                     __gm__ void* c,
+                                                     uint32_t matrix_size) {
+  run_simple_matmul<float>((__gm__ float*)a, (__gm__ float*)b, (__gm__ float*)c,
+                           matrix_size);
+}
+
+#endif

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -12,14 +12,12 @@ for the full License text.
 #define MEMORY_BASE
 #include <pto/common/type.hpp>
 
-extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
+extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x,
+                                                     __gm__ void* s,
                                                      uint32_t matrix_size) {}
 
-extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
+extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x,
+                                                     __gm__ void* s,
                                                      uint32_t matrix_size) {}
 
 #elif (__CHECK_FEATURE_AT_PRECOMPILE) || \
@@ -33,96 +31,20 @@ extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
 
 using namespace pto;
 
-constexpr unsigned NUM_BLOCKS = 20;    // number of AICs
 constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
 
-template <pipe_t SrcPipe, pipe_t DstPipe>
-AICORE inline void SetFlag(uint32_t id) {
-  set_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
-}
-template <pipe_t SrcPipe, pipe_t DstPipe>
-AICORE inline void WaitFlag(uint32_t id) {
-  wait_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
-}
 
 template <typename InputT, typename OutputT, uint32_t matrix_size>
-AICORE void runKernelSimpleMatMul(__gm__ InputT* a, __gm__ InputT* b,
+AICORE void runKernelSimpleMatMul(__gm__ InputT* a,
                                   __gm__ OutputT* c) {
-  constexpr uint32_t tile_len = matrix_size * matrix_size;
 
-  /* Global Memory / Tensors */
-  using TensorShapeIn =
-      TileShape2D<InputT, matrix_size, matrix_size, Layout::ND>;
-  using TensorStridesIn =
-      BaseShape2D<InputT, matrix_size, matrix_size, Layout::ND>;
-  using GlobalTensorIn =
-      GlobalTensor<InputT, TensorShapeIn, TensorStridesIn, Layout::ND>;
-
-  using TensorShapeOut =
-      TileShape2D<OutputT, matrix_size, matrix_size, Layout::ND>;
-  using TensorStridesOut =
-      BaseShape2D<OutputT, matrix_size, matrix_size, Layout::ND>;
-  using GlobalTensorOut =
-      GlobalTensor<OutputT, TensorShapeOut, TensorStridesOut, Layout::ND>;
-
-  /* L1 Memory */
-  using TileL1AB =
-      Tile<TileType::Mat, InputT, matrix_size, matrix_size, BLayout::ColMajor,
-           matrix_size, matrix_size, SLayout::RowMajor, 512>;
-
-  /* L0 Memory */
-  using TileL0A = TileLeft<InputT, matrix_size, matrix_size>;
-  using TileL0B = TileRight<InputT, matrix_size, matrix_size>;
-  using TileL0C = TileAcc<OutputT, matrix_size, matrix_size>;
-
-  GlobalTensorIn a_global_in(a);
-  GlobalTensorIn b_global_in(b);
-  GlobalTensorOut c_global_out(c);
-  TASSIGN(a_global_in, a);
-  TASSIGN(b_global_in, b);
-  TASSIGN(c_global_out, c);
-
-  TileL1AB a_l1_tile;
-  TileL1AB b_l1_tile;
-  TASSIGN(a_l1_tile, 0x0);
-  TASSIGN(b_l1_tile, 0x0 + tile_len * sizeof(InputT));
-
-  TileL0A a_l0_tile;
-  TileL0B b_l0_tile;
-  TileL0C c_l0_tile;
-  // L0A/L0B/L0C are distinct scratchpads
-  TASSIGN(a_l0_tile, 0x0);
-  TASSIGN(b_l0_tile, 0x0);
-  TASSIGN(c_l0_tile, 0x0);
-
-  // LOAD matrix A from GM -> L1 (MTE2)
-  TLOAD(a_l1_tile, a_global_in);
-  TLOAD(b_l1_tile, b_global_in);
-  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
-  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-
-  // Copy A from L1 -> L0 (MTE1)
-  // MatMul unit waits (using id:0) for MTE1 to load matrices into L0A/B
-  TMOV(a_l0_tile, a_l1_tile);
-  // Copy B from L1 -> L0B
-  // MatMul unit waits (using id:1) for MTE1 to load matrices into L0A/B
-  TMOV(b_l0_tile, b_l1_tile);
-  SetFlag<PIPE_MTE1, PIPE_M>(0);   // MTE1 pipe sets flag for MM pipe
-  WaitFlag<PIPE_MTE1, PIPE_M>(0);  // MM pipe waits for MTE1 pipe to set flag
-
-  // MATMUL (M)
-  TMATMUL(c_l0_tile, a_l0_tile, b_l0_tile);
-  pipe_barrier(PIPE_ALL);
-  SetFlag<PIPE_M, PIPE_FIX>(0);   // M pipe sets flag for FIX pipe
-  WaitFlag<PIPE_M, PIPE_FIX>(0);  // FIX pipe waits for M pipe to set flag
-  TSTORE(c_global_out, c_l0_tile);
 }
 
 template <typename T>
-AICORE void run_simple_matmul(__gm__ T* a, __gm__ T* b, __gm__ float* c,
+AICORE void run_scan_ul1(__gm__ T* a, __gm__ float* c,
                               uint32_t matrix_size) {
   static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
-                "simple_matmul supports only fp16/fp32.");
+                "scan_ul1 supports only fp16/fp32.");
 
   switch (matrix_size) {
     case 16:
@@ -146,19 +68,17 @@ AICORE void run_simple_matmul(__gm__ T* a, __gm__ T* b, __gm__ float* c,
   }
 }
 
-extern "C" __global__ AICORE void simple_matmul_fp16(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
+extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x,
+                                                     __gm__ void* s,
                                                      uint32_t matrix_size) {
-  run_simple_matmul<half>((__gm__ half*)a, (__gm__ half*)b, (__gm__ float*)c,
+  run_scan_ul1<half>((__gm__ half*)a, (__gm__ float*)c,
                           matrix_size);
 }
 
-extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
-                                                     __gm__ void* b,
-                                                     __gm__ void* c,
+extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x,
+                                                     __gm__ void* s,
                                                      uint32_t matrix_size) {
-  run_simple_matmul<float>((__gm__ float*)a, (__gm__ float*)b, (__gm__ float*)c,
+  run_scan_ul1<float>((__gm__ float*)a, (__gm__ float*)c,
                            matrix_size);
 }
 

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -16,7 +16,7 @@ constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
 
 template <typename InputT, typename OutputT, uint32_t matrix_size>
 AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
-                             __gm__ InputT* u, __gm__ OutputT* l,
+                             __gm__ InputT* u, __gm__ InputT* l,
                              __gm__ OutputT* s) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
@@ -47,16 +47,17 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   GlobalDataIn xGlobal(x);
   GlobalDataIn oGlobal(o);
   GlobalDataIn uGlobal(u);
-  GlobalDataOut lGlobal(l);
+  GlobalDataIn lGlobal(l);
   GlobalDataOut sGlobal(s);
-  GlobalDataOut c1GM(s);  // Reuse output buffer for intermediate result C1
+  // Reuse output buffer for intermediate result C1
+  GlobalDataIn c1GM(reinterpret_cast<__gm__ InputT*>(s));
 
   // Load data from GM to L1
   TileL1In xL1;
   TileL1In oL1;
   TileL1In uL1;
-  TileL1Out c1L1;
-  TileL1Out lL1;
+  TileL1In c1L1;
+  TileL1In lL1;
   TASSIGN(xL1, 0x0);
   const uint32_t tile_l1_in_byte_size =
       matrix_size * matrix_size * sizeof(InputT);
@@ -65,7 +66,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   TASSIGN(oL1, 0x0 + tile_l1_in_byte_size);
   TASSIGN(uL1, 0x0 + 2 * tile_l1_in_byte_size);
   TASSIGN(c1L1, 0x0 + 3 * tile_l1_in_byte_size);
-  TASSIGN(lL1, 0x0 + 3 * tile_l1_in_byte_size + tile_l1_out_byte_size);
+  TASSIGN(lL1, 0x0 + 4 * tile_l1_in_byte_size);
 
   TLOAD(xL1, xGlobal);
   TLOAD(oL1, oGlobal);
@@ -150,12 +151,12 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 
   // Load Ls from L1 to L0
-  TileL0AOut lL0;
+  TileL0A lL0;
   TASSIGN(lL0, 0x0);
   TMOV(lL0, lL1);
 
   // Load C1 from L1 to L0
-  TileL0BOut c1L0;
+  TileL0B c1L0;
   TASSIGN(c1L0, 0x0);
   TMOV(c1L0, c1L1);
 
@@ -187,7 +188,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
 }
 
 template <typename T>
-AICORE void run_scan_ul1(__gm__ T* x, __gm__ T* o, __gm__ T* u, __gm__ float* l,
+AICORE void run_scan_ul1(__gm__ T* x, __gm__ T* o, __gm__ T* u, __gm__ T* l,
                          __gm__ float* s, uint32_t matrix_size) {
   static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
                 "scan_ul1 supports only fp16/fp32.");
@@ -199,15 +200,12 @@ AICORE void run_scan_ul1(__gm__ T* x, __gm__ T* o, __gm__ T* u, __gm__ float* l,
     case 32:
       runKernelScanUl1<T, float, 32>(x, o, u, l, s);
       break;
-
     case 64:
       runKernelScanUl1<T, float, 64>(x, o, u, l, s);
       break;
-
     case 96:
       runKernelScanUl1<T, float, 96>(x, o, u, l, s);
       break;
-
     case 128:
       runKernelScanUl1<T, float, 128>(x, o, u, l, s);
       break;
@@ -218,8 +216,8 @@ extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void* o,
                                                 __gm__ void* u, __gm__ void* l,
                                                 __gm__ void* s,
                                                 uint32_t matrix_size) {
-  run_scan_ul1<half>((__gm__ half*)x, (__gm__ half*)o, (__gm__ half*)u,
-                     (__gm__ float*)l, (__gm__ float*)s, matrix_size);
+  run_scan_ul1((__gm__ half*)x, (__gm__ half*)o, (__gm__ half*)u,
+               (__gm__ half*)l, (__gm__ float*)s, matrix_size);
 }
 
 extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x, __gm__ void* o,
@@ -227,6 +225,6 @@ extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x, __gm__ void* o,
 
                                                 __gm__ void* l, __gm__ void* s,
                                                 uint32_t matrix_size) {
-  run_scan_ul1<float>((__gm__ float*)x, (__gm__ float*)o, (__gm__ float*)u,
-                      (__gm__ float*)l, (__gm__ float*)s, matrix_size);
+  run_scan_ul1((__gm__ float*)x, (__gm__ float*)o, (__gm__ float*)u,
+               (__gm__ float*)l, (__gm__ float*)s, matrix_size);
 }

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -7,7 +7,7 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include "kernel_utils.h"
 #include <pto/pto-inst.hpp>
 
 using namespace pto;

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -38,7 +38,9 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
 
   // L0
   using TileL0A = TileLeft<InputT, matrix_size, matrix_size>;
+  using TileL0AOut = TileLeft<OutputT, matrix_size, matrix_size>;
   using TileL0B = TileRight<InputT, matrix_size, matrix_size>;
+  using TileL0BOut = TileRight<OutputT, matrix_size, matrix_size>;
   using TileL0C = TileAcc<OutputT, matrix_size, matrix_size>;
 
   // GM Data
@@ -52,16 +54,22 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   TileL1In xL1;
   TileL1In oL1;
   TileL1In uL1;
-  TileL1Out sL1;
+  TileL1Out c1L1;
+  TileL1Out lL1;
   TASSIGN(xL1, 0x0);
-  const uint32_t tile_l1_in_byte_size = matrix_size * matrix_size * sizeof(InputT);
-  const uint32_t tile_l1_out_byte_size = matrix_size * matrix_size * sizeof(OutputT);
+  const uint32_t tile_l1_in_byte_size =
+      matrix_size * matrix_size * sizeof(InputT);
+  const uint32_t tile_l1_out_byte_size =
+      matrix_size * matrix_size * sizeof(OutputT);
   TASSIGN(oL1, 0x0 + tile_l1_in_byte_size);
   TASSIGN(uL1, 0x0 + 2 * tile_l1_in_byte_size);
-  TASSIGN(sL1, 0x0 + 3 *tile_l1_in_byte_size);
+  TASSIGN(c1L1, 0x0 + 3 * tile_l1_in_byte_size);
+  TASSIGN(lL1, 0x0 + 3 * tile_l1_in_byte_size + tile_l1_out_byte_size);
+
   TLOAD(xL1, xGlobal);
   TLOAD(oL1, oGlobal);
   TLOAD(uL1, uGlobal);
+  TLOAD(lL1, lGlobal);
 
   // Wait for load to complete before moving data to L0
   set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -69,23 +77,66 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
 
   // Load data from L1 to L0
   TileL0A xL0;
-  TileL0B uL0;
+  TileL0B oL0;
   TileL0C sL0;
-  
+
   // L0A/L0B/L0C are distinct scratchpads
   TASSIGN(xL0, 0x0);
-  TASSIGN(uL0, 0x0);
+  TASSIGN(oL0, 0x0);
   TASSIGN(sL0, 0x0);
 
   TMOV(xL0, xL1);
+  TMOV(oL0, oL1);
   TMOV(uL0, uL1);
+
   // Cube unit waits for MTE1
   set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
   wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 
   // In the paper notation C1 = As @ 1s
+  // row-wise reduction for the A tile
+  TMATMUL(sL0, xL0, oL0);
+
+  // Wait for matmul to complete before storing result back to GM
+  set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+  // Move C1 from L0C to L1
+  TMOV(cL1, sL0);
+
+  // Wait for FP
+  set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+
+  // Load Us from L1 to L0
+  TileL0B uL0;
+  TASSIGN(uL0, 0x0)
+  TMOV(uL0, uL1);
+
+  // Int the paper notation C2 = A @ U
   // row-wise inclusive scan for the A tile
   TMATMUL(sL0, xL0, uL0);
+
+  // Wait for matmul to complet before loading Ls and C1
+  set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+
+  // Load Ls from L1 to L0
+  TileL0AOut lL0;
+  TASSIGN(lL0, 0x0);
+  TMOV(lL0, lL1);
+
+  // Load C1 from L1 to L0
+  TileL0BOut c1L0;
+  TASSIGN(c1L0, 0x0);
+  TMOV(c1L0, c1L1);
+
+  // Wait for load to be complete
+  set_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
+  wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
+
+  // In the paper notation C2 += Ls @ C1
+  TMATMUL_ACC(sL0, lL0, c1L0);
 
   // Wait for matmul to complete before storing result back to GM
   set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -6,28 +6,9 @@ See LICENSE in the root of the software repository:
 https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
-#if defined __CCE_AICORE__ == 220 && defined(__DAV_C220_VEC__)
-
-// Placeholder for VEC compilation (the real kernel is CUBE-only).
-#define MEMORY_BASE
-#include <pto/common/type.hpp>
-
-extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x,
-                                                     __gm__ void* s,
-                                                     uint32_t matrix_size) {}
-
-extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x,
-                                                     __gm__ void* s,
-                                                     uint32_t matrix_size) {}
-
-#elif (__CHECK_FEATURE_AT_PRECOMPILE) || \
-    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
-
-#define MEMORY_BASE
-
-#include <pto/pto-inst.hpp>
 
 #define GM_ADDR __gm__ uint8_t*  // To avoid #include "kernel_operator.h"
+#include <pto/pto-inst.hpp>
 
 using namespace pto;
 
@@ -35,35 +16,40 @@ constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
 
 
 template <typename InputT, typename OutputT, uint32_t matrix_size>
-AICORE void runKernelSimpleMatMul(__gm__ InputT* a,
-                                  __gm__ OutputT* c) {
+AICORE void runKernelScanUl1(__gm__ InputT* x,
+                                  __gm__ OutputT* s) {
 
+#if (__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+#else
+// Nothing to do on VEC
+#endif
 }
 
 template <typename T>
-AICORE void run_scan_ul1(__gm__ T* a, __gm__ float* c,
+AICORE void run_scan_ul1(__gm__ T* x, __gm__ float* s,
                               uint32_t matrix_size) {
   static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
                 "scan_ul1 supports only fp16/fp32.");
 
   switch (matrix_size) {
     case 16:
-      runKernelSimpleMatMul<T, float, 16>(a, b, c);
+      runKernelScanUl1<T, float, 16>(x, s);
       break;
     case 32:
-      runKernelSimpleMatMul<T, float, 32>(a, b, c);
+      runKernelScanUl1<T, float, 32>(x, s);
       break;
 
     case 64:
-      runKernelSimpleMatMul<T, float, 64>(a, b, c);
+      runKernelScanUl1<T, float, 64>(x, s);
       break;
 
     case 96:
-      runKernelSimpleMatMul<T, float, 96>(a, b, c);
+      runKernelScanUl1<T, float, 96>(x, s);
       break;
 
     case 128:
-      runKernelSimpleMatMul<T, float, 128>(a, b, c);
+      runKernelScanUl1<T, float, 128>(x, s);
       break;
   }
 }
@@ -71,15 +57,13 @@ AICORE void run_scan_ul1(__gm__ T* a, __gm__ float* c,
 extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x,
                                                      __gm__ void* s,
                                                      uint32_t matrix_size) {
-  run_scan_ul1<half>((__gm__ half*)a, (__gm__ float*)c,
+  run_scan_ul1<half>((__gm__ half*)x, (__gm__ float*)s,
                           matrix_size);
 }
 
 extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x,
                                                      __gm__ void* s,
                                                      uint32_t matrix_size) {
-  run_scan_ul1<float>((__gm__ float*)a, (__gm__ float*)c,
+  run_scan_ul1<float>((__gm__ float*)x, (__gm__ float*)s,
                            matrix_size);
 }
-
-#endif

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -14,6 +14,24 @@ using namespace pto;
 
 constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
 
+/**
+ * @brief Kernel implementation for scan operation on a single cube.
+ *
+ * The implemetation follows the ScanUL1 algorithm described in [1]
+ *
+ * [1] Parallel Scan on Ascend AI Accelerators
+ * (https://arxiv.org/abs/2505.15112v1).
+ *
+ * @tparam InputT Input data type. Supports `fp16` or `fp32`
+ * @tparam OutputT Output data type 'fp32`
+ * @tparam matrix_size Size of the square matrix
+ *
+ * @param x Input matrix in GM
+ * @param o Ones matrix in GM
+ * @param u Upper triangular matrix in GM
+ * @param l Lower triangular matrix in GM
+ * @param s Output matrix in GM, also used as intermediate buffer for C1
+ */
 template <typename InputT, typename OutputT, uint32_t matrix_size>
 AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
                              __gm__ InputT* u, __gm__ InputT* l,

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -7,8 +7,9 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#include "kernel_utils.h"
 #include <pto/pto-inst.hpp>
+
+#include "kernel_utils.h"
 
 using namespace pto;
 

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -15,7 +15,9 @@ using namespace pto;
 constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
 
 template <typename InputT, typename OutputT, uint32_t matrix_size>
-AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ OutputT* s) {
+AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
+                             __gm__ InputT* u, __gm__ OutputT* l,
+                             __gm__ OutputT* s) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
 
@@ -23,11 +25,15 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ OutputT* s) {
   // GM
   using Shape = pto::Shape<1, 1, 1, matrix_size, matrix_size>;
   using Stride = pto::Stride<1, 1, 1, matrix_size, 1>;
-  using GlobalData = pto::GlobalTensor<InputT, Shape, Stride, Layout::ND>;
+  using GlobalDataIn = pto::GlobalTensor<InputT, Shape, Stride, Layout::ND>;
+  using GlobalDataOut = pto::GlobalTensor<OutputT, Shape, Stride, Layout::ND>;
 
   // L1
-  using TileL1 =
+  using TileL1In =
       Tile<TileType::Mat, InputT, matrix_size, matrix_size, BLayout::ColMajor,
+           matrix_size, matrix_size, SLayout::RowMajor, 512>;
+  using TileL1Out =
+      Tile<TileType::Mat, OutputT, matrix_size, matrix_size, BLayout::ColMajor,
            matrix_size, matrix_size, SLayout::RowMajor, 512>;
 
   // L0
@@ -36,22 +42,56 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ OutputT* s) {
   using TileL0C = TileAcc<OutputT, matrix_size, matrix_size>;
 
   // GM Data
-  GlobalData xGlobal(x);
-  GlobalData sGlobal(s);
+  GlobalDataIn xGlobal(x);
+  GlobalDataIn oGlobal(o);
+  GlobalDataIn uGlobal(u);
+  GlobalDataOut lGlobal(l);
+  GlobalDataOut sGlobal(s);
 
   // Load data from GM to L1
-  TileL1 xL1;
-  TileL1 sL1;
+  TileL1In xL1;
+  TileL1In oL1;
+  TileL1In uL1;
+  TileL1Out sL1;
   TASSIGN(xL1, 0x0);
-  const uint32_t tile_l1_byte_size = matrix_size * matrix_size * sizeof(InputT);
-  TASSIGN(sL1, 0x0 + tile_l1_byte_size);
+  const uint32_t tile_l1_in_byte_size = matrix_size * matrix_size * sizeof(InputT);
+  const uint32_t tile_l1_out_byte_size = matrix_size * matrix_size * sizeof(OutputT);
+  TASSIGN(oL1, 0x0 + tile_l1_in_byte_size);
+  TASSIGN(uL1, 0x0 + 2 * tile_l1_in_byte_size);
+  TASSIGN(sL1, 0x0 + 3 *tile_l1_in_byte_size);
   TLOAD(xL1, xGlobal);
+  TLOAD(oL1, oGlobal);
+  TLOAD(uL1, uGlobal);
+
   // Wait for load to complete before moving data to L0
   set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
   wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
 
   // Load data from L1 to L0
   TileL0A xL0;
+  TileL0B uL0;
+  TileL0C sL0;
+  
+  // L0A/L0B/L0C are distinct scratchpads
+  TASSIGN(xL0, 0x0);
+  TASSIGN(uL0, 0x0);
+  TASSIGN(sL0, 0x0);
+
+  TMOV(xL0, xL1);
+  TMOV(uL0, uL1);
+  // Cube unit waits for MTE1
+  set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+  wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
+  // In the paper notation C1 = As @ 1s
+  // row-wise inclusive scan for the A tile
+  TMATMUL(sL0, xL0, uL0);
+
+  // Wait for matmul to complete before storing result back to GM
+  set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+
+  TSTORE(sGlobal, sL0);
 
 #else
 // Nothing to do on VEC
@@ -59,42 +99,46 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ OutputT* s) {
 }
 
 template <typename T>
-AICORE void run_scan_ul1(__gm__ T* x, __gm__ float* s, uint32_t matrix_size) {
+AICORE void run_scan_ul1(__gm__ T* x, __gm__ T* o, __gm__ T* u, __gm__ float* l,
+                         __gm__ float* s, uint32_t matrix_size) {
   static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
                 "scan_ul1 supports only fp16/fp32.");
 
   switch (matrix_size) {
     case 16:
-      runKernelScanUl1<T, float, 16>(x, s);
+      runKernelScanUl1<T, float, 16>(x, o, u, l, s);
       break;
     case 32:
-      runKernelScanUl1<T, float, 32>(x, s);
+      runKernelScanUl1<T, float, 32>(x, o, u, l, s);
       break;
 
     case 64:
-      runKernelScanUl1<T, float, 64>(x, s);
+      runKernelScanUl1<T, float, 64>(x, o, u, l, s);
       break;
 
     case 96:
-      runKernelScanUl1<T, float, 96>(x, s);
+      runKernelScanUl1<T, float, 96>(x, o, u, l, s);
       break;
 
     case 128:
-      runKernelScanUl1<T, float, 128>(x, s);
+      runKernelScanUl1<T, float, 128>(x, o, u, l, s);
       break;
   }
 }
 
-extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void* u,
-                                                __gm__ void* l, __gm__ void* s,
+extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void* o,
+                                                __gm__ void* u, __gm__ void* l,
+                                                __gm__ void* s,
                                                 uint32_t matrix_size) {
-  run_scan_ul1<half>((__gm__ half*)x, (__gm__ half*)u, (__gm__ half*)l,
-                     (__gm__ float*)s, matrix_size);
+  run_scan_ul1<half>((__gm__ half*)x, (__gm__ half*)o, (__gm__ half*)u,
+                     (__gm__ float*)l, (__gm__ float*)s, matrix_size);
 }
 
-extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x, __gm__ void* u,
+extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x, __gm__ void* o,
+                                                __gm__ void* u,
+
                                                 __gm__ void* l, __gm__ void* s,
                                                 uint32_t matrix_size) {
-  run_scan_ul1<float>((__gm__ float*)x, (__gm__ float*)u, (__gm__ float*)l,
-                      (__gm__ float*)s, matrix_size);
+  run_scan_ul1<float>((__gm__ float*)x, (__gm__ float*)o, (__gm__ float*)u,
+                      (__gm__ float*)l, (__gm__ float*)s, matrix_size);
 }

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -87,7 +87,6 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
 
   TMOV(xL0, xL1);
   TMOV(oL0, oL1);
-  TMOV(uL0, uL1);
 
   // Cube unit waits for MTE1
   set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
@@ -102,7 +101,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
   // Move C1 from L0C to L1
-  TMOV(cL1, sL0);
+  TMOV(c1L1, sL0);
 
   // Wait for FP
   set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
@@ -110,7 +109,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
 
   // Load Us from L1 to L0
   TileL0B uL0;
-  TASSIGN(uL0, 0x0)
+  TASSIGN(uL0, 0x0);
   TMOV(uL0, uL1);
 
   // Int the paper notation C2 = A @ U
@@ -136,7 +135,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
 
   // In the paper notation C2 += Ls @ C1
-  TMATMUL_ACC(sL0, lL0, c1L0);
+  TMATMUL_ACC(sL0, sL0, lL0, c1L0);
 
   // Wait for matmul to complete before storing result back to GM
   set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -14,21 +14,52 @@ using namespace pto;
 
 constexpr unsigned UB_SIZE = 0x30000;  // 192KB UB of A2A3
 
-
 template <typename InputT, typename OutputT, uint32_t matrix_size>
-AICORE void runKernelScanUl1(__gm__ InputT* x,
-                                  __gm__ OutputT* s) {
-
+AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ OutputT* s) {
 #if (__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+
+  // Type definitions for different memory levels
+  // GM
+  using Shape = pto::Shape<1, 1, 1, matrix_size, matrix_size>;
+  using Stride = pto::Stride<1, 1, 1, matrix_size, 1>;
+  using GlobalData = pto::GlobalTensor<InputT, Shape, Stride, Layout::ND>;
+
+  // L1
+  using TileL1 =
+      Tile<TileType::Mat, InputT, matrix_size, matrix_size, BLayout::ColMajor,
+           matrix_size, matrix_size, SLayout::RowMajor, 512>;
+
+  // L0
+  using TileL0A = TileLeft<InputT, matrix_size, matrix_size>;
+  using TileL0B = TileRight<InputT, matrix_size, matrix_size>;
+  using TileL0C = TileAcc<OutputT, matrix_size, matrix_size>;
+
+  // GM Data
+  GlobalData xGlobal(x);
+  GlobalData sGlobal(s);
+
+  // Load data from GM to L1
+  TileL1 xL1;
+  TileL1 sL1;
+  TASSIGN(xL1, 0x0);
+  const uint32_t tile_l1_byte_size = matrix_size * matrix_size * sizeof(InputT);
+  TASSIGN(sL1, 0x0 + tile_l1_byte_size);
+  TLOAD(xL1, xGlobal);
+  // Wait for load to complete before moving data to L0
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+
+  // Load data from L1 to L0
+  TileL0A xL0;
+
 #else
 // Nothing to do on VEC
 #endif
 }
 
 template <typename T>
-AICORE void run_scan_ul1(__gm__ T* x, __gm__ float* s,
-                              uint32_t matrix_size) {
+AICORE void run_scan_ul1(__gm__ T* x, __gm__ float* s, uint32_t matrix_size) {
   static_assert(std::is_same_v<T, half> or std::is_same_v<T, float>,
                 "scan_ul1 supports only fp16/fp32.");
 
@@ -54,16 +85,16 @@ AICORE void run_scan_ul1(__gm__ T* x, __gm__ float* s,
   }
 }
 
-extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x,
-                                                     __gm__ void* s,
-                                                     uint32_t matrix_size) {
-  run_scan_ul1<half>((__gm__ half*)x, (__gm__ float*)s,
-                          matrix_size);
+extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void* u,
+                                                __gm__ void* l, __gm__ void* s,
+                                                uint32_t matrix_size) {
+  run_scan_ul1<half>((__gm__ half*)x, (__gm__ half*)u, (__gm__ half*)l,
+                     (__gm__ float*)s, matrix_size);
 }
 
-extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x,
-                                                     __gm__ void* s,
-                                                     uint32_t matrix_size) {
-  run_scan_ul1<float>((__gm__ float*)x, (__gm__ float*)s,
-                           matrix_size);
+extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x, __gm__ void* u,
+                                                __gm__ void* l, __gm__ void* s,
+                                                uint32_t matrix_size) {
+  run_scan_ul1<float>((__gm__ float*)x, (__gm__ float*)u, (__gm__ float*)l,
+                      (__gm__ float*)s, matrix_size);
 }

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -146,13 +146,6 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   pipe_barrier(PIPE_M);
   TMATMUL(sL0, xL0, uL0);
 
-  // // >>>> DEBUG
-  // //For debugging: store C2 to GM
-  // set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-  // wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-  // TSTORE(c1GM, sL0);
-  // // <<<< DEBUG
-
   // Wait for store to complete before loading C1
   set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
   wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
@@ -185,14 +178,6 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   // In the paper notation C2 += Ls @ C1
   pipe_barrier(PIPE_M);
   TMATMUL_ACC(sL0, sL0, lL0, c1L0);
-
-  // // >>>> DEBUG
-  // TMATMUL(sL0, lL0, c1L0);
-  // // For debugging: store L @ C1 to GM
-  // set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-  // wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-  // TSTORE(sGlobal, sL0);
-  // // <<<< DEBUG
 
   // Wait for matmul to complete before storing result back to GM
   set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -49,6 +49,7 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   GlobalDataIn uGlobal(u);
   GlobalDataOut lGlobal(l);
   GlobalDataOut sGlobal(s);
+  GlobalDataOut c1GM(s);  // Reuse output buffer for intermediate result C1
 
   // Load data from GM to L1
   TileL1In xL1;
@@ -101,7 +102,11 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 
   // Move C1 from L0C to L1
-  TMOV(c1L1, sL0);
+  // TMOV_FLOAT(c1L1, sL0);
+
+  // Move C1 from L0C to GM  in the float case
+  // we cannot move to L1 because of downcasting
+  TSTORE(c1GM, sL0);
 
   // Wait for FP
   set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
@@ -112,9 +117,32 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   TASSIGN(uL0, 0x0);
   TMOV(uL0, uL1);
 
+  // Cube unit waits for MTE1
+  set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+  wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+
   // Int the paper notation C2 = A @ U
   // row-wise inclusive scan for the A tile
+  pipe_barrier(PIPE_M);
   TMATMUL(sL0, xL0, uL0);
+
+  // // >>>> DEBUG 
+  // //For debugging: store C2 to GM
+  // set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  // wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  // TSTORE(c1GM, sL0);
+  // // <<<< DEBUG
+
+  // Wait for store to complete before loading C1
+  set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+  wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+
+  // Load C1 from GM to L1
+  TLOAD(c1L1, c1GM);
+
+  // Wait for load to be complete before moving C1 to L0
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
 
   // Wait for matmul to complet before loading Ls and C1
   set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
@@ -135,7 +163,16 @@ AICORE void runKernelScanUl1(__gm__ InputT* x, __gm__ InputT* o,
   wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
 
   // In the paper notation C2 += Ls @ C1
+  pipe_barrier(PIPE_M);
   TMATMUL_ACC(sL0, sL0, lL0, c1L0);
+
+  // // >>>> DEBUG 
+  // TMATMUL(sL0, lL0, c1L0);
+  // // For debugging: store L @ C1 to GM
+  // set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  // wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  // TSTORE(sGlobal, sL0);
+  // // <<<< DEBUG
 
   // Wait for matmul to complete before storing result back to GM
   set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
@@ -176,8 +213,10 @@ AICORE void run_scan_ul1(__gm__ T* x, __gm__ T* o, __gm__ T* u, __gm__ float* l,
   }
 }
 
-extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void* o,
-                                                __gm__ void* u, __gm__ void* l,
+extern "C" __global__ AICORE void scan_ul1_fp16(__gm__ void* x, __gm__ void*
+o,
+                                                __gm__ void* u, __gm__ void*
+                                                l,
                                                 __gm__ void* s,
                                                 uint32_t matrix_size) {
   run_scan_ul1<half>((__gm__ half*)x, (__gm__ half*)o, (__gm__ half*)u,

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -11,7 +11,7 @@ import pytest
 from pto_kernels import pto_scan_ul1
 
 
-@pytest.mark.parametrize("scan_size", [16*16])
+@pytest.mark.parametrize("scan_size", [16 * 16])
 @pytest.mark.parametrize("dtype", [torch.float32], ids=str)
 def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
     a = torch.ones(scan_size, dtype=dtype)
@@ -23,5 +23,5 @@ def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
 
     print("Scan result on NPU:", scan_npu.cpu())
     print("Reference result:", ref)
-    
+
     assert torch.allclose(scan_npu.cpu(), ref)

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -1,0 +1,23 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All rights reserved.
+# See LICENSE in the root of the software repository:
+# https://github.com/huawei-csl/pto-kernels/
+# for the full License text.
+# --------------------------------------------------------------------------------
+
+import torch
+import pytest
+from pto_kernels import pto_scan_ul1
+
+
+@pytest.mark.parametrize("scan_size", [16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=str)
+def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
+    a = torch.ones(scan_size, dtype=dtype)
+
+    a_npu = a.npu()
+    scan_npu = pto_scan_ul1(a_npu)
+
+    ref = torch.cumsum(a, dim=0)
+    assert torch.allclose(scan_npu.cpu(), ref)

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -10,18 +10,18 @@ import torch
 import pytest
 from pto_kernels import pto_scan_ul1
 
+size = [16, 32, 64, 128]
+matrix_size = [s * s for s in size]
 
-@pytest.mark.parametrize("scan_size", [16 * 16])
-@pytest.mark.parametrize("dtype", [torch.float32], ids=str)
+
+@pytest.mark.parametrize("scan_size", matrix_size)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=str)
 def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
     a = torch.ones(scan_size, dtype=dtype)
 
     a_npu = a.npu()
     scan_npu = pto_scan_ul1(a_npu)
 
-    ref = torch.cumsum(a, dim=0)
-
-    print("Scan result on NPU:", scan_npu.cpu())
-    print("Reference result:", ref)
+    ref = torch.cumsum(a.to(torch.float32), dim=0)
 
     assert torch.allclose(scan_npu.cpu(), ref)

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -20,4 +20,6 @@ def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
     scan_npu = pto_scan_ul1(a_npu)
 
     ref = torch.cumsum(a, dim=0)
+
+    breakpoint()
     assert torch.allclose(scan_npu.cpu(), ref)

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -21,5 +21,7 @@ def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
 
     ref = torch.cumsum(a, dim=0)
 
-    breakpoint()
+    print("Scan result on NPU:", scan_npu.cpu())
+    print("Reference result:", ref)
+    
     assert torch.allclose(scan_npu.cpu(), ref)

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -25,3 +25,7 @@ def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
     ref = torch.cumsum(a.to(torch.float32), dim=0)
 
     assert torch.allclose(scan_npu.cpu(), ref)
+
+
+if __name__ == "__main__":
+    test_pto_scan_ul1(128 * 128, torch.float32)

--- a/tests/test_scan_ul1.py
+++ b/tests/test_scan_ul1.py
@@ -11,8 +11,8 @@ import pytest
 from pto_kernels import pto_scan_ul1
 
 
-@pytest.mark.parametrize("scan_size", [16])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=str)
+@pytest.mark.parametrize("scan_size", [16*16])
+@pytest.mark.parametrize("dtype", [torch.float32], ids=str)
 def test_pto_scan_ul1(scan_size: int, dtype: torch.dtype):
     a = torch.ones(scan_size, dtype=dtype)
 


### PR DESCRIPTION
This PR implements the single core, cube only, prefix sum (scan) [algorithm](https://arxiv.org/abs/2505.15112v1). 
This implementation is the `ScanUL1` from the paper.