### PR TITLE
Test new tilelang varlen kernel

### DIFF
--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/chunk_gated_delta_rule_varlen_H32_kernel.cpp
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/chunk_gated_delta_rule_varlen_H32_kernel.cpp
@@ -1,0 +1,208 @@
+#include "common.h"
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace pto;
+
+AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ half *v_handle, __gm__ half *w_handle, __gm__ float *g_handle, __gm__ half *v_new_handle, __gm__ half *h0_handle, __gm__ half *ht_handle, __gm__ int *cu_seqlens_handle, __gm__ float *ws_wh_handle, __gm__ half *ws_vnew_handle, __gm__ half *ws_hupd_handle, __gm__ half *ws_h_handle, uint64_t ffts_Addr) {
+  auto cid = get_block_idx();
+  set_ffts_base_addr(ffts_Addr);
+
+  chunk_gdn_pto::TileMatL1<half, 128, 128, 128, 128> h_state_l1;
+  TASSIGN(h_state_l1, 0);
+  chunk_gdn_pto::TileMatL1<half, 64, 128, 64, 128> w_chunk_l1;
+  TASSIGN(w_chunk_l1, 32768);
+  TileAcc<float, 64, 128, 64, 128> wh_frag;
+  TASSIGN(wh_frag, 0);
+  chunk_gdn_pto::TileMatL1<half, 64, 128, 64, 128> v_new_l1;
+  TASSIGN(v_new_l1, 49152);
+  chunk_gdn_pto::TileMatL1<half, 64, 128, 64, 128> k_chunk_l1;
+  TASSIGN(k_chunk_l1, 65536);
+  TileAcc<float, 128, 128, 128, 128> hupd_frag;
+  TASSIGN(hupd_frag, 32768);
+  chunk_gdn_pto::TileUbDataND<half, 64, 128, 64, 128> h_state_ub;
+  TASSIGN(h_state_ub, 0);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> wh_ub_float;
+  TASSIGN(wh_ub_float, 16384);
+  chunk_gdn_pto::TileUbDataND<half, 32, 128, 32, 128> v_chunk_ub;
+  TASSIGN(v_chunk_ub, 32768);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> v_chunk_ub_float;
+  TASSIGN(v_chunk_ub_float, 40960);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> v_new_ub_float;
+  TASSIGN(v_new_ub_float, 57344);
+  chunk_gdn_pto::TileUbDataND<float, 1, 64, 1, 64> g_chunk_ub_all;
+  TASSIGN(g_chunk_ub_all, 73728);
+  chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub;
+  TASSIGN(g_chunk_ub, 73984);
+  chunk_gdn_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar;
+  TASSIGN(g_last_scalar, 74112);
+  chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub;
+  TASSIGN(g_exp_ub, 74144);
+  chunk_gdn_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad;
+  TASSIGN(g_exp_ub_pad, 74272);
+  chunk_gdn_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad;
+  TASSIGN(g_mask_ub_pad, 74528);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> g_exp_ub_broc;
+  TASSIGN(g_exp_ub_broc, 82752);
+  chunk_gdn_pto::TileUbDataND<uint8_t, 1, 8192, 1, 8192> tmp_ub;
+  TASSIGN(tmp_ub, 74560);
+  chunk_gdn_pto::TileUbDataND<float, 64, 128, 64, 128> h_state_ub_float;
+  TASSIGN(h_state_ub_float, 99136);
+  chunk_gdn_pto::TileUbDataND<half, 32, 128, 32, 128> v_new_ub;
+  TASSIGN(v_new_ub, 131904);
+  chunk_gdn_pto::TileUbDataND<half, 64, 128, 64, 128> hupd_ub;
+  TASSIGN(hupd_ub, 140096);
+  chunk_gdn_pto::TileUbDataND<float, 64, 128, 64, 128> hupd_ub_float;
+  TASSIGN(hupd_ub_float, 156480);
+  auto vid = get_subblockid();
+#if defined(__DAV_C220_CUBE__)
+    pipe_barrier(PIPE_ALL);
+    int32_t bos = *(cu_seqlens_handle + (cid / 32));
+    pipe_barrier(PIPE_ALL);
+    int32_t eos = *(cu_seqlens_handle + ((cid / 32) + 1));
+
+  for (int32_t i = 0; i < 16; ++i) {
+      pipe_barrier(PIPE_ALL);
+      if (i < (((eos + 63) - bos) / 64)) {
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 128, 128, 1048576, 524288, 16384, 128, 1, 128, 128>(ws_h_handle + (cid * 16384), 0, 0, 128, 128);
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 8650752, 4096, 1, 64, 128>(w_handle + (((i * 262144) + (bos * 4096)) + ((cid % 32) * 128)), 32768, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        chunk_gdn_pto::gemm_v0<half, float, 64, 128, 128, 64, 128, 128, 128, false, false>(w_chunk_l1, h_state_l1, wh_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        chunk_gdn_pto::copy_l0c_to_gm<float, float, 1, 1, 1, 64, 128, 524288, 262144, 8192, 128, 1, 64, 128>(ws_wh_handle + (cid * 8192), 0, 0, 64, 128);
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 524288, 262144, 8192, 128, 1, 64, 128>(ws_vnew_handle + (cid * 8192), 49152, 0, 64, 128);
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 4325376, 2048, 1, 64, 128>(k_handle + (((i * 131072) + (bos * 2048)) + (((cid % 32) / 2) * 128)), 65536, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        chunk_gdn_pto::gemm_v0<half, float, 128, 128, 64, 128, 128, 64, 64, true, false>(k_chunk_l1, v_new_l1, hupd_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        chunk_gdn_pto::copy_l0c_to_gm<half, float, 1, 1, 1, 128, 128, 1048576, 524288, 16384, 128, 1, 128, 128>(ws_hupd_handle + (cid * 16384), 32768, 0, 128, 128);
+      }
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
+    }
+#endif
+#if defined(__DAV_C220_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    pipe_barrier(PIPE_ALL);
+    int32_t bos_1 = *(cu_seqlens_handle + (cid / 32));
+    pipe_barrier(PIPE_ALL);
+    int32_t eos_1 = *(cu_seqlens_handle + ((cid / 32) + 1));
+    chunk_gdn_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 1048576, 524288, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(h0_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+
+  for (int32_t i_1 = 0; i_1 < 16; ++i_1) {
+      pipe_barrier(PIPE_ALL);
+      if (i_1 < (((eos_1 + 63) - bos_1) / 64)) {
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1, 1, 1, 1048576, 1, 64, 128>(ws_h_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 1, 128);
+        chunk_gdn_pto::copy_gm_to_ub<float, float, 1, 1, 1, 32, 128, 524288, 262144, 8192, 128, 1, 32, 128, pto::PadValue::Zero>(ws_wh_handle + ((cid * 8192) + (vid * 4096)), 16384, 0, 32, 128);
+        chunk_gdn_pto::copy_gm_to_ub<half, half, 1, 1, 1, 32, 128, 1, 1, 8650752, 4096, 1, 32, 128, pto::PadValue::Zero>(v_handle + ((((i_1 * 262144) + (vid * 131072)) + (bos_1 * 4096)) + ((cid % 32) * 128)), 32768, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TCVT(v_chunk_ub_float, v_chunk_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TSUB(v_new_ub_float, v_chunk_ub_float, wh_ub_float);
+        chunk_gdn_pto::copy_gm_to_ub<float, float, 1, 1, 1, 1, 64, 1, 1, 67584, 32, 1, 1, 64, pto::PadValue::Zero>(g_handle + (((i_1 * 2048) + (bos_1 * 32)) + (cid % 32)), 73728, 0, ((-2048 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-2112 < ((0 - bos_1) - (i_1 * 64))) ? ((2112 - bos_1) - (i_1 * 64)) : 0)), 1);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub_all_temp_0;
+        TASSIGN(g_chunk_ub_all_temp_0, 73728 + (vid * 32) * 4);
+        TMOV(g_chunk_ub, g_chunk_ub_all_temp_0);
+        pipe_barrier(PIPE_ALL);
+        if (((i_1 * 64) + 64) <= (eos_1 - bos_1)) {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue(63));
+        } else {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue((((((int64_t)eos_1) - ((int64_t)bos_1)) - (((int64_t)i_1) * (int64_t)64)) - (int64_t)1)));
+        }
+        pipe_barrier(PIPE_ALL);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        TEXPANDS(g_exp_ub, g_last_scalar.GetValue(0));
+        pipe_barrier(PIPE_V);
+        TSUB(g_exp_ub, g_exp_ub, g_chunk_ub);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_0;
+        TASSIGN(g_exp_ub_pad_temp_0, 74272 + 0 * 4);
+        TMOV(g_exp_ub_pad_temp_0, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad_temp_1;
+        TASSIGN(g_exp_ub_pad_temp_1, 74272 + 0 * 4);
+        chunk_gdn_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad_temp_0;
+        TASSIGN(g_mask_ub_pad_temp_0, 74528 + 0 * 1);
+        chunk_gdn_pto::compare_scalar(g_mask_ub_pad_temp_0, g_exp_ub_pad_temp_1, 0.000000e+00f, CmpMode::LE);
+        pipe_barrier(PIPE_V);
+        pto::TSELS(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, tmp_ub, -CUDART_INF_F);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_2;
+        TASSIGN(g_exp_ub_pad_temp_2, 74272 + 0 * 4);
+        TMOV(g_exp_ub, g_exp_ub_pad_temp_2);
+        pipe_barrier(PIPE_V);
+        TEXP(g_exp_ub, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataDN<float, 32, 1, 32, 1> g_exp_ub_temp_0;
+        TASSIGN(g_exp_ub_temp_0, 74144 + 0 * 4);
+        TROWEXPAND(g_exp_ub_broc, g_exp_ub_temp_0);
+        pipe_barrier(PIPE_V);
+        TMUL(v_new_ub_float, v_new_ub_float, g_exp_ub_broc);
+        chunk_gdn_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_0;
+        TASSIGN(g_last_scalar_temp_0, 74112 + 0 * 4);
+        chunk_gdn_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_1;
+        TASSIGN(g_last_scalar_temp_1, 74112 + 0 * 4);
+        TEXP(g_last_scalar_temp_1, g_last_scalar_temp_0);
+        TCVT(h_state_ub_float, h_state_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        auto g_last_scalar_scalar_temp_0 = g_last_scalar.GetValue(0);
+        TMULS(h_state_ub_float, h_state_ub_float, g_last_scalar_scalar_temp_0);
+        TCVT(v_new_ub, v_new_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 8650752, 4096, 1, 32, 128>(v_new_handle + ((((i_1 * 262144) + (vid * 131072)) + (bos_1 * 4096)) + ((cid % 32) * 128)), 131904, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 1, 524288, 1, 32, 128>(ws_vnew_handle + ((cid * 8192) + (vid * 4096)), 131904, 0, 1, 128);
+        chunk_gdn_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 1048576, 524288, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(ws_hupd_handle + ((cid * 16384) + (vid * 8192)), 140096, 0, 64, 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        TCVT(hupd_ub_float, hupd_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TADD(h_state_ub_float, h_state_ub_float, hupd_ub_float);
+        pipe_barrier(PIPE_V);
+        TCVT(h_state_ub, h_state_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 8388608, 524288, 16384, 128, 1, 64, 128>(h_handle + (((((cid / 32) * 8388608) + (i_1 * 524288)) + ((cid % 32) * 16384)) + (vid * 8192)), 0, 0, 64, 128);
+      }
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
+    }
+    chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1048576, 524288, 16384, 128, 1, 64, 128>(ht_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+#endif
+}
+
+extern "C" __global__ AICORE void launch_kernel(__gm__ uint8_t *h_handle, __gm__ uint8_t *k_handle, __gm__ uint8_t *v_handle, __gm__ uint8_t *w_handle, __gm__ uint8_t *g_handle, __gm__ uint8_t *v_new_handle, __gm__ uint8_t *h0_handle, __gm__ uint8_t *ht_handle, __gm__ uint8_t *cu_seqlens_handle, __gm__ uint8_t *ws_wh_handle, __gm__ uint8_t *ws_vnew_handle, __gm__ uint8_t *ws_hupd_handle, __gm__ uint8_t *ws_h_handle, uint64_t fftsAddr)
+{
+    main_kernel(reinterpret_cast<__gm__ half *>(h_handle),
+     reinterpret_cast<__gm__ half *>(k_handle),
+     reinterpret_cast<__gm__ half *>(v_handle),
+     reinterpret_cast<__gm__ half *>(w_handle),
+     reinterpret_cast<__gm__ float *>(g_handle),
+     reinterpret_cast<__gm__ half *>(v_new_handle),
+     reinterpret_cast<__gm__ half *>(h0_handle),
+     reinterpret_cast<__gm__ half *>(ht_handle),
+     reinterpret_cast<__gm__ int *>(cu_seqlens_handle),
+     reinterpret_cast<__gm__ float *>(ws_wh_handle),
+     reinterpret_cast<__gm__ half *>(ws_vnew_handle),
+     reinterpret_cast<__gm__ half *>(ws_hupd_handle),
+     reinterpret_cast<__gm__ half *>(ws_h_handle),
+     reinterpret_cast<uint64_t>(fftsAddr));
+}
+
+extern "C" void call(uint8_t *h_handle, uint8_t *k_handle, uint8_t *v_handle, uint8_t *w_handle, uint8_t *g_handle, uint8_t *v_new_handle, uint8_t *h0_handle, uint8_t *ht_handle, uint8_t *cu_seqlens_handle, uint8_t *ws_wh_handle, uint8_t *ws_vnew_handle, uint8_t *ws_hupd_handle, uint8_t *ws_h_handle, void *stream)
+{
+    uint32_t fftsLen{0};
+    uint64_t fftsAddr{0};
+    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+    launch_kernel<<<64, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
+}

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/chunk_gated_delta_rule_varlen_H48_kernel.cpp
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/chunk_gated_delta_rule_varlen_H48_kernel.cpp
@@ -1,0 +1,208 @@
+#include "common.h"
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace pto;
+
+AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ half *v_handle, __gm__ half *w_handle, __gm__ float *g_handle, __gm__ half *v_new_handle, __gm__ half *h0_handle, __gm__ half *ht_handle, __gm__ int *cu_seqlens_handle, __gm__ float *ws_wh_handle, __gm__ half *ws_vnew_handle, __gm__ half *ws_hupd_handle, __gm__ half *ws_h_handle, uint64_t ffts_Addr) {
+  auto cid = get_block_idx();
+  set_ffts_base_addr(ffts_Addr);
+
+  chunk_gdn_pto::TileMatL1<half, 128, 128, 128, 128> h_state_l1;
+  TASSIGN(h_state_l1, 0);
+  chunk_gdn_pto::TileMatL1<half, 64, 128, 64, 128> w_chunk_l1;
+  TASSIGN(w_chunk_l1, 32768);
+  TileAcc<float, 64, 128, 64, 128> wh_frag;
+  TASSIGN(wh_frag, 0);
+  chunk_gdn_pto::TileMatL1<half, 64, 128, 64, 128> v_new_l1;
+  TASSIGN(v_new_l1, 49152);
+  chunk_gdn_pto::TileMatL1<half, 64, 128, 64, 128> k_chunk_l1;
+  TASSIGN(k_chunk_l1, 65536);
+  TileAcc<float, 128, 128, 128, 128> hupd_frag;
+  TASSIGN(hupd_frag, 32768);
+  chunk_gdn_pto::TileUbDataND<half, 64, 128, 64, 128> h_state_ub;
+  TASSIGN(h_state_ub, 0);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> wh_ub_float;
+  TASSIGN(wh_ub_float, 16384);
+  chunk_gdn_pto::TileUbDataND<half, 32, 128, 32, 128> v_chunk_ub;
+  TASSIGN(v_chunk_ub, 32768);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> v_chunk_ub_float;
+  TASSIGN(v_chunk_ub_float, 40960);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> v_new_ub_float;
+  TASSIGN(v_new_ub_float, 57344);
+  chunk_gdn_pto::TileUbDataND<float, 1, 64, 1, 64> g_chunk_ub_all;
+  TASSIGN(g_chunk_ub_all, 73728);
+  chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub;
+  TASSIGN(g_chunk_ub, 73984);
+  chunk_gdn_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar;
+  TASSIGN(g_last_scalar, 74112);
+  chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub;
+  TASSIGN(g_exp_ub, 74144);
+  chunk_gdn_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad;
+  TASSIGN(g_exp_ub_pad, 74272);
+  chunk_gdn_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad;
+  TASSIGN(g_mask_ub_pad, 74528);
+  chunk_gdn_pto::TileUbDataND<float, 32, 128, 32, 128> g_exp_ub_broc;
+  TASSIGN(g_exp_ub_broc, 82752);
+  chunk_gdn_pto::TileUbDataND<uint8_t, 1, 8192, 1, 8192> tmp_ub;
+  TASSIGN(tmp_ub, 74560);
+  chunk_gdn_pto::TileUbDataND<float, 64, 128, 64, 128> h_state_ub_float;
+  TASSIGN(h_state_ub_float, 99136);
+  chunk_gdn_pto::TileUbDataND<half, 32, 128, 32, 128> v_new_ub;
+  TASSIGN(v_new_ub, 131904);
+  chunk_gdn_pto::TileUbDataND<half, 64, 128, 64, 128> hupd_ub;
+  TASSIGN(hupd_ub, 140096);
+  chunk_gdn_pto::TileUbDataND<float, 64, 128, 64, 128> hupd_ub_float;
+  TASSIGN(hupd_ub_float, 156480);
+  auto vid = get_subblockid();
+#if defined(__DAV_C220_CUBE__)
+    pipe_barrier(PIPE_ALL);
+    int32_t bos = *(cu_seqlens_handle + (cid / 48));
+    pipe_barrier(PIPE_ALL);
+    int32_t eos = *(cu_seqlens_handle + ((cid / 48) + 1));
+
+  for (int32_t i = 0; i < 4; ++i) {
+      pipe_barrier(PIPE_ALL);
+      if (i < (((eos + 63) - bos) / 64)) {
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 128, 128, 3932160, 786432, 16384, 128, 1, 128, 128>(ws_h_handle + (cid * 16384), 0, 0, 128, 128);
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 3489792, 6144, 1, 64, 128>(w_handle + (((i * 393216) + (bos * 6144)) + ((cid % 48) * 128)), 32768, 0, ((-504 <= ((0 - bos) - (i * 64))) ? 64 : ((-568 < ((0 - bos) - (i * 64))) ? ((568 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        chunk_gdn_pto::gemm_v0<half, float, 64, 128, 128, 64, 128, 128, 128, false, false>(w_chunk_l1, h_state_l1, wh_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        chunk_gdn_pto::copy_l0c_to_gm<float, float, 1, 1, 1, 64, 128, 1966080, 393216, 8192, 128, 1, 64, 128>(ws_wh_handle + (cid * 8192), 0, 0, 64, 128);
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1966080, 393216, 8192, 128, 1, 64, 128>(ws_vnew_handle + (cid * 8192), 49152, 0, 64, 128);
+        chunk_gdn_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 1163264, 2048, 1, 64, 128>(k_handle + (((i * 131072) + (bos * 2048)) + (((cid % 48) / 3) * 128)), 65536, 0, ((-504 <= ((0 - bos) - (i * 64))) ? 64 : ((-568 < ((0 - bos) - (i * 64))) ? ((568 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        chunk_gdn_pto::gemm_v0<half, float, 128, 128, 64, 128, 128, 64, 64, true, false>(k_chunk_l1, v_new_l1, hupd_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        chunk_gdn_pto::copy_l0c_to_gm<half, float, 1, 1, 1, 128, 128, 3932160, 786432, 16384, 128, 1, 128, 128>(ws_hupd_handle + (cid * 16384), 32768, 0, 128, 128);
+      }
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
+    }
+#endif
+#if defined(__DAV_C220_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    pipe_barrier(PIPE_ALL);
+    int32_t bos_1 = *(cu_seqlens_handle + (cid / 48));
+    pipe_barrier(PIPE_ALL);
+    int32_t eos_1 = *(cu_seqlens_handle + ((cid / 48) + 1));
+    chunk_gdn_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 3932160, 786432, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(h0_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+
+  for (int32_t i_1 = 0; i_1 < 4; ++i_1) {
+      pipe_barrier(PIPE_ALL);
+      if (i_1 < (((eos_1 + 63) - bos_1) / 64)) {
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1, 1, 1, 3932160, 1, 64, 128>(ws_h_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 1, 128);
+        chunk_gdn_pto::copy_gm_to_ub<float, float, 1, 1, 1, 32, 128, 1966080, 393216, 8192, 128, 1, 32, 128, pto::PadValue::Zero>(ws_wh_handle + ((cid * 8192) + (vid * 4096)), 16384, 0, 32, 128);
+        chunk_gdn_pto::copy_gm_to_ub<half, half, 1, 1, 1, 32, 128, 1, 1, 3489792, 6144, 1, 32, 128, pto::PadValue::Zero>(v_handle + ((((i_1 * 393216) + (vid * 196608)) + (bos_1 * 6144)) + ((cid % 48) * 128)), 32768, 0, ((-536 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-568 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((568 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TCVT(v_chunk_ub_float, v_chunk_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TSUB(v_new_ub_float, v_chunk_ub_float, wh_ub_float);
+        chunk_gdn_pto::copy_gm_to_ub<float, float, 1, 1, 1, 1, 64, 1, 1, 27264, 48, 1, 1, 64, pto::PadValue::Zero>(g_handle + (((i_1 * 3072) + (bos_1 * 48)) + (cid % 48)), 73728, 0, ((-504 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-568 < ((0 - bos_1) - (i_1 * 64))) ? ((568 - bos_1) - (i_1 * 64)) : 0)), 1);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub_all_temp_0;
+        TASSIGN(g_chunk_ub_all_temp_0, 73728 + (vid * 32) * 4);
+        TMOV(g_chunk_ub, g_chunk_ub_all_temp_0);
+        pipe_barrier(PIPE_ALL);
+        if (((i_1 * 64) + 64) <= (eos_1 - bos_1)) {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue(63));
+        } else {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue((((((int64_t)eos_1) - ((int64_t)bos_1)) - (((int64_t)i_1) * (int64_t)64)) - (int64_t)1)));
+        }
+        pipe_barrier(PIPE_ALL);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        TEXPANDS(g_exp_ub, g_last_scalar.GetValue(0));
+        pipe_barrier(PIPE_V);
+        TSUB(g_exp_ub, g_exp_ub, g_chunk_ub);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_0;
+        TASSIGN(g_exp_ub_pad_temp_0, 74272 + 0 * 4);
+        TMOV(g_exp_ub_pad_temp_0, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad_temp_1;
+        TASSIGN(g_exp_ub_pad_temp_1, 74272 + 0 * 4);
+        chunk_gdn_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad_temp_0;
+        TASSIGN(g_mask_ub_pad_temp_0, 74528 + 0 * 1);
+        chunk_gdn_pto::compare_scalar(g_mask_ub_pad_temp_0, g_exp_ub_pad_temp_1, 0.000000e+00f, CmpMode::LE);
+        pipe_barrier(PIPE_V);
+        pto::TSELS(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, tmp_ub, -CUDART_INF_F);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_2;
+        TASSIGN(g_exp_ub_pad_temp_2, 74272 + 0 * 4);
+        TMOV(g_exp_ub, g_exp_ub_pad_temp_2);
+        pipe_barrier(PIPE_V);
+        TEXP(g_exp_ub, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        chunk_gdn_pto::TileUbDataDN<float, 32, 1, 32, 1> g_exp_ub_temp_0;
+        TASSIGN(g_exp_ub_temp_0, 74144 + 0 * 4);
+        TROWEXPAND(g_exp_ub_broc, g_exp_ub_temp_0);
+        pipe_barrier(PIPE_V);
+        TMUL(v_new_ub_float, v_new_ub_float, g_exp_ub_broc);
+        chunk_gdn_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_0;
+        TASSIGN(g_last_scalar_temp_0, 74112 + 0 * 4);
+        chunk_gdn_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_1;
+        TASSIGN(g_last_scalar_temp_1, 74112 + 0 * 4);
+        TEXP(g_last_scalar_temp_1, g_last_scalar_temp_0);
+        TCVT(h_state_ub_float, h_state_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        auto g_last_scalar_scalar_temp_0 = g_last_scalar.GetValue(0);
+        TMULS(h_state_ub_float, h_state_ub_float, g_last_scalar_scalar_temp_0);
+        TCVT(v_new_ub, v_new_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 3489792, 6144, 1, 32, 128>(v_new_handle + ((((i_1 * 393216) + (vid * 196608)) + (bos_1 * 6144)) + ((cid % 48) * 128)), 131904, 0, ((-536 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-568 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((568 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 1, 1966080, 1, 32, 128>(ws_vnew_handle + ((cid * 8192) + (vid * 4096)), 131904, 0, 1, 128);
+        chunk_gdn_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 3932160, 786432, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(ws_hupd_handle + ((cid * 16384) + (vid * 8192)), 140096, 0, 64, 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        TCVT(hupd_ub_float, hupd_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TADD(h_state_ub_float, h_state_ub_float, hupd_ub_float);
+        pipe_barrier(PIPE_V);
+        TCVT(h_state_ub, h_state_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 3145728, 786432, 16384, 128, 1, 64, 128>(h_handle + (((((cid / 48) * 3145728) + (i_1 * 786432)) + ((cid % 48) * 16384)) + (vid * 8192)), 0, 0, 64, 128);
+      }
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
+    }
+    chunk_gdn_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 3932160, 786432, 16384, 128, 1, 64, 128>(ht_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+#endif
+}
+
+extern "C" __global__ AICORE void launch_kernel(__gm__ uint8_t *h_handle, __gm__ uint8_t *k_handle, __gm__ uint8_t *v_handle, __gm__ uint8_t *w_handle, __gm__ uint8_t *g_handle, __gm__ uint8_t *v_new_handle, __gm__ uint8_t *h0_handle, __gm__ uint8_t *ht_handle, __gm__ uint8_t *cu_seqlens_handle, __gm__ uint8_t *ws_wh_handle, __gm__ uint8_t *ws_vnew_handle, __gm__ uint8_t *ws_hupd_handle, __gm__ uint8_t *ws_h_handle, uint64_t fftsAddr)
+{
+    main_kernel(reinterpret_cast<__gm__ half *>(h_handle),
+     reinterpret_cast<__gm__ half *>(k_handle),
+     reinterpret_cast<__gm__ half *>(v_handle),
+     reinterpret_cast<__gm__ half *>(w_handle),
+     reinterpret_cast<__gm__ float *>(g_handle),
+     reinterpret_cast<__gm__ half *>(v_new_handle),
+     reinterpret_cast<__gm__ half *>(h0_handle),
+     reinterpret_cast<__gm__ half *>(ht_handle),
+     reinterpret_cast<__gm__ int *>(cu_seqlens_handle),
+     reinterpret_cast<__gm__ float *>(ws_wh_handle),
+     reinterpret_cast<__gm__ half *>(ws_vnew_handle),
+     reinterpret_cast<__gm__ half *>(ws_hupd_handle),
+     reinterpret_cast<__gm__ half *>(ws_h_handle),
+     reinterpret_cast<uint64_t>(fftsAddr));
+}
+
+extern "C" void call(uint8_t *h_handle, uint8_t *k_handle, uint8_t *v_handle, uint8_t *w_handle, uint8_t *g_handle, uint8_t *v_new_handle, uint8_t *h0_handle, uint8_t *ht_handle, uint8_t *cu_seqlens_handle, uint8_t *ws_wh_handle, uint8_t *ws_vnew_handle, uint8_t *ws_hupd_handle, uint8_t *ws_h_handle, void *stream)
+{
+    uint32_t fftsLen{0};
+    uint64_t fftsAddr{0};
+    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+    launch_kernel<<<240, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
+}

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/compile_varlen_kernels.sh
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/compile_varlen_kernels.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# After copying fresh dumps from ``tilelang_codegen/kernels/chunk_gated_delta_rule_varlen_H{32,48}.cpp``:
+#   - Replace ``#include \"tl_templates/pto/common.h\"`` + duplicate pto include with ``#include \"common.h\"``.
+#   - Replace ``tl::ascend_pto::`` with ``chunk_gdn_pto::``.
+#   - Replace ``TSELS(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, -CUDART_INF_F);`` with
+#     ``pto::TSELS(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, tmp_ub, -CUDART_INF_F);`` (pto-isa API).
+set -euo pipefail
+export PTO_LIB_PATH="${PTO_LIB_PATH:-/sources/pto-isa}"
+cd "$(dirname "$0")"
+python3 - <<'PY'
+from pto_static_common import compile_pto_kernel
+
+compile_pto_kernel(
+    "chunk_gated_delta_rule_varlen_H32_kernel.cpp",
+    "chunk_gated_delta_rule_varlen_H32_static.so",
+)
+compile_pto_kernel(
+    "chunk_gated_delta_rule_varlen_H48_kernel.cpp",
+    "chunk_gated_delta_rule_varlen_H48_static.so",
+)
+print("compiled chunk_gated_delta_rule_varlen_H{32,48}_static.so")
+PY

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/include/common.h
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/include/common.h
@@ -1,0 +1,1087 @@
+#include <pto/pto-inst.hpp>
+#include <type_traits>
+
+#ifdef __CCE_AICORE__
+#define CUDART_INF_F 1.0f / 0.0f
+
+namespace chunk_gdn_pto {
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL1 = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                            pto::BLayout::ColMajor, RowValid, ColValid,
+                            pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols,
+                              pto::BLayout::RowMajor, RowValid, ColValid,
+                              pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols>
+using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols,
+                             pto::BLayout::RowMajor, RowValid, ColValid,
+                             pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols, pto::PadValue PadVal = pto::PadValue::Null>
+using TileUbDataND =
+    pto::Tile<pto::TileType::Vec, T, Rows, Cols, pto::BLayout::RowMajor,
+              RowValid, ColValid, pto::SLayout::NoneBox, 512, PadVal>;
+
+template <typename T, int Rows, int Cols, int RowValid = Rows,
+          int ColValid = Cols, pto::PadValue PadVal = pto::PadValue::Null>
+using TileUbDataDN =
+    pto::Tile<pto::TileType::Vec, T, Rows, Cols, pto::BLayout::ColMajor,
+              RowValid, ColValid, pto::SLayout::NoneBox, 512, PadVal>;
+
+template <typename T, int32_t shape>
+AICORE PTO_INLINE void mov_tile(int32_t src_addr, int32_t dst_addr,
+                                int32_t src_offset, int32_t dst_offset,
+                                int32_t len) {
+  // TileUbDataND<float, 1, shape> src_temp_ub(1, shape);
+  TileUbDataND<T, 1, shape, 1, shape> src_temp_ub;
+  pto::TASSIGN(src_temp_ub, src_addr + src_offset * len);
+  TileUbDataND<T, 1, shape, 1, shape> dst_temp_ub;
+  pto::TASSIGN(dst_temp_ub, dst_addr + dst_offset * len);
+  pto::TMOV(dst_temp_ub, src_temp_ub);
+}
+
+template <typename T1, typename T2, int32_t shape>
+AICORE PTO_INLINE void cvt_tile(int32_t src_addr, int32_t dst_addr,
+                                int32_t src_offset, int32_t dst_offset,
+                                int32_t src_len, int32_t dst_len,
+                                pto::RoundMode rmode) {
+  TileUbDataND<T1, 1, shape, 1, shape> src_temp_ub;
+  pto::TASSIGN(src_temp_ub, src_addr + src_offset * src_len);
+  TileUbDataND<T2, 1, shape, 1, shape> dst_temp_ub;
+  pto::TASSIGN(dst_temp_ub, dst_addr + dst_offset * dst_len);
+  pto::TCVT(dst_temp_ub, src_temp_ub, rmode);
+}
+
+template <typename T, uint32_t M, uint32_t N, uint32_t M_L1, uint32_t N_L1,
+          bool transpose = false>
+AICORE PTO_INLINE void copy_l1_to_l0a(
+    TileMatL0A<T, M, N, M, N> &l0a,
+    std::conditional_t<transpose, TileMatL1ZN<T, M_L1, N_L1, M_L1, N_L1>,
+                       TileMatL1<T, M_L1, N_L1, M_L1, N_L1>> &A,
+    uint32_t indexRow, uint32_t indexCol) {
+  pto::TEXTRACT(l0a, A, indexRow, indexCol);
+}
+
+template <typename T, uint32_t M, uint32_t N, uint32_t M_L1, uint32_t N_L1,
+          bool transpose = false>
+AICORE PTO_INLINE void copy_l1_to_l0b(
+    TileMatL0B<T, M, N, M, N> &l0b,
+    std::conditional_t<transpose, TileMatL1ZN<T, M_L1, N_L1, M_L1, N_L1>,
+                       TileMatL1<T, M_L1, N_L1, M_L1, N_L1>> &B,
+    uint32_t indexRow, uint32_t indexCol) {
+  pto::TEXTRACT(l0b, B, indexRow, indexCol);
+}
+
+template <typename T1, typename T2, int M, int N, int K, int validM = M,
+          int validN = N>
+AICORE PTO_INLINE void mma(TileMatL0A<T1, M, K> l0a, TileMatL0B<T1, K, N> l0b,
+                           pto::TileAcc<T2, M, N, validM, validN> &C,
+                           bool init) {
+  if (init) {
+    pto::TMATMUL(C, l0a, l0b);
+  } else {
+    pto::TMATMUL_ACC(C, C, l0a, l0b);
+  }
+}
+
+template <typename T1, typename T2, uint32_t M, uint32_t N, uint32_t K,
+          uint32_t validM = M, uint32_t validN = N, uint32_t validK = K,
+          uint32_t K_tail, bool transpose_A = false, bool transpose_B = false>
+AICORE PTO_INLINE void
+gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>,
+                           TileMatL1<T1, M, K, validM, validK>> &A,
+        std::conditional_t<transpose_B, TileMatL1<T1, N, K, validN, validK>,
+                           TileMatL1<T1, K, N, validK, validN>> &B,
+        pto::TileAcc<T2, M, N, validM, validN> &C, bool clear) {
+  constexpr uint32_t kL0Size =
+      128; // L0 slice size, adapted to 64K memory limit
+  const uint32_t kL0split = (K + kL0Size - 1) / kL0Size; // Number of slices
+  bool initflag = false;
+
+  TileMatL0A<T1, M, kL0Size, M, kL0Size> l0a;
+  pto::TASSIGN(l0a, 0x0);
+  TileMatL0B<T1, kL0Size, N, kL0Size, N> l0b;
+  pto::TASSIGN(l0b, 0x0);
+
+  auto war_event_id = (event_t)(((int)EVENT_ID0 + 1) % 8);
+
+  set_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, war_event_id);
+
+  for (uint32_t kL0Idx = 0; kL0Idx < kL0split; kL0Idx++) {
+    initflag = (clear && (kL0Idx == 0));
+    const bool is_tail_block =
+        (kL0Idx == kL0split - 1); // Determine whether it is a tail block
+
+    // Dynamically define the L0 cache size based on whether the tile is an end
+    // tile.
+    if (is_tail_block) {
+      TileMatL0A<T1, M, K_tail, M, K_tail> l0a;
+      TileMatL0B<T1, K_tail, N, K_tail, N> l0b;
+      pto::TASSIGN(l0a, 0x0);
+      pto::TASSIGN(l0b, 0x0);
+
+      /**
+       * Added synchronization logic: Write-After-Read (WAR) protection
+       * Objective: Prevent MTE1 (data transfer) from overwriting L0 before M
+       * (Cube) completes processing the previous round of data
+       * TODO: Support Ping-Pong buffer.
+       */
+      set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+      wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+      if constexpr (!transpose_A) {
+        copy_l1_to_l0a<T1, M, K_tail, M, K, false>(l0a, A, 0, kL0Idx * K_tail);
+      } else {
+        TileMatL1ZN<T1, M, K, validM, validK> A_t;
+        pto::TRESHAPE(A_t, A);
+        copy_l1_to_l0a<T1, M, K_tail, M, K, true>(l0a, A_t, 0, kL0Idx * K_tail);
+      }
+      if constexpr (!transpose_B) {
+        copy_l1_to_l0b<T1, K_tail, N, K, N, false>(l0b, B, kL0Idx * K_tail, 0);
+      } else {
+        TileMatL1ZN<T1, K, N, validK, validN> B_t;
+        pto::TRESHAPE(B_t, B);
+        copy_l1_to_l0b<T1, K_tail, N, K, N, true>(l0b, B_t, kL0Idx * K_tail, 0);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+
+      if (initflag) {
+        pto::TMATMUL(C, l0a, l0b);
+      } else {
+        pto::TMATMUL_ACC(C, C, l0a, l0b);
+      }
+
+    } else {
+      // Non-tail block: The L0 cache is defined at the standard size
+      // (current_kSize = kL0Size=128).
+      TileMatL0A<T1, M, kL0Size, M, kL0Size> l0a;
+      TileMatL0B<T1, kL0Size, N, kL0Size, N> l0b;
+      pto::TASSIGN(l0a, 0x0);
+      pto::TASSIGN(l0b, 0x0);
+
+      set_flag(PIPE_M, PIPE_MTE1, war_event_id);
+      wait_flag(PIPE_M, PIPE_MTE1, war_event_id);
+
+      set_flag(PIPE_FIX, PIPE_M, war_event_id);
+      wait_flag(PIPE_FIX, PIPE_M, war_event_id);
+
+      if constexpr (!transpose_A) {
+        copy_l1_to_l0a<T1, M, kL0Size, M, K, false>(l0a, A, 0,
+                                                    kL0Idx * kL0Size);
+      } else {
+        TileMatL1ZN<T1, M, K, validM, validK> A_t;
+        pto::TRESHAPE(A_t, A);
+        copy_l1_to_l0a<T1, M, kL0Size, M, K, true>(l0a, A_t, 0,
+                                                   kL0Idx * kL0Size);
+      }
+      if constexpr (!transpose_B) {
+        copy_l1_to_l0b<T1, kL0Size, N, K, N, false>(l0b, B, kL0Idx * kL0Size,
+                                                    0);
+      } else {
+        TileMatL1ZN<T1, K, N, validK, validN> B_t;
+        pto::TRESHAPE(B_t, B);
+        copy_l1_to_l0b<T1, kL0Size, N, K, N, true>(l0b, B_t, kL0Idx * kL0Size,
+                                                   0);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_M, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_M, war_event_id);
+
+      if (initflag) {
+        pto::TMATMUL(C, l0a, l0b);
+      } else {
+        pto::TMATMUL_ACC(C, C, l0a, l0b);
+      }
+
+      set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+      wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+    }
+  }
+
+  set_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+  wait_flag(PIPE_MTE1, PIPE_MTE2, war_event_id);
+
+  set_flag(PIPE_M, PIPE_FIX, war_event_id);
+  wait_flag(PIPE_M, PIPE_FIX, war_event_id);
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t valid1, uint32_t valid2>
+AICORE PTO_INLINE void copy_gm_to_l1_dynamic(
+    __gm__ T1 *handle,
+    const pto::Shape<shape1, shape2, shape3, shape4, shape5> &shape,
+    const pto::Stride<stride1, stride2, stride3, stride4, stride5> &stride,
+    int32_t buffer_addr, int32_t offset, int32_t actualTailM = 0,
+    int32_t actualTailN = 0) {
+  constexpr uint8_t len = sizeof(T2);
+  bool useTail = shape4 == valid1 && shape5 == valid2;
+  int tailM = (useTail && actualTailM != 0) ? actualTailM : valid1;
+  int tailN = (useTail && actualTailN != 0) ? actualTailN : valid2;
+  TileMatL1<T2, shape4, shape5, pto::DYNAMIC, pto::DYNAMIC> L1(tailM, tailN);
+  pto::TASSIGN(L1, buffer_addr + offset * len);
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = useTail ? tailM : shape4;
+  dynamic_shape.shape[4] = useTail ? tailN : shape5;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape, stride);
+  pto::TLOAD(L1, global_tensor);
+  if (useTail && (tailM != shape4 || tailN != shape5)) {
+    pto::TFILLPAD(L1, L1);
+  }
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t valid1, uint32_t valid2>
+AICORE PTO_INLINE void copy_l0c_to_gm_dynamic(
+    __gm__ T1 *handle,
+    const pto::Shape<shape1, shape2, shape3, shape4, shape5> &shape,
+    const pto::Stride<stride1, stride2, stride3, stride4, stride5> &stride,
+    int32_t buffer_addr, int32_t offset, int32_t actualTailM = 0,
+    int32_t actualTailN = 0) {
+  constexpr uint8_t len = sizeof(T2);
+  bool useTail = shape4 == valid1 && shape5 == valid2;
+  int tailM = (useTail && actualTailM != 0) ? actualTailM : valid1;
+  int tailN = (useTail && actualTailN != 0) ? actualTailN : valid2;
+  pto::TileAcc<T2, shape4, shape5, pto::DYNAMIC, pto::DYNAMIC> L0c(tailM,
+                                                                   tailN);
+  pto::TASSIGN(L0c, buffer_addr + offset * len);
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = useTail ? tailM : shape4;
+  dynamic_shape.shape[4] = useTail ? tailN : shape5;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape, stride);
+  pto::TSTORE(global_tensor, L0c);
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t ub_shape1, uint32_t ub_shape2,
+          pto::PadValue PadVal = pto::PadValue::Null>
+AICORE PTO_INLINE void copy_gm_to_ub_dynamic(
+    __gm__ T1 *handle,
+    const pto::Shape<shape1, shape2, shape3, shape4, shape5> &shape,
+    const pto::Stride<stride1, stride2, stride3, stride4, stride5> &stride,
+    int32_t ub_shape_addr, int32_t ub_offset, int32_t valid_row,
+    int32_t valid_col) {
+  constexpr uint8_t len = sizeof(T2);
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = valid_row;
+  dynamic_shape.shape[4] = valid_col;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape, stride);
+  if constexpr (std::is_same_v<T1, T2>) {
+    // Source Tile: dynamic valid, PadVal for TLOAD 32-byte alignment
+    using SrcTile = TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC,
+                                 pto::DYNAMIC, PadVal>;
+    SrcTile src_tile(valid_row, valid_col);
+    pto::TASSIGN(src_tile, ub_shape_addr + ub_offset * len);
+    pto::TLOAD(src_tile, global_tensor);
+
+    // TFILLPAD_INPLACE: fill outside valid region with PadVal (only for tail
+    // blocks with valid PadVal)
+    if constexpr (PadVal != pto::PadValue::Null) {
+      if (valid_row != static_cast<int32_t>(ub_shape1) ||
+          valid_col != static_cast<int32_t>(ub_shape2)) {
+        using DstTile = pto::Tile<pto::TileType::Vec, T2, ub_shape1, ub_shape2,
+                                  pto::BLayout::RowMajor, ub_shape1, ub_shape2,
+                                  pto::SLayout::NoneBox, 512, PadVal>;
+        DstTile dst_tile;
+        pto::TASSIGN(dst_tile, ub_shape_addr + ub_offset * len);
+        pto::TFILLPAD_INPLACE(dst_tile, src_tile);
+      }
+    }
+  } else {
+    TileUbDataND<T1, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+        temp_src_ub(valid_row, valid_col);
+    pto::TASSIGN(temp_src_ub,
+                 ub_shape_addr + ub_offset * sizeof(T1) / sizeof(T1) * len);
+    pto::TLOAD(temp_src_ub, global_tensor);
+    TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+        temp_dst_ub(valid_row, valid_col);
+    pto::TASSIGN(temp_dst_ub, ub_shape_addr + ub_offset * len);
+    pto::TCVT(temp_dst_ub, temp_src_ub, pto::RoundMode::CAST_NONE);
+  }
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t ub_shape1, uint32_t ub_shape2>
+AICORE PTO_INLINE void copy_ub_to_gm_dynamic(
+    __gm__ T1 *handle,
+    const pto::Shape<shape1, shape2, shape3, shape4, shape5> &shape,
+    const pto::Stride<stride1, stride2, stride3, stride4, stride5> &stride,
+    int32_t ub_shape_addr, int32_t ub_offset, int32_t valid_row,
+    int32_t valid_col) {
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = valid_row;
+  dynamic_shape.shape[4] = valid_col;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape, stride);
+  constexpr uint8_t len = sizeof(T2);
+  constexpr bool use_nd = (static_cast<uint64_t>(ub_shape2) * len) >= 32;
+  if constexpr (std::is_same_v<T1, T2>) {
+    if constexpr (use_nd) {
+      TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_ub, ub_shape_addr + ub_offset * len);
+      pto::TSTORE(global_tensor, temp_ub);
+    } else {
+      TileUbDataDN<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_ub, ub_shape_addr + ub_offset * len);
+      pto::TSTORE(global_tensor, temp_ub);
+    }
+  } else {
+    if constexpr (use_nd) {
+      TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_src_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_src_ub, ub_shape_addr + ub_offset * len);
+      TileUbDataND<T1, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_dst_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_dst_ub, ub_shape_addr + ub_offset * sizeof(T1));
+      pto::TCVT(temp_dst_ub, temp_src_ub, pto::RoundMode::CAST_NONE);
+      pto::TSTORE(global_tensor, temp_dst_ub);
+    } else {
+      TileUbDataDN<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_src_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_src_ub, ub_shape_addr + ub_offset * len);
+      TileUbDataDN<T1, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_dst_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_dst_ub, ub_shape_addr + ub_offset * sizeof(T1));
+      pto::TCVT(temp_dst_ub, temp_src_ub, pto::RoundMode::CAST_NONE);
+      pto::TSTORE(global_tensor, temp_dst_ub);
+    }
+  }
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t valid1, uint32_t valid2>
+AICORE PTO_INLINE void copy_gm_to_l1(__gm__ T1 *handle, int32_t buffer_addr,
+                                     int32_t offset, int32_t actualTailM = 0,
+                                     int32_t actualTailN = 0) {
+  constexpr uint8_t len = sizeof(T2);
+  bool useTail = shape4 == valid1 && shape5 == valid2;
+  int tailM = (useTail && actualTailM != 0) ? actualTailM : valid1;
+  int tailN = (useTail && actualTailN != 0) ? actualTailN : valid2;
+  TileMatL1<T2, shape4, shape5, pto::DYNAMIC, pto::DYNAMIC> L1(tailM, tailN);
+  pto::TASSIGN(L1, buffer_addr + offset * len);
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = useTail ? tailM : shape4;
+  dynamic_shape.shape[4] = useTail ? tailN : shape5;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape);
+  pto::TLOAD(L1, global_tensor);
+  if (useTail && (tailM != shape4 || tailN != shape5)) {
+    pto::TFILLPAD(L1, L1);
+  }
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t valid1, uint32_t valid2>
+AICORE PTO_INLINE void copy_l0c_to_gm(__gm__ T1 *handle, int32_t buffer_addr,
+                                      int32_t offset, int32_t actualTailM = 0,
+                                      int32_t actualTailN = 0) {
+  constexpr uint8_t len = sizeof(T2);
+  bool useTail = shape4 == valid1 && shape5 == valid2;
+  int tailM = (useTail && actualTailM != 0) ? actualTailM : valid1;
+  int tailN = (useTail && actualTailN != 0) ? actualTailN : valid2;
+  pto::TileAcc<T2, shape4, shape5, pto::DYNAMIC, pto::DYNAMIC> L0c(tailM,
+                                                                   tailN);
+  pto::TASSIGN(L0c, buffer_addr + offset * len);
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = useTail ? tailM : shape4;
+  dynamic_shape.shape[4] = useTail ? tailN : shape5;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape);
+  pto::TSTORE(global_tensor, L0c);
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t ub_shape1, uint32_t ub_shape2,
+          pto::PadValue PadVal = pto::PadValue::Null>
+AICORE PTO_INLINE void copy_gm_to_ub(__gm__ T1 *handle, int32_t ub_shape_addr,
+                                     int32_t ub_offset, int32_t valid_row,
+                                     int32_t valid_col) {
+  constexpr uint8_t len = sizeof(T2);
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = valid_row;
+  dynamic_shape.shape[4] = valid_col;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape);
+  if constexpr (std::is_same_v<T1, T2>) {
+    // Source Tile: dynamic valid, PadVal for TLOAD 32-byte alignment
+    using SrcTile = TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC,
+                                 pto::DYNAMIC, PadVal>;
+    SrcTile src_tile(valid_row, valid_col);
+    pto::TASSIGN(src_tile, ub_shape_addr + ub_offset * len);
+    pto::TLOAD(src_tile, global_tensor);
+
+    // TFILLPAD_INPLACE: fill outside valid region with PadVal (only for tail
+    // blocks with valid PadVal)
+    if constexpr (PadVal != pto::PadValue::Null) {
+      if (valid_row != static_cast<int32_t>(ub_shape1) ||
+          valid_col != static_cast<int32_t>(ub_shape2)) {
+        using DstTile = pto::Tile<pto::TileType::Vec, T2, ub_shape1, ub_shape2,
+                                  pto::BLayout::RowMajor, ub_shape1, ub_shape2,
+                                  pto::SLayout::NoneBox, 512, PadVal>;
+        DstTile dst_tile;
+        pto::TASSIGN(dst_tile, ub_shape_addr + ub_offset * len);
+        pto::TFILLPAD_INPLACE(dst_tile, src_tile);
+      }
+    }
+  } else {
+    TileUbDataND<T1, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+        temp_src_ub(valid_row, valid_col);
+    pto::TASSIGN(temp_src_ub,
+                 ub_shape_addr + ub_offset * sizeof(T1) / sizeof(T1) * len);
+    pto::TLOAD(temp_src_ub, global_tensor);
+    TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+        temp_dst_ub(valid_row, valid_col);
+    pto::TASSIGN(temp_dst_ub, ub_shape_addr + ub_offset * len);
+    pto::TCVT(temp_dst_ub, temp_src_ub, pto::RoundMode::CAST_NONE);
+  }
+}
+
+template <typename T1, typename T2, int32_t shape1, int32_t shape2,
+          int32_t shape3, int32_t shape4, int32_t shape5, int32_t stride1,
+          int32_t stride2, int32_t stride3, int32_t stride4, int32_t stride5,
+          uint32_t ub_shape1, uint32_t ub_shape2>
+AICORE PTO_INLINE void copy_ub_to_gm(__gm__ T1 *handle, int32_t ub_shape_addr,
+                                     int32_t ub_offset, int32_t valid_row,
+                                     int32_t valid_col) {
+  pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC> dynamic_shape;
+  dynamic_shape.shape[3] = valid_row;
+  dynamic_shape.shape[4] = valid_col;
+  pto::GlobalTensor<
+      T1, pto::Shape<shape1, shape2, shape3, pto::DYNAMIC, pto::DYNAMIC>,
+      pto::Stride<stride1, stride2, stride3, stride4, stride5>>
+      global_tensor(handle, dynamic_shape);
+  constexpr uint8_t len = sizeof(T2);
+  constexpr bool use_nd = (static_cast<uint64_t>(ub_shape2) * len) >= 32;
+  if constexpr (std::is_same_v<T1, T2>) {
+    if constexpr (use_nd) {
+      TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_ub, ub_shape_addr + ub_offset * len);
+      pto::TSTORE(global_tensor, temp_ub);
+    } else {
+      TileUbDataDN<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_ub, ub_shape_addr + ub_offset * len);
+      pto::TSTORE(global_tensor, temp_ub);
+    }
+  } else {
+    if constexpr (use_nd) {
+      TileUbDataND<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_src_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_src_ub, ub_shape_addr + ub_offset * len);
+      TileUbDataND<T1, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_dst_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_dst_ub, ub_shape_addr + ub_offset * sizeof(T1));
+      pto::TCVT(temp_dst_ub, temp_src_ub, pto::RoundMode::CAST_NONE);
+      pto::TSTORE(global_tensor, temp_dst_ub);
+    } else {
+      TileUbDataDN<T2, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_src_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_src_ub, ub_shape_addr + ub_offset * len);
+      TileUbDataDN<T1, ub_shape1, ub_shape2, pto::DYNAMIC, pto::DYNAMIC>
+          temp_dst_ub(valid_row, valid_col);
+      pto::TASSIGN(temp_dst_ub, ub_shape_addr + ub_offset * sizeof(T1));
+      pto::TCVT(temp_dst_ub, temp_src_ub, pto::RoundMode::CAST_NONE);
+      pto::TSTORE(global_tensor, temp_dst_ub);
+    }
+  }
+}
+
+enum class BinaryOp { TADD, TSUB, TMUL, TDIV, TMAX, TMIN, TAND, TOR };
+
+template <BinaryOp Op, typename T, int32_t shape>
+AICORE PTO_INLINE void binary_tile(int32_t dst_addr, int32_t src0_addr,
+                                   int32_t src1_addr, int32_t dst_offset,
+                                   int32_t src0_offset, int32_t src1_offset,
+                                   int32_t len) {
+  // TileUbDataND<T, 1, shape> src0_temp_ub(1, shape);
+  TileUbDataND<T, 1, shape, 1, shape> src0_temp_ub;
+
+  pto::TASSIGN(src0_temp_ub, src0_addr + src0_offset * len);
+  // TileUbDataND<T, 1, shape> src1_temp_ub(1, shape);
+  TileUbDataND<T, 1, shape, 1, shape> src1_temp_ub;
+
+  pto::TASSIGN(src1_temp_ub, src1_addr + src1_offset * len);
+  // TileUbDataND<T, 1, shape> dst_temp_ub(1, shape);
+  TileUbDataND<T, 1, shape, 1, shape> dst_temp_ub;
+
+  pto::TASSIGN(dst_temp_ub, dst_addr + dst_offset * len);
+  if constexpr (Op == BinaryOp::TADD) {
+    pto::TADD(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TSUB) {
+    pto::TSUB(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TMUL) {
+    pto::TMUL(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TDIV) {
+    pto::TDIV(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TMAX) {
+    pto::TMAX(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TMIN) {
+    pto::TMIN(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TAND) {
+    pto::TAND(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  } else if constexpr (Op == BinaryOp::TOR) {
+    pto::TOR(dst_temp_ub, src0_temp_ub, src1_temp_ub);
+  }
+}
+
+enum class UnaryOp { TEXP, TLOG, TABS, TRECIP, TSQRT, TRSQRT, TRELU, TNOT };
+
+template <UnaryOp Op, typename T, int32_t shape>
+AICORE PTO_INLINE void unary_tile(int32_t dst_addr, int32_t src_addr,
+                                  int32_t dst_offset, int32_t src_offset,
+                                  int32_t len) {
+  TileUbDataND<T, 1, shape, 1, shape> src_temp_ub;
+  pto::TASSIGN(src_temp_ub, src_addr + src_offset * len);
+
+  TileUbDataND<T, 1, shape, 1, shape> dst_temp_ub;
+  pto::TASSIGN(dst_temp_ub, dst_addr + dst_offset * len);
+
+  if constexpr (Op == UnaryOp::TEXP) {
+    pto::TEXP(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TLOG) {
+    pto::TLOG(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TABS) {
+    pto::TABS(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TRECIP) {
+    pto::TRECIP(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TSQRT) {
+    pto::TSQRT(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TRSQRT) {
+    pto::TRSQRT(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TRELU) {
+    pto::TRELU(dst_temp_ub, src_temp_ub);
+  } else if constexpr (Op == UnaryOp::TNOT) {
+    pto::TNOT(dst_temp_ub, src_temp_ub);
+  }
+}
+
+template <typename T, int32_t row, int32_t col>
+AICORE PTO_INLINE void
+TSIGMOID(TileUbDataND<T, row, col, row, col> &dst_addr,
+         TileUbDataND<T, row, col, row, col> &src0_addr) {
+  TMULS(src0_addr, src0_addr, -1);
+  pipe_barrier(PIPE_V);
+  TEXP(src0_addr, src0_addr);
+  pipe_barrier(PIPE_V);
+  TADDS(src0_addr, src0_addr, 1);
+  pipe_barrier(PIPE_V);
+  TRECIP(dst_addr, src0_addr);
+}
+
+template <typename T, int32_t row, int32_t col>
+AICORE PTO_INLINE void axpy(TileUbDataND<T, row, col, row, col> &dst,
+                            TileUbDataND<T, row, col, row, col> &src0,
+                            float scalar_value) {
+  TMULS(src0, src0, static_cast<T>(scalar_value));
+  pipe_barrier(PIPE_V);
+  TADD(dst, dst, src0);
+  pipe_barrier(PIPE_V);
+  TMULS(src0, src0, static_cast<T>(1.0f / scalar_value));
+}
+
+template <typename T1, typename T2, typename T3, int32_t rows_src,
+          int32_t cols_src, int32_t validRow_src, int32_t validCol_src,
+          int32_t cols_dst, int32_t row_tmp, int32_t col_tmp>
+AICORE PTO_INLINE void
+TROWMAX_with_slice_buffer(uint64_t handle_src, uint64_t handle_dst,
+                          TileUbDataDN<T2, cols_dst, 1, validRow_src, 1> ub_DN,
+                          TileUbDataND<T3, row_tmp, col_tmp> tmp_ub) {
+  chunk_gdn_pto::TileUbDataND<T1, rows_src, cols_src, validRow_src,
+                               validCol_src>
+      tileUbWithValid;
+  pto::TASSIGN(tileUbWithValid, handle_src);
+  pto::TROWMAX(ub_DN, tileUbWithValid, tmp_ub);
+}
+
+template <typename T1, typename T2, typename T3, int32_t rows_src,
+          int32_t cols_src, int32_t validRow_src, int32_t validCol_src,
+          int32_t cols_dst, int32_t row_tmp, int32_t col_tmp>
+AICORE PTO_INLINE void
+TROWMIN_with_slice_buffer(uint64_t handle_src, uint64_t handle_dst,
+                          TileUbDataDN<T2, cols_dst, 1, validRow_src, 1> ub_DN,
+                          TileUbDataND<T3, row_tmp, col_tmp> tmp_ub) {
+  chunk_gdn_pto::TileUbDataND<T1, rows_src, cols_src, validRow_src,
+                               validCol_src>
+      tileUbWithValid;
+  pto::TASSIGN(tileUbWithValid, handle_src);
+  pto::TROWMIN(ub_DN, tileUbWithValid, tmp_ub);
+}
+
+template <typename T1, typename T2, typename T3, int32_t rows_src,
+          int32_t cols_src, int32_t validRow_src, int32_t validCol_src,
+          int32_t cols_dst, int32_t row_tmp, int32_t col_tmp>
+AICORE PTO_INLINE void
+TROWSUM_with_slice_buffer(uint64_t handle_src, uint64_t handle_dst,
+                          TileUbDataDN<T2, cols_dst, 1, validRow_src, 1> ub_DN,
+                          TileUbDataND<T3, row_tmp, col_tmp> tmp_ub) {
+  chunk_gdn_pto::TileUbDataND<T1, rows_src, cols_src, validRow_src,
+                               validCol_src>
+      tileUbWithValid;
+  pto::TASSIGN(tileUbWithValid, handle_src);
+  pto::TROWSUM(ub_DN, tileUbWithValid, tmp_ub);
+}
+
+template <typename T1, typename T2, typename T3, int32_t rows_src,
+          int32_t cols_src, int32_t validRow_src, int32_t validCol_src,
+          int32_t cols_dst, int32_t row_tmp, int32_t col_tmp>
+AICORE PTO_INLINE void
+TCOLMAX_with_slice_buffer(uint64_t handle_src, uint64_t handle_dst,
+                          TileUbDataND<T2, 1, cols_src, 1, validCol_src> ub,
+                          TileUbDataND<T3, row_tmp, col_tmp> tmp_ub) {
+  chunk_gdn_pto::TileUbDataND<T1, rows_src, cols_src, validRow_src,
+                               validCol_src>
+      tileUbWithValid;
+  pto::TASSIGN(tileUbWithValid, handle_src);
+  pto::TCOLMAX(ub, tileUbWithValid);
+}
+
+template <typename T1, typename T2, typename T3, int32_t rows_src,
+          int32_t cols_src, int32_t validRow_src, int32_t validCol_src,
+          int32_t cols_dst, int32_t row_tmp, int32_t col_tmp>
+AICORE PTO_INLINE void
+TCOLMIN_with_slice_buffer(uint64_t handle_src, uint64_t handle_dst,
+                          TileUbDataND<T2, 1, cols_src, 1, validCol_src> ub,
+                          TileUbDataND<T3, row_tmp, col_tmp> tmp_ub) {
+  chunk_gdn_pto::TileUbDataND<T1, rows_src, cols_src, validRow_src,
+                               validCol_src>
+      tileUbWithValid;
+  pto::TASSIGN(tileUbWithValid, handle_src);
+  pto::TCOLMIN(ub, tileUbWithValid);
+}
+
+template <typename T1, typename T2, int32_t rows_src, int32_t cols_src,
+          int32_t validRow_src, int32_t validCol_src, int32_t cols_dst,
+          int32_t row_tmp, int32_t col_tmp>
+AICORE PTO_INLINE void
+TCOLSUM_with_slice_buffer(uint64_t handle_src, uint64_t handle_dst,
+                          TileUbDataND<T2, 1, cols_src, 1, validCol_src> ub,
+                          uint64_t tmp_addr) {
+  chunk_gdn_pto::TileUbDataND<T1, rows_src, cols_src, validRow_src,
+                               validCol_src>
+      tileUbWithValid;
+  pto::TASSIGN(tileUbWithValid, handle_src);
+  TileUbDataND<T1, row_tmp, col_tmp> tmp_ub;
+  pto::TASSIGN(tmp_ub, tmp_addr);
+  pto::TCOLSUM(ub, tileUbWithValid, tmp_ub, true);
+}
+
+template <typename TileType, typename DataType>
+void TCI(TileType &tile, DataType firstValue);
+
+template <typename T, int32_t row, int32_t col>
+AICORE PTO_INLINE void tci(int32_t ub_addr, int32_t ub_offset, int32_t len,
+                           T firstValue) {
+  using TileData = TileUbDataND<T, row, col, row, col>;
+  TileData temp_ub;
+  TASSIGN(temp_ub, ub_addr + ub_offset * len);
+  TCI<TileData, T, 0>(temp_ub, firstValue);
+}
+
+template <typename T> struct is_float_or_half : std::false_type {};
+
+template <> struct is_float_or_half<float> : std::true_type {};
+
+template <> struct is_float_or_half<half> : std::true_type {};
+
+template <typename T, int32_t row, int32_t col, int32_t tmp_rows>
+AICORE PTO_INLINE typename std::enable_if<is_float_or_half<T>::value>::type
+pow(TileUbDataND<T, row, col, row, col> &dst,
+    TileUbDataND<T, row, col, row, col> &src0,
+    TileUbDataND<T, row, col, row, col> &src1,
+    TileUbDataND<uint8_t, tmp_rows, col, tmp_rows, col> &tmp) {
+  TLOG(src0, src0);
+  pipe_barrier(PIPE_V);
+  TMUL(dst, src0, src1);
+  pipe_barrier(PIPE_V);
+  TEXP(dst, dst);
+}
+
+template <typename T, int32_t row, int32_t col, int32_t tmp_rows>
+AICORE PTO_INLINE typename std::enable_if<std::is_integral<T>::value>::type
+pow(TileUbDataND<T, row, col, row, col> &dst,
+    TileUbDataND<T, row, col, row, col> &src0,
+    TileUbDataND<T, row, col, row, col> &src1,
+    TileUbDataND<uint8_t, tmp_rows, col, tmp_rows, col> &tmp) {
+  using FloatT = float;
+  constexpr int32_t float_buf_size = row * col * sizeof(FloatT);
+  auto tmp_float0 = reinterpret_cast<__ubuf__ FloatT *>(tmp.data());
+  auto tmp_float1 =
+      reinterpret_cast<__ubuf__ FloatT *>(tmp.data() + float_buf_size);
+
+  TileUbDataND<FloatT, row, col, row, col> src0_float;
+  TileUbDataND<FloatT, row, col, row, col> log_src0_float;
+  TileUbDataND<FloatT, row, col, row, col> src1_float;
+
+  pto::TASSIGN(src0_float, reinterpret_cast<uint64_t>(tmp_float0));
+  pto::TASSIGN(log_src0_float, reinterpret_cast<uint64_t>(tmp_float1));
+  pto::TASSIGN(src1_float, reinterpret_cast<uint64_t>(tmp_float0));
+
+  pto::TCVT(src0_float, src0, pto::RoundMode::CAST_ROUND);
+  pipe_barrier(PIPE_V);
+  pto::TLOG(log_src0_float, src0_float);
+  pipe_barrier(PIPE_V);
+  pto::TCVT(src1_float, src1, pto::RoundMode::CAST_ROUND);
+  pipe_barrier(PIPE_V);
+  pto::TMUL(log_src0_float, log_src0_float, src1_float);
+  pipe_barrier(PIPE_V);
+  pto::TEXP(log_src0_float, log_src0_float);
+  pipe_barrier(PIPE_V);
+  pto::TCVT(dst, log_src0_float, pto::RoundMode::CAST_ROUND);
+}
+
+enum class BinaryOps { TADDS, TSUBS, TMULS, TDIVS, TMAXS, TMINS };
+
+template <BinaryOps Op, typename T, int32_t dst_shape, int32_t src_shape>
+AICORE PTO_INLINE void binarys_tile(int32_t dst_addr, int32_t src_addr,
+                                    int32_t dst_offset, int32_t src_offset,
+                                    int32_t len, T scalar_value) {
+  TileUbDataND<T, 1, dst_shape, 1, dst_shape> dst_temp_ub;
+  pto::TASSIGN(dst_temp_ub, dst_addr + dst_offset * len);
+  TileUbDataND<T, 1, src_shape, 1, src_shape> src_temp_ub;
+  pto::TASSIGN(src_temp_ub, src_addr + src_offset * len);
+  if constexpr (Op == BinaryOps::TADDS) {
+    pto::TADDS(dst_temp_ub, src_temp_ub, scalar_value);
+  } else if constexpr (Op == BinaryOps::TSUBS) {
+    pto::TSUBS(dst_temp_ub, src_temp_ub, scalar_value);
+  } else if constexpr (Op == BinaryOps::TMULS) {
+    pto::TMULS(dst_temp_ub, src_temp_ub, scalar_value);
+  } else if constexpr (Op == BinaryOps::TDIVS) {
+    pto::TDIVS(dst_temp_ub, src_temp_ub, scalar_value);
+  } else if constexpr (Op == BinaryOps::TMAXS) {
+    pto::TMAXS(dst_temp_ub, src_temp_ub, scalar_value);
+  } else if constexpr (Op == BinaryOps::TMINS) {
+    pto::TMINS(dst_temp_ub, src_temp_ub, scalar_value);
+  }
+}
+
+template <pipe_t pipe, pipe_t tpipe>
+AICORE PTO_INLINE void set_flag_pipeline(int32_t pipeID) {
+  switch (pipeID) {
+  case 0:
+    set_flag(pipe, tpipe, EVENT_ID0);
+    break;
+  case 1:
+    set_flag(pipe, tpipe, EVENT_ID1);
+    break;
+  case 2:
+    set_flag(pipe, tpipe, EVENT_ID2);
+    break;
+  case 3:
+    set_flag(pipe, tpipe, EVENT_ID3);
+    break;
+  case 4:
+    set_flag(pipe, tpipe, EVENT_ID4);
+    break;
+  case 5:
+    set_flag(pipe, tpipe, EVENT_ID5);
+    break;
+  case 6:
+    set_flag(pipe, tpipe, EVENT_ID6);
+    break;
+  case 7:
+    set_flag(pipe, tpipe, EVENT_ID7);
+    break;
+  default:
+    break;
+  }
+}
+
+template <pipe_t pipe, pipe_t tpipe>
+AICORE PTO_INLINE void wait_flag_pipeline(int32_t pipeID) {
+  switch (pipeID) {
+  case 0:
+    wait_flag(pipe, tpipe, EVENT_ID0);
+    break;
+  case 1:
+    wait_flag(pipe, tpipe, EVENT_ID1);
+    break;
+  case 2:
+    wait_flag(pipe, tpipe, EVENT_ID2);
+    break;
+  case 3:
+    wait_flag(pipe, tpipe, EVENT_ID3);
+    break;
+  case 4:
+    wait_flag(pipe, tpipe, EVENT_ID4);
+    break;
+  case 5:
+    wait_flag(pipe, tpipe, EVENT_ID5);
+    break;
+  case 6:
+    wait_flag(pipe, tpipe, EVENT_ID6);
+    break;
+  case 7:
+    wait_flag(pipe, tpipe, EVENT_ID7);
+    break;
+  default:
+    break;
+  }
+}
+
+template <typename dstT, int32_t dstRow, int32_t dstCol, int32_t dstRowValid,
+          int32_t dstColValid, typename srcT, int32_t srcRow, int32_t srcCol,
+          int32_t srcRowValid, int32_t srcColValid, int32_t src_element_count>
+AICORE PTO_INLINE void TROWEXPAND_with_slice_buffer(
+    TileUbDataND<dstT, dstRow, dstCol, dstRow, dstCol> dst,
+    TileUbDataDN<srcT, srcRow, srcCol, srcRow, srcCol> src, int32_t src_addr,
+    int32_t src_offset) {
+  TileUbDataDN<srcT, src_element_count, srcCol, src_element_count, srcColValid>
+      src_temp_ub;
+  pto::TASSIGN(src_temp_ub, src_addr + src_offset);
+
+  pto::TROWEXPAND(dst, src_temp_ub);
+}
+template <pipe_t pipe>
+AICORE PTO_INLINE void set_cross_flag(int32_t flag, int32_t mode) {
+  int config = 1 | (mode << 4) | (flag << 8);
+  ffts_cross_core_sync(pipe, config);
+}
+
+template <pipe_t pipe>
+AICORE PTO_INLINE void set_intra_block_cube(int32_t flag) {
+  set_intra_block(pipe, flag);
+  set_intra_block(pipe, flag + 16);
+}
+
+template <pipe_t pipe>
+AICORE PTO_INLINE void set_intra_block_vec(int32_t flag) {
+  set_intra_block(pipe, flag);
+}
+
+AICORE PTO_INLINE void wait_cross_flag(int32_t flag) { wait_flag_dev(flag); }
+
+template <pipe_t pipe>
+AICORE PTO_INLINE void wait_intra_block_cube(int32_t flag) {
+  wait_intra_block(pipe, flag);
+  wait_intra_block(pipe, flag + 16);
+}
+
+template <pipe_t pipe>
+AICORE PTO_INLINE void wait_intra_block_vec(int32_t flag) {
+  wait_intra_block(pipe, flag);
+}
+
+// ============================================================================
+// Merge Sort for PTO backend
+// tmp buffer is passed from caller, MrgSortExecutedNumList is managed
+// internally Each element is a value-index pair: 2 floats per element [value,
+// index]
+// ============================================================================
+
+// 2-way merge sort
+template <typename T, int32_t SrcCols, int32_t DstCols>
+AICORE PTO_INLINE void
+MergeSort(TileUbDataND<T, 1, DstCols, 1, DstCols> &dst,
+          TileUbDataND<T, 1, DstCols, 1, DstCols> &tmp,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src0,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src1) {
+
+  pto::MrgSortExecutedNumList executedNumList;
+  pto::TMRGSORT<TileUbDataND<T, 1, DstCols, 1, DstCols>,
+                TileUbDataND<T, 1, DstCols, 1, DstCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>, false>(
+      dst, executedNumList, tmp, src0, src1);
+  pipe_barrier(PIPE_V);
+}
+
+// 3-way merge sort
+template <typename T, int32_t SrcCols, int32_t DstCols>
+AICORE PTO_INLINE void
+MergeSort(TileUbDataND<T, 1, DstCols, 1, DstCols> &dst,
+          TileUbDataND<T, 1, DstCols, 1, DstCols> &tmp,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src0,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src1,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src2) {
+
+  pto::MrgSortExecutedNumList executedNumList;
+  pto::TMRGSORT<TileUbDataND<T, 1, DstCols, 1, DstCols>,
+                TileUbDataND<T, 1, DstCols, 1, DstCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>, false>(
+      dst, executedNumList, tmp, src0, src1, src2);
+  pipe_barrier(PIPE_V);
+}
+
+// 4-way merge sort
+template <typename T, int32_t SrcCols, int32_t DstCols>
+AICORE PTO_INLINE void
+MergeSort(TileUbDataND<T, 1, DstCols, 1, DstCols> &dst,
+          TileUbDataND<T, 1, DstCols, 1, DstCols> &tmp,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src0,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src1,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src2,
+          TileUbDataND<T, 1, SrcCols, 1, SrcCols> &src3) {
+
+  pto::MrgSortExecutedNumList executedNumList;
+  pto::TMRGSORT<TileUbDataND<T, 1, DstCols, 1, DstCols>,
+                TileUbDataND<T, 1, DstCols, 1, DstCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>,
+                TileUbDataND<T, 1, SrcCols, 1, SrcCols>, false>(
+      dst, executedNumList, tmp, src0, src1, src2, src3);
+  pipe_barrier(PIPE_V);
+}
+
+template <typename T, int32_t Rows, int32_t Cols>
+AICORE PTO_INLINE void transpose(TileUbDataND<T, Rows, Cols, Rows, Cols> &dst,
+                                 TileUbDataND<T, Rows, Cols, Rows, Cols> &src,
+                                 TileUbDataND<T, Rows, Cols, Rows, Cols> &tmp) {
+  pto::TTRANS(dst, src, tmp);
+}
+
+template <typename DstT, typename SrcT, int32_t DstRows, int32_t DstCols,
+          int32_t SrcRows, int32_t SrcCols>
+AICORE PTO_INLINE void
+compare(TileUbDataND<DstT, DstRows, DstCols, DstRows, DstCols> &dst,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src0,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src1,
+        pto::CmpMode mode) {
+  pto::TCMP(dst, src0, src1, mode);
+}
+
+template <typename SrcT, int32_t DstRows, int32_t DstCols, int32_t SrcRows,
+          int32_t SrcCols>
+AICORE PTO_INLINE void
+compare(TileUbDataND<int8_t, DstRows, DstCols, DstRows, DstCols> &dst,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src0,
+        TileUbDataND<SrcT, SrcRows, SrcCols, SrcRows, SrcCols> &src1,
+        pto::CmpMode mode) {
+  auto &dst_uint8 = reinterpret_cast<
+      TileUbDataND<uint8_t, DstRows, DstCols, DstRows, DstCols> &>(dst);
+  pto::TCMP(dst_uint8, src0, src1, mode);
+}
+
+template <typename DstT, typename SrcT, int32_t DstRows, int32_t DstCols,
+          int32_t DstRowValid, int32_t DstColValid, int32_t SrcRows,
+          int32_t SrcCols, int32_t SrcRowValid, int32_t SrcColValid>
+AICORE PTO_INLINE void compare_scalar(
+    TileUbDataND<DstT, DstRows, DstCols, DstRowValid, DstColValid> &dst,
+    TileUbDataND<SrcT, SrcRows, SrcCols, SrcRowValid, SrcColValid> &src,
+    SrcT scalar, pto::CmpMode mode) {
+  pto::TCMPS(dst, src, scalar, mode);
+}
+
+template <typename SrcT, int32_t DstRows, int32_t DstCols, int32_t DstRowValid,
+          int32_t DstColValid, int32_t SrcRows, int32_t SrcCols,
+          int32_t SrcRowValid, int32_t SrcColValid>
+AICORE PTO_INLINE void compare_scalar(
+    TileUbDataND<int8_t, DstRows, DstCols, DstRowValid, DstColValid> &dst,
+    TileUbDataND<SrcT, SrcRows, SrcCols, SrcRowValid, SrcColValid> &src,
+    SrcT scalar, pto::CmpMode mode) {
+  auto &dst_uint8 = reinterpret_cast<
+      TileUbDataND<uint8_t, DstRows, DstCols, DstRowValid, DstColValid> &>(dst);
+  pto::TCMPS(dst_uint8, src, scalar, mode);
+}
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid,
+          int32_t ColValid>
+AICORE PTO_INLINE void
+fill_scalar(TileUbDataND<T, Rows, Cols, RowValid, ColValid> &dst, T scalar) {
+  for (int i = 0; i < RowValid; i++) {
+    for (int j = 0; j < ColValid; j++) {
+      dst.data()[i * Cols + j] = scalar;
+    }
+  }
+}
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid,
+          int32_t ColValid>
+AICORE PTO_INLINE void
+tand(TileUbDataND<T, Rows, Cols, RowValid, ColValid> &dst,
+     TileUbDataND<T, Rows, Cols, RowValid, ColValid> &src0,
+     TileUbDataND<T, Rows, Cols, RowValid, ColValid> &src1) {
+  pto::TAND(dst, src0, src1);
+}
+
+template <int32_t Rows, int32_t Cols, int32_t RowValid, int32_t ColValid>
+AICORE PTO_INLINE void
+tand(TileUbDataND<uint8_t, Rows, Cols, RowValid, ColValid> &dst,
+     TileUbDataND<uint8_t, Rows, Cols, RowValid, ColValid> &src0,
+     TileUbDataND<uint8_t, Rows, Cols, RowValid, ColValid> &src1) {
+  auto &dst_u16 = reinterpret_cast<
+      TileUbDataND<uint16_t, Rows, Cols / 2, RowValid, ColValid / 2> &>(dst);
+  auto &src0_u16 = reinterpret_cast<
+      TileUbDataND<uint16_t, Rows, Cols / 2, RowValid, ColValid / 2> &>(src0);
+  auto &src1_u16 = reinterpret_cast<
+      TileUbDataND<uint16_t, Rows, Cols / 2, RowValid, ColValid / 2> &>(src1);
+  pto::TAND(dst_u16, src0_u16, src1_u16);
+}
+
+template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid,
+          int32_t ColValid>
+AICORE PTO_INLINE void
+tor(TileUbDataND<T, Rows, Cols, RowValid, ColValid> &dst,
+    TileUbDataND<T, Rows, Cols, RowValid, ColValid> &src0,
+    TileUbDataND<T, Rows, Cols, RowValid, ColValid> &src1) {
+  pto::TOR(dst, src0, src1);
+}
+
+template <int32_t Rows, int32_t Cols, int32_t RowValid, int32_t ColValid>
+AICORE PTO_INLINE void
+tor(TileUbDataND<uint8_t, Rows, Cols, RowValid, ColValid> &dst,
+    TileUbDataND<uint8_t, Rows, Cols, RowValid, ColValid> &src0,
+    TileUbDataND<uint8_t, Rows, Cols, RowValid, ColValid> &src1) {
+  auto &dst_u16 = reinterpret_cast<
+      TileUbDataND<uint16_t, Rows, Cols / 2, RowValid, ColValid / 2> &>(dst);
+  auto &src0_u16 = reinterpret_cast<
+      TileUbDataND<uint16_t, Rows, Cols / 2, RowValid, ColValid / 2> &>(src0);
+  auto &src1_u16 = reinterpret_cast<
+      TileUbDataND<uint16_t, Rows, Cols / 2, RowValid, ColValid / 2> &>(src1);
+  pto::TOR(dst_u16, src0_u16, src1_u16);
+}
+
+} // namespace chunk_gdn_pto
+#endif

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/pto_static_common.py
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/pto_static_common.py
@@ -1,0 +1,80 @@
+"""
+Shared PTO static-kernel build helpers (bisheng, include order, compiled_lib output).
+
+Same behavior as ``static_baseline/pto_static_common.py``; duplicated so this
+directory stays self-contained.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+
+ASCEND_TOOLKIT_HOME = os.environ.get("ASCEND_TOOLKIT_HOME") or os.environ.get(
+    "ASCEND_HOME_PATH", ""
+)
+if not ASCEND_TOOLKIT_HOME:
+    raise RuntimeError("Set ASCEND_TOOLKIT_HOME or ASCEND_HOME_PATH")
+
+PTO_LIB_PATH = os.environ.get("PTO_LIB_PATH", ASCEND_TOOLKIT_HOME)
+_pto_inc = os.path.join(PTO_LIB_PATH, "include")
+if not os.path.isdir(_pto_inc):
+    raise RuntimeError(
+        f"PTO include directory missing: {_pto_inc!r} (set PTO_LIB_PATH; must be before CANN -I)."
+    )
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+INCLUDE_DIR = os.path.join(_HERE, "include")
+COMPILED_DIR = os.path.join(_HERE, "compiled_lib")
+_DRIVER_INC = "/usr/local/Ascend/driver/kernel/inc"
+
+
+@lru_cache(maxsize=64)
+def _compile_pto_kernel_cached(
+    kernel_cpp_basename: str, so_basename: str, cpp_mtime_ns: int
+) -> str:
+    """Internal: ``cpp_mtime_ns`` busts the cache when the source file changes."""
+    os.makedirs(COMPILED_DIR, exist_ok=True)
+    cpp_path = os.path.join(_HERE, kernel_cpp_basename)
+    lib_path = os.path.join(COMPILED_DIR, so_basename)
+    extra = os.environ.get("PTO_STATIC_EXTRA_FLAGS", "").split()
+    flags = [
+        "-fPIC",
+        "-shared",
+        "-xcce",
+        "-DMEMORY_BASE",
+        "-O2",
+        "-std=gnu++17",
+        "--cce-aicore-arch=dav-c220",
+        "-mllvm",
+        "-cce-aicore-stack-size=0x8000",
+        "-mllvm",
+        "-cce-aicore-function-stack-size=0x8000",
+        "-mllvm",
+        "-cce-aicore-record-overflow=true",
+        "-mllvm",
+        "-cce-aicore-dcci-insert-for-scalar=false",
+        "-Wno-macro-redefined",
+        "-Wno-ignored-attributes",
+        f"-I{INCLUDE_DIR}",
+        f"-I{_pto_inc}",
+        f"-I{ASCEND_TOOLKIT_HOME}/include",
+        f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc",
+        f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc/runtime",
+        f"-I{ASCEND_TOOLKIT_HOME}/pkg_inc/profiling",
+    ]
+    if os.path.isdir(_DRIVER_INC):
+        flags.append(f"-I{_DRIVER_INC}")
+    flags.extend(extra)
+    cmd = ["bisheng", *flags, cpp_path, "-o", lib_path]
+    if os.environ.get("VERBOSE_COMPILE"):
+        print("compile:", " ".join(cmd))
+    subprocess.run(cmd, check=True, timeout=300)
+    return lib_path
+
+
+def compile_pto_kernel(kernel_cpp_basename: str, so_basename: str) -> str:
+    """Compile ``kernel_cpp_basename`` to ``compiled_lib/so_basename`` (rebuilds if ``*.cpp`` changed)."""
+    cpp_path = os.path.join(_HERE, kernel_cpp_basename)
+    mtime_ns = os.stat(cpp_path).st_mtime_ns
+    return _compile_pto_kernel_cached(kernel_cpp_basename, so_basename, mtime_ns)

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/run_chunk_gated_delta_rule_varlen_static.py
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/run_chunk_gated_delta_rule_varlen_static.py
@@ -1,0 +1,320 @@
+"""
+Compile (bisheng) and run the static varlen chunk_gated_delta_rule PTO kernels,
+then compare to a pure PyTorch reference (no TileLang).
+
+The dumped ``*_H32.cpp`` / ``*_H48.cpp`` kernels bake in ``T_total_pad``,
+``NT_max``, and ``N * H`` launch geometry. Constants below match the copies in
+this directory (generated from ``tilelang_codegen/kernels``).
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import sys
+
+import torch
+import torch.nn.functional as F
+
+_DIR = os.path.dirname(os.path.abspath(__file__))
+if _DIR not in sys.path:
+    sys.path.insert(0, _DIR)
+
+import pto_static_common  # noqa: F401 — env validation
+
+from static_kernel_libs import lib_chunk_gated_delta_rule_varlen_h32, lib_chunk_gated_delta_rule_varlen_h48
+
+torch_npu = torch.npu  # noqa: F401 — register NPU
+
+BT = 64
+
+# Baked into the dumped AICore code (strides / bounds / launch grid).
+KERNEL_META = {
+    "H48": {
+        "lib_fn": lib_chunk_gated_delta_rule_varlen_h48,
+        "H": 48,
+        "Hg": 16,
+        "N": 5,
+        "T_pad": 568,
+        "NT_max": 4,
+        "default_seqlens": (7, 32, 159, 256, 50),
+    },
+    "H32": {
+        "lib_fn": lib_chunk_gated_delta_rule_varlen_h32,
+        "H": 32,
+        "Hg": 16,
+        "N": 2,
+        "T_pad": 1056,
+        "NT_max": 16,
+        # Strides in H32 dump match ``T_total = 992`` (not 1024); use this for exact GM layout.
+        "default_seqlens": (496, 496),
+        "alt_seqlens_512": (512, 512),
+    },
+}
+
+
+def prepare_chunk_offsets(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    chunk_offsets = []
+    offset = 0
+    cu_seqlens_np = cu_seqlens.cpu().numpy()
+    for i in range(len(cu_seqlens_np) - 1):
+        t_len = int(cu_seqlens_np[i + 1] - cu_seqlens_np[i])
+        nt = (t_len + chunk_size - 1) // chunk_size
+        chunk_offsets.append(offset)
+        offset += nt
+    return torch.tensor(chunk_offsets, dtype=torch.int32, device=cu_seqlens.device)
+
+
+def ref_chunk_gated_delta_rule_varlen(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor,
+    chunk_size: int = BT,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """Varlen-only reference (same math as ``chunk_gated_delta_rule_varlen.ref_chunk_gated_delta_rule``)."""
+    kf = k.float()
+    wf = w.float()
+    uf = u.float()
+    gf = g.float() if g is not None else None
+    init_f = initial_state.float() if initial_state is not None else None
+
+    _, t_total, hg, kk = k.shape
+    _, _, h, v = u.shape
+    n = len(cu_seqlens) - 1
+
+    nt_total = sum(
+        (int(cu_seqlens[i + 1].item()) - int(cu_seqlens[i].item()) + chunk_size - 1) // chunk_size
+        for i in range(n)
+    )
+
+    h_out = torch.zeros(1, nt_total, h, kk, v, dtype=torch.float32, device=k.device)
+    v_new = torch.zeros(1, t_total, h, v, dtype=torch.float32, device=k.device)
+    final_state = (
+        torch.zeros(1, n, h, kk, v, dtype=torch.float32, device=k.device) if output_final_state else None
+    )
+
+    chunk_offset = 0
+    for i_n in range(n):
+        bos, eos = int(cu_seqlens[i_n].item()), int(cu_seqlens[i_n + 1].item())
+        t_len = eos - bos
+        nt = (t_len + chunk_size - 1) // chunk_size
+
+        for i_h in range(h):
+            h_state = (
+                init_f[0, i_n, i_h].clone()
+                if init_f is not None
+                else torch.zeros(kk, v, dtype=torch.float32, device=k.device)
+            )
+            k_head = i_h // (h // hg)
+
+            for i_t in range(nt):
+                t_start = i_t * chunk_size
+                t_end = min((i_t + 1) * chunk_size, t_len)
+
+                h_out[0, chunk_offset + i_t, i_h] = h_state
+                k_chunk = kf[0, bos + t_start : bos + t_end, k_head, :]
+                w_chunk = wf[0, bos + t_start : bos + t_end, i_h, :]
+                v_chunk = uf[0, bos + t_start : bos + t_end, i_h, :]
+
+                v_n = v_chunk - torch.matmul(w_chunk, h_state)
+                v_new[0, bos + t_start : bos + t_end, i_h, :] = v_n
+
+                if gf is not None:
+                    g_chunk = gf[0, bos + t_start : bos + t_end, i_h]
+                    g_last = g_chunk[-1].item()
+                    v_n = v_n * torch.exp(g_last - g_chunk)[:, None]
+                    h_state = h_state * torch.exp(torch.tensor(g_last, device=k.device, dtype=torch.float32))
+
+                h_state = h_state + torch.matmul(k_chunk.transpose(-1, -2), v_n)
+
+            if output_final_state and final_state is not None:
+                final_state[0, i_n, i_h] = h_state
+        chunk_offset += nt
+
+    return h_out.half(), v_new.half(), final_state.half() if final_state is not None else None
+
+
+def pack_h_ret(
+    h_work: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    chunk_size: int,
+    nt_max: int,
+    h_: int,
+    kk: int,
+    v: int,
+) -> torch.Tensor:
+    """Match ``chunk_gated_delta_rule_fwd_h`` varlen packing: ``(1, NT_total, H, K, V)``."""
+    n = len(cu_seqlens) - 1
+    nt_total = int(
+        sum(
+            (int(cu_seqlens[i + 1].item()) - int(cu_seqlens[i].item()) + chunk_size - 1) // chunk_size
+            for i in range(n)
+        )
+    )
+    h_ret = torch.zeros(1, nt_total, h_, kk, v, dtype=torch.float16, device=h_work.device)
+    cu_np = cu_seqlens.cpu().numpy()
+    for i in range(n):
+        nt_i = (int(cu_np[i + 1]) - int(cu_np[i]) + chunk_size - 1) // chunk_size
+        offset = int(chunk_offsets[i].item())
+        h_ret[0, offset : offset + nt_i] = h_work[i, :nt_i]
+    return h_ret
+
+
+def run_varlen_kernel(
+    lib,
+    h_out: torch.Tensor,
+    k_pad: torch.Tensor,
+    u_pad: torch.Tensor,
+    w_pad: torch.Tensor,
+    g_pad: torch.Tensor,
+    v_new_pad: torch.Tensor,
+    h0: torch.Tensor,
+    ht: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    ws_wh: torch.Tensor,
+    ws_vnew: torch.Tensor,
+    ws_hupd: torch.Tensor,
+    ws_h: torch.Tensor,
+    stream,
+):
+    lib.call(
+        ctypes.c_void_p(h_out.data_ptr()),
+        ctypes.c_void_p(k_pad.data_ptr()),
+        ctypes.c_void_p(u_pad.data_ptr()),
+        ctypes.c_void_p(w_pad.data_ptr()),
+        ctypes.c_void_p(g_pad.data_ptr()),
+        ctypes.c_void_p(v_new_pad.data_ptr()),
+        ctypes.c_void_p(h0.data_ptr()),
+        ctypes.c_void_p(ht.data_ptr()),
+        ctypes.c_void_p(cu_seqlens.data_ptr()),
+        ctypes.c_void_p(ws_wh.data_ptr()),
+        ctypes.c_void_p(ws_vnew.data_ptr()),
+        ctypes.c_void_p(ws_hupd.data_ptr()),
+        ctypes.c_void_p(ws_h.data_ptr()),
+        stream,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Static PTO varlen chunk_gated_delta_rule vs PyTorch ref")
+    parser.add_argument(
+        "--profile",
+        choices=("H32", "H48"),
+        default="H48",
+        help="Which dumped kernel (must match head count / launch geometry).",
+    )
+    parser.add_argument(
+        "--seqlens",
+        type=str,
+        default=None,
+        help="Comma-separated sequence lengths (default: profile-specific layout-safe tuple).",
+    )
+    parser.add_argument("--rtol", type=float, default=5e-2)
+    parser.add_argument("--atol", type=float, default=5e-2)
+    parser.add_argument("--seed", type=int, default=41)
+    args = parser.parse_args()
+
+    meta = KERNEL_META[args.profile]
+    h, hg = meta["H"], meta["Hg"]
+    n_expect = meta["N"]
+    t_pad = meta["T_pad"]
+    nt_max = meta["NT_max"]
+
+    if args.seqlens is not None:
+        seqlens = tuple(int(x.strip()) for x in args.seqlens.split(",") if x.strip())
+    else:
+        seqlens = meta["default_seqlens"]
+
+    if len(seqlens) != n_expect:
+        raise ValueError(f"Profile {args.profile} expects N={n_expect} sequences, got {len(seqlens)}.")
+
+    t_total = sum(seqlens)
+    if t_total + BT != t_pad:
+        print(
+            f"WARNING: sum(seqlens)+BT = {t_total + BT} != baked T_pad={t_pad}; "
+            "GM strides in the dump may not match (e.g. use default seqlens for H32).",
+            file=sys.stderr,
+        )
+
+    torch.manual_seed(args.seed)
+    torch.npu.set_device("npu:0")
+    stream = torch.npu.current_stream()._as_parameter_
+
+    cu_seqlens = torch.tensor([0] + list(torch.cumsum(torch.tensor(seqlens), dim=0)), dtype=torch.int32, device="npu")
+    chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
+
+    kk, v = 128, 128
+    k = torch.randn(1, t_total, hg, kk, device="npu", dtype=torch.float16) * 0.01
+    w = torch.randn(1, t_total, h, kk, device="npu", dtype=torch.float16) * 0.01
+    u = torch.randn(1, t_total, h, v, device="npu", dtype=torch.float16) * 0.01
+    g = torch.randn(1, t_total, h, device="npu", dtype=torch.float32) * 0.01
+    initial_state = torch.randn(1, n_expect, h, kk, v, device="npu", dtype=torch.float16) * 0.01
+
+    def pad_tensor(t: torch.Tensor) -> torch.Tensor:
+        # ``t`` is ``[1, T, ...]`` (batch 1); pad the time axis like ``torch.cat`` on dim 0 of flattened ``[T, ...]``.
+        z = torch.zeros((t.shape[0], BT) + t.shape[2:], dtype=t.dtype, device=t.device)
+        return torch.cat([t, z], dim=1)
+
+    k_pad = pad_tensor(k)
+    w_pad = pad_tensor(w)
+    u_pad = pad_tensor(u)
+    g_pad = pad_tensor(g.float()).contiguous()
+    v_new_pad = torch.empty(1, t_pad, h, v, device="npu", dtype=torch.float16)
+    v_new_pad.zero_()
+
+    h_work = torch.zeros(n_expect, nt_max, h, kk, v, device="npu", dtype=torch.float16)
+    h0 = torch.zeros(n_expect, h, kk, v, device="npu", dtype=torch.float16)
+    h0.copy_(initial_state.squeeze(0))
+    ht = torch.zeros(n_expect, h, kk, v, device="npu", dtype=torch.float16)
+
+    ws_wh = torch.zeros(n_expect, h, BT, v, device="npu", dtype=torch.float32)
+    ws_vnew = torch.zeros(n_expect, h, BT, v, device="npu", dtype=torch.float16)
+    ws_hupd = torch.zeros(n_expect, h, kk, v, device="npu", dtype=torch.float16)
+    ws_h = torch.zeros(n_expect, h, kk, v, device="npu", dtype=torch.float16)
+
+    lib = meta["lib_fn"]()
+    run_varlen_kernel(
+        lib,
+        h_work,
+        k_pad.squeeze(0),
+        u_pad.squeeze(0),
+        w_pad.squeeze(0),
+        g_pad.squeeze(0),
+        v_new_pad.squeeze(0),
+        h0,
+        ht,
+        cu_seqlens,
+        ws_wh,
+        ws_vnew,
+        ws_hupd,
+        ws_h,
+        stream,
+    )
+    torch.npu.synchronize()
+
+    v_new_out = v_new_pad[:, :t_total].contiguous()
+    h_packed = pack_h_ret(h_work, cu_seqlens, chunk_offsets, BT, nt_max, h, kk, v)
+
+    ref_h, ref_v_new, ref_ht = ref_chunk_gated_delta_rule_varlen(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu(),
+        initial_state.cpu(),
+        True,
+        cu_seqlens.cpu(),
+    )
+
+    torch.testing.assert_close(h_packed.cpu(), ref_h.cpu(), rtol=args.rtol, atol=args.atol)
+    torch.testing.assert_close(v_new_out.cpu(), ref_v_new.cpu(), rtol=args.rtol, atol=args.atol)
+    torch.testing.assert_close(ht.cpu(), ref_ht.squeeze(0).cpu(), rtol=args.rtol, atol=args.atol)
+    print(f"chunk_gated_delta_rule varlen static ({args.profile}) matches PyTorch reference.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/static_kernel_libs.py
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/static_kernel_libs.py
@@ -1,0 +1,50 @@
+"""
+Load compiled varlen chunk_gated_delta_rule PTO shared libraries (ctypes).
+"""
+from __future__ import annotations
+
+import ctypes
+import os
+from functools import lru_cache
+
+from pto_static_common import compile_pto_kernel
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _kernel_mtime(cpp_name: str) -> int:
+    return os.stat(os.path.join(_HERE, cpp_name)).st_mtime_ns
+
+
+@lru_cache(maxsize=4)
+def _lib_varlen_h32_cached(cpp_mtime_ns: int):
+    del cpp_mtime_ns
+    p = compile_pto_kernel(
+        "chunk_gated_delta_rule_varlen_H32_kernel.cpp",
+        "chunk_gated_delta_rule_varlen_H32_static.so",
+    )
+    lib = ctypes.CDLL(os.path.abspath(p))
+    lib.call.argtypes = [ctypes.c_void_p] * 12 + [ctypes.c_void_p]
+    lib.call.restype = None
+    return lib
+
+
+def lib_chunk_gated_delta_rule_varlen_h32():
+    return _lib_varlen_h32_cached(_kernel_mtime("chunk_gated_delta_rule_varlen_H32_kernel.cpp"))
+
+
+@lru_cache(maxsize=4)
+def _lib_varlen_h48_cached(cpp_mtime_ns: int):
+    del cpp_mtime_ns
+    p = compile_pto_kernel(
+        "chunk_gated_delta_rule_varlen_H48_kernel.cpp",
+        "chunk_gated_delta_rule_varlen_H48_static.so",
+    )
+    lib = ctypes.CDLL(os.path.abspath(p))
+    lib.call.argtypes = [ctypes.c_void_p] * 12 + [ctypes.c_void_p]
+    lib.call.restype = None
+    return lib
+
+
+def lib_chunk_gated_delta_rule_varlen_h48():
+    return _lib_varlen_h48_cached(_kernel_mtime("chunk_gated_delta_rule_varlen_H48_kernel.cpp"))

--- a/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/test_chunk_gated_delta_rule_varlen_static.sh
+++ b/examples/jit_cpp/chunk_gdn/static_baseline/varlen_groupvalue/test_chunk_gated_delta_rule_varlen_static.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Compile and run static PTO varlen chunk_gated_delta_rule kernels (bisheng + ctypes).
+# Prefer latest PTO headers from the pto-isa tree used by TileLang dumps:
+#   export PTO_LIB_PATH=/sources/pto-isa
+set -euo pipefail
+export PTO_LIB_PATH="${PTO_LIB_PATH:-/sources/pto-isa}"
+cd "$(dirname "$0")"
+./compile_varlen_kernels.sh
+python3 run_chunk_gated_delta_rule_varlen_static.py --profile H48
+python3 run_chunk_gated_delta_rule_varlen_static.py --profile H32

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.cpp
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.cpp
@@ -1,191 +1,209 @@
-#include "tl_templates/ascend/common.h"
+#include "tl_templates/pto/common.h"
+#include <pto/pto-inst.hpp>
 #include "acl/acl.h"
 #include <runtime/rt_ffts.h>
-using namespace Catlass;
-using uint = unsigned int;
-using uchar = unsigned char;
-using ushort = unsigned short;
+using namespace pto;
 
-extern "C" __global__ __aicore__ void main_kernel( GM_ADDR h_handle,  GM_ADDR k_handle,  GM_ADDR v_handle,  GM_ADDR w_handle,  GM_ADDR g_handle,  GM_ADDR v_new_handle,  GM_ADDR h0_handle,  GM_ADDR ht_handle,  GM_ADDR cu_seqlens_handle,  GM_ADDR ws_wh_handle,  GM_ADDR ws_vnew_handle,  GM_ADDR ws_hupd_handle,  GM_ADDR ws_h_handle, uint64_t fftsAddr) {
-  KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
-  AscendC::TPipe pipe;
+AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ half *v_handle, __gm__ half *w_handle, __gm__ float *g_handle, __gm__ half *v_new_handle, __gm__ half *h0_handle, __gm__ half *ht_handle, __gm__ int *cu_seqlens_handle, __gm__ float *ws_wh_handle, __gm__ half *ws_vnew_handle, __gm__ half *ws_hupd_handle, __gm__ half *ws_h_handle, uint64_t ffts_Addr) {
+  auto cid = get_block_idx();
+  set_ffts_base_addr(ffts_Addr);
 
-  AscendC::GlobalTensor<half> h;
-  h.SetGlobalBuffer((__gm__ half*)h_handle);
-  AscendC::GlobalTensor<half> k;
-  k.SetGlobalBuffer((__gm__ half*)k_handle);
-  AscendC::GlobalTensor<half> v;
-  v.SetGlobalBuffer((__gm__ half*)v_handle);
-  AscendC::GlobalTensor<half> w;
-  w.SetGlobalBuffer((__gm__ half*)w_handle);
-  AscendC::GlobalTensor<float> g;
-  g.SetGlobalBuffer((__gm__ float*)g_handle);
-  AscendC::GlobalTensor<half> v_new;
-  v_new.SetGlobalBuffer((__gm__ half*)v_new_handle);
-  AscendC::GlobalTensor<half> h0;
-  h0.SetGlobalBuffer((__gm__ half*)h0_handle);
-  AscendC::GlobalTensor<half> ht;
-  ht.SetGlobalBuffer((__gm__ half*)ht_handle);
-  AscendC::GlobalTensor<int> cu_seqlens;
-  cu_seqlens.SetGlobalBuffer((__gm__ int*)cu_seqlens_handle);
-  AscendC::GlobalTensor<float> ws_wh;
-  ws_wh.SetGlobalBuffer((__gm__ float*)ws_wh_handle);
-  AscendC::GlobalTensor<half> ws_vnew;
-  ws_vnew.SetGlobalBuffer((__gm__ half*)ws_vnew_handle);
-  AscendC::GlobalTensor<half> ws_hupd;
-  ws_hupd.SetGlobalBuffer((__gm__ half*)ws_hupd_handle);
-  AscendC::GlobalTensor<half> ws_h;
-  ws_h.SetGlobalBuffer((__gm__ half*)ws_h_handle);
+  tl::ascend_pto::TileMatL1<half, 128, 128, 128, 128> h_state_l1;
+  TASSIGN(h_state_l1, 0);
+  tl::ascend_pto::TileMatL1<half, 64, 128, 64, 128> w_chunk_l1;
+  TASSIGN(w_chunk_l1, 32768);
+  TileAcc<float, 64, 128, 64, 128> wh_frag;
+  TASSIGN(wh_frag, 0);
+  tl::ascend_pto::TileMatL1<half, 64, 128, 64, 128> v_new_l1;
+  TASSIGN(v_new_l1, 49152);
+  tl::ascend_pto::TileMatL1<half, 64, 128, 64, 128> k_chunk_l1;
+  TASSIGN(k_chunk_l1, 65536);
+  TileAcc<float, 128, 128, 128, 128> hupd_frag;
+  TASSIGN(hupd_frag, 32768);
+  tl::ascend_pto::TileUbDataND<half, 64, 128, 64, 128> h_state_ub;
+  TASSIGN(h_state_ub, 0);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> wh_ub_float;
+  TASSIGN(wh_ub_float, 16384);
+  tl::ascend_pto::TileUbDataND<half, 32, 128, 32, 128> v_chunk_ub;
+  TASSIGN(v_chunk_ub, 32768);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> v_chunk_ub_float;
+  TASSIGN(v_chunk_ub_float, 40960);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> v_new_ub_float;
+  TASSIGN(v_new_ub_float, 57344);
+  tl::ascend_pto::TileUbDataND<float, 1, 64, 1, 64> g_chunk_ub_all;
+  TASSIGN(g_chunk_ub_all, 73728);
+  tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub;
+  TASSIGN(g_chunk_ub, 73984);
+  tl::ascend_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar;
+  TASSIGN(g_last_scalar, 74112);
+  tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub;
+  TASSIGN(g_exp_ub, 74144);
+  tl::ascend_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad;
+  TASSIGN(g_exp_ub_pad, 74272);
+  tl::ascend_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad;
+  TASSIGN(g_mask_ub_pad, 74528);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> g_exp_ub_broc;
+  TASSIGN(g_exp_ub_broc, 74560);
+  tl::ascend_pto::TileUbDataND<uint8_t, 1, 8192, 1, 8192> tmp_ub;
+  TASSIGN(tmp_ub, 90944);
+  tl::ascend_pto::TileUbDataND<float, 64, 128, 64, 128> h_state_ub_float;
+  TASSIGN(h_state_ub_float, 99136);
+  tl::ascend_pto::TileUbDataND<half, 32, 128, 32, 128> v_new_ub;
+  TASSIGN(v_new_ub, 131904);
+  tl::ascend_pto::TileUbDataND<half, 64, 128, 64, 128> hupd_ub;
+  TASSIGN(hupd_ub, 140096);
+  tl::ascend_pto::TileUbDataND<float, 64, 128, 64, 128> hupd_ub_float;
+  TASSIGN(hupd_ub_float, 156480);
+  auto vid = get_subblockid();
+#if defined(__DAV_C220_CUBE__)
+    pipe_barrier(PIPE_ALL);
+    int32_t bos = *(cu_seqlens_handle + 0);
+    pipe_barrier(PIPE_ALL);
+    int32_t eos = *(cu_seqlens_handle + 1);
 
-  AscendC::TBuf<AscendC::TPosition::A2> ascend_l0a;
-  pipe.InitBuffer(ascend_l0a, 65536);
-  AscendC::TBuf<AscendC::TPosition::B2> ascend_l0b;
-  pipe.InitBuffer(ascend_l0b, 65536);
-  AscendC::TBuf<AscendC::TPosition::A1> ascend_l1; pipe.InitBuffer(ascend_l1, 524032);
-  AscendC::TBuf<AscendC::TPosition::CO1> ascend_l0c; pipe.InitBuffer(ascend_l0c, 131072);
-  AscendC::TBuf<AscendC::TPosition::VECCALC> ascend_ub; pipe.InitBuffer(ascend_ub, 196352);
-  pipe.Destroy();
-  auto cid = AscendC::GetBlockIdx();
-  if ASCEND_IS_AIV {
-    cid = cid / 2;
-  }
-  auto h_state_l1 = ascend_l1.GetWithOffset<half>(16384, 0);
-  auto w_chunk_l1 = ascend_l1.GetWithOffset<half>(8192, 32768);
-  auto wh_frag = ascend_l0c.GetWithOffset<float>(8192, 0);
-  auto v_new_l1 = ascend_l1.GetWithOffset<half>(8192, 49152);
-  auto k_chunk_l1 = ascend_l1.GetWithOffset<half>(8192, 65536);
-  auto hupd_frag = ascend_l0c.GetWithOffset<float>(16384, 32768);
-  auto h_state_ub = ascend_ub.GetWithOffset<half>(8192, 0);
-  auto wh_ub_float = ascend_ub.GetWithOffset<float>(4096, 16384);
-  auto v_chunk_ub = ascend_ub.GetWithOffset<half>(4096, 32768);
-  auto v_chunk_ub_float = ascend_ub.GetWithOffset<float>(4096, 40960);
-  auto v_new_ub_float = ascend_ub.GetWithOffset<float>(4096, 57344);
-  auto g_chunk_ub_all = ascend_ub.GetWithOffset<float>(64, 73728);
-  auto g_chunk_ub = ascend_ub.GetWithOffset<float>(32, 73984);
-  auto g_last_scalar = ascend_ub.GetWithOffset<float>(1, 74112);
-  auto g_exp_ub = ascend_ub.GetWithOffset<float>(32, 74144);
-  auto g_exp_ub_pad = ascend_ub.GetWithOffset<float>(64, 74272);
-  auto g_mask_ub_pad = ascend_ub.GetWithOffset<uint8_t>(8, 74528);
-  auto g_exp_ub_broc = ascend_ub.GetWithOffset<float>(4096, 74560);
-  auto tmp_ub = ascend_ub.GetWithOffset<uint8_t>(4096, 90944);
-  auto h_state_ub_float = ascend_ub.GetWithOffset<float>(8192, 95040);
-  auto v_new_ub = ascend_ub.GetWithOffset<half>(4096, 127808);
-  auto hupd_ub = ascend_ub.GetWithOffset<half>(8192, 136000);
-  auto hupd_ub_float = ascend_ub.GetWithOffset<float>(8192, 152384);
-  auto vid = AscendC::GetSubBlockIdx();
-  if ASCEND_IS_AIC {
-    AscendC::PipeBarrier<PIPE_ALL>();
-    int32_t bos = cu_seqlens.GetValue(0);
-    AscendC::PipeBarrier<PIPE_ALL>();
-    int32_t eos = cu_seqlens.GetValue(1);
-    for (int32_t i = 0; i < 32; ++i) {
-      AscendC::PipeBarrier<PIPE_ALL>();
+  for (int32_t i = 0; i < 32; ++i) {
+      pipe_barrier(PIPE_ALL);
       if (i < (((eos + 63) - bos) / 64)) {
-        tl::ascend::copy_gm_to_l1<half, 128, 128>(h_state_l1[0], ws_h[(cid * 16384)], 128, 128, 128);
-        tl::ascend::copy_gm_to_l1<half, 64, 128>(w_chunk_l1[0], w[(((i * 65536) + (bos * 1024)) + (cid * 128))], 1024, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_M>(1);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_M>(1);
-        tl::ascend::gemm_v0<half, float, 64, 128, 128, false, false>(w_chunk_l1[0], h_state_l1[0], wh_frag[0], ascend_l0a, ascend_l0b, (bool)1);
-        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(2);
-        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(2);
-        tl::ascend::copy_l0c_to_gm<float, float, layout::RowMajor, 64, 128, 0>(ws_wh[(cid * 8192)], wh_frag[0], 128, 64, 128);
-        tl::ascend::copy_gm_to_l1<half, 64, 128>(v_new_l1[0], ws_vnew[(cid * 8192)], 128, 64, 128);
-        tl::ascend::copy_gm_to_l1<half, 64, 128>(k_chunk_l1[0], k[(((i * 32768) + (bos * 512)) + ((cid / 2) * 128))], 512, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_M>(3);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_M>(3);
-        tl::ascend::gemm_v0<half, float, 128, 128, 64, true, false>(k_chunk_l1[0], v_new_l1[0], hupd_frag[0], ascend_l0a, ascend_l0b, (bool)1);
-        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(4);
-        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(4);
-        tl::ascend::copy_l0c_to_gm<float, half, layout::RowMajor, 128, 128, 0>(ws_hupd[(cid * 16384)], hupd_frag[0], 128, 128, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 128, 128, 131072, 131072, 16384, 128, 1, 128, 128>(ws_h_handle + (cid * 16384), 0, 0, 128, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 2162688, 1024, 1, 64, 128>(w_handle + (((i * 65536) + (bos * 1024)) + (cid * 128)), 32768, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        tl::ascend_pto::gemm_v0<half, float, 64, 128, 128, 64, 128, 128, 128, false, false>(w_chunk_l1, h_state_l1, wh_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        tl::ascend_pto::copy_l0c_to_gm<float, float, 1, 1, 1, 64, 128, 65536, 65536, 8192, 128, 1, 64, 128>(ws_wh_handle + (cid * 8192), 0, 0, 64, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 65536, 65536, 8192, 128, 1, 64, 128>(ws_vnew_handle + (cid * 8192), 49152, 0, 64, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 1081344, 512, 1, 64, 128>(k_handle + (((i * 32768) + (bos * 512)) + ((cid / 2) * 128)), 65536, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        tl::ascend_pto::gemm_v0<half, float, 128, 128, 64, 128, 128, 64, 64, true, false>(k_chunk_l1, v_new_l1, hupd_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        tl::ascend_pto::copy_l0c_to_gm<half, float, 1, 1, 1, 128, 128, 131072, 131072, 16384, 128, 1, 128, 128>(ws_hupd_handle + (cid * 16384), 32768, 0, 128, 128);
       }
-      AscendC::PipeBarrier<PIPE_ALL>();
-      AscendC::PipeBarrier<PIPE_ALL>();
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
     }
-  }
-  if ASCEND_IS_AIV {
-    AscendC::PipeBarrier<PIPE_ALL>();
-    int32_t bos_1 = cu_seqlens.GetValue(0);
-    AscendC::PipeBarrier<PIPE_ALL>();
-    int32_t eos_1 = cu_seqlens.GetValue(1);
-    tl::ascend::copy_gm_to_ub<half, 128, 64>(h_state_ub[0], h0[((cid * 16384) + (vid * 8192))], 128, 64, 128, half(0.000000e+00f));
-    for (int32_t i_1 = 0; i_1 < 32; ++i_1) {
-      AscendC::PipeBarrier<PIPE_ALL>();
+#endif
+#if defined(__DAV_C220_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    pipe_barrier(PIPE_ALL);
+    int32_t bos_1 = *(cu_seqlens_handle + 0);
+    pipe_barrier(PIPE_ALL);
+    int32_t eos_1 = *(cu_seqlens_handle + 1);
+    tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 131072, 131072, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(h0_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+
+  for (int32_t i_1 = 0; i_1 < 32; ++i_1) {
+      pipe_barrier(PIPE_ALL);
       if (i_1 < (((eos_1 + 63) - bos_1) / 64)) {
-        tl::ascend::copy_ub_to_gm<half, 128, 64>(ws_h[((cid * 16384) + (vid * 8192))], h_state_ub[0], 131072, 1, 128);
-        tl::ascend::copy_gm_to_ub<float, 128, 32>(wh_ub_float[0], ws_wh[((cid * 8192) + (vid * 4096))], 128, 32, 128, 0.000000e+00f);
-        tl::ascend::copy_gm_to_ub<half, 128, 32>(v_chunk_ub[0], v[((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128))], 1024, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128, half(0.000000e+00f));
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(1);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(1);
-        tl::ascend::copy_ub_to_ub<float, half, 4096>(v_chunk_ub_float[0], v_chunk_ub[0]);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Sub(v_new_ub_float[0], v_chunk_ub_float[0], wh_ub_float[0], 4096);
-        tl::ascend::copy_gm_to_ub<float, 64>(g_chunk_ub_all[0], g[(((i_1 * 512) + (bos_1 * 8)) + cid)], 8, ((-2048 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-2112 < ((0 - bos_1) - (i_1 * 64))) ? ((2112 - bos_1) - (i_1 * 64)) : 0)), 1, 0.000000e+00f);
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(2);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(2);
-        tl::ascend::copy_ub_to_ub<float, float, 32>(g_chunk_ub[0], g_chunk_ub_all[(vid * 32)]);
-        AscendC::PipeBarrier<PIPE_ALL>();
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1, 1, 131072, 131072, 1, 64, 128>(ws_h_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 1, 128);
+        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 32, 128, 65536, 65536, 8192, 128, 1, 32, 128, pto::PadValue::Zero>(ws_wh_handle + ((cid * 8192) + (vid * 4096)), 16384, 0, 32, 128);
+        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 32, 128, 1, 1, 2162688, 1024, 1, 32, 128, pto::PadValue::Zero>(v_handle + ((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128)), 32768, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TCVT(v_chunk_ub_float, v_chunk_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TSUB(v_new_ub_float, v_chunk_ub_float, wh_ub_float);
+        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 1, 64, 1, 1, 16896, 8, 1, 1, 64, pto::PadValue::Zero>(g_handle + (((i_1 * 512) + (bos_1 * 8)) + cid), 73728, 0, ((-2048 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-2112 < ((0 - bos_1) - (i_1 * 64))) ? ((2112 - bos_1) - (i_1 * 64)) : 0)), 1);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub_all_temp_0;
+        TASSIGN(g_chunk_ub_all_temp_0, 73728 + (vid * 32) * 4);
+        TMOV(g_chunk_ub, g_chunk_ub_all_temp_0);
+        pipe_barrier(PIPE_ALL);
         if (((i_1 * 64) + 64) <= (eos_1 - bos_1)) {
           g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue(63));
         } else {
           g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue((((((int64_t)eos_1) - ((int64_t)bos_1)) - (((int64_t)i_1) * (int64_t)64)) - (int64_t)1)));
         }
-        AscendC::PipeBarrier<PIPE_ALL>();
-        tl::ascend::Fill<float>(g_exp_ub[0], g_last_scalar.GetValue(0), 32);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Sub(g_exp_ub[0], g_exp_ub[0], g_chunk_ub[0], 32);
-        AscendC::PipeBarrier<PIPE_V>();
-        tl::ascend::copy_ub_to_ub<float, float, 32>(g_exp_ub_pad[0], g_exp_ub[0]);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::CompareScalar(g_mask_ub_pad[0], g_exp_ub_pad[0], 0.000000e+00f, AscendC::CMPMODE::LE, 64);
-        AscendC::PipeBarrier<PIPE_V>();
-AscendC::Select<float, uint8_t>(g_exp_ub_pad[0], g_mask_ub_pad[0], g_exp_ub_pad[0], static_cast<float>(-CUDART_INF_F), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, 64);
-        AscendC::PipeBarrier<PIPE_V>();
-        tl::ascend::copy_ub_to_ub<float, float, 32>(g_exp_ub[0], g_exp_ub_pad[0]);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Exp(g_exp_ub[0], g_exp_ub[0], 32);
-        AscendC::PipeBarrier<PIPE_V>();
-        tl::ascend::Broadcast<float, 2, 1, false>(g_exp_ub_broc[0],g_exp_ub[0],tmp_ub,(uint32_t[]){32, 128}, (uint32_t[]){32, 1});
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Mul(v_new_ub_float[0], v_new_ub_float[0], g_exp_ub_broc[0], 4096);
-        AscendC::Exp(g_last_scalar[0], g_last_scalar[0], 1);
-        tl::ascend::copy_ub_to_ub<float, half, 8192>(h_state_ub_float[0], h_state_ub[0]);
-        AscendC::PipeBarrier<PIPE_V>();
-        {
-        AscendC::PipeBarrier<PIPE_ALL>();
-        auto g_last_scalar_scalar = g_last_scalar.GetValue(0);
-        AscendC::Muls(h_state_ub_float[0], h_state_ub_float[0], g_last_scalar_scalar, 8192);
-        }
-        tl::ascend::copy_ub_to_ub<half, float, 4096>(v_new_ub[0], v_new_ub_float[0]);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(3);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(3);
-        tl::ascend::copy_ub_to_gm<half, 128, 32>(v_new[((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128))], v_new_ub[0], 1024, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
-        tl::ascend::copy_ub_to_gm<half, 128, 32>(ws_vnew[((cid * 8192) + (vid * 4096))], v_new_ub[0], 65536, 1, 128);
-        tl::ascend::copy_gm_to_ub<half, 128, 64>(hupd_ub[0], ws_hupd[((cid * 16384) + (vid * 8192))], 128, 64, 128, half(0.000000e+00f));
-        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(4);
-        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(4);
-        tl::ascend::copy_ub_to_ub<float, half, 8192>(hupd_ub_float[0], hupd_ub[0]);
-        AscendC::PipeBarrier<PIPE_V>();
-        AscendC::Add(h_state_ub_float[0], h_state_ub_float[0], hupd_ub_float[0], 8192);
-        AscendC::PipeBarrier<PIPE_V>();
-        tl::ascend::copy_ub_to_ub<half, float, 8192>(h_state_ub[0], h_state_ub_float[0]);
-        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(5);
-        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(5);
-        tl::ascend::copy_ub_to_gm<half, 128, 64>(h[(((i_1 * 131072) + (cid * 16384)) + (vid * 8192))], h_state_ub[0], 128, 64, 128);
+        pipe_barrier(PIPE_ALL);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        TEXPANDS(g_exp_ub, g_last_scalar.GetValue(0));
+        pipe_barrier(PIPE_V);
+        TSUB(g_exp_ub, g_exp_ub, g_chunk_ub);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_0;
+        TASSIGN(g_exp_ub_pad_temp_0, 74272 + 0 * 4);
+        TMOV(g_exp_ub_pad_temp_0, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad_temp_1;
+        TASSIGN(g_exp_ub_pad_temp_1, 74272 + 0 * 4);
+        tl::ascend_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad_temp_0;
+        TASSIGN(g_mask_ub_pad_temp_0, 74528 + 0 * 1);
+        tl::ascend_pto::compare_scalar(g_mask_ub_pad_temp_0, g_exp_ub_pad_temp_1, 0.000000e+00f, CmpMode::LE);
+        pipe_barrier(PIPE_V);
+        TSELS(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, -CUDART_INF_F);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_2;
+        TASSIGN(g_exp_ub_pad_temp_2, 74272 + 0 * 4);
+        TMOV(g_exp_ub, g_exp_ub_pad_temp_2);
+        pipe_barrier(PIPE_V);
+        TEXP(g_exp_ub, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataDN<float, 32, 1, 32, 1> g_exp_ub_temp_0;
+        TASSIGN(g_exp_ub_temp_0, 74144 + 0 * 4);
+        TROWEXPAND(g_exp_ub_broc, g_exp_ub_temp_0);
+        pipe_barrier(PIPE_V);
+        TMUL(v_new_ub_float, v_new_ub_float, g_exp_ub_broc);
+        tl::ascend_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_0;
+        TASSIGN(g_last_scalar_temp_0, 74112 + 0 * 4);
+        tl::ascend_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_1;
+        TASSIGN(g_last_scalar_temp_1, 74112 + 0 * 4);
+        TEXP(g_last_scalar_temp_1, g_last_scalar_temp_0);
+        TCVT(h_state_ub_float, h_state_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        auto g_last_scalar_scalar_temp_0 = g_last_scalar.GetValue(0);
+        TMULS(h_state_ub_float, h_state_ub_float, g_last_scalar_scalar_temp_0);
+        TCVT(v_new_ub, v_new_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 2162688, 1024, 1, 32, 128>(v_new_handle + ((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128)), 131904, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 65536, 65536, 1, 32, 128>(ws_vnew_handle + ((cid * 8192) + (vid * 4096)), 131904, 0, 1, 128);
+        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 131072, 131072, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(ws_hupd_handle + ((cid * 16384) + (vid * 8192)), 140096, 0, 64, 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        TCVT(hupd_ub_float, hupd_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TADD(h_state_ub_float, h_state_ub_float, hupd_ub_float);
+        pipe_barrier(PIPE_V);
+        TCVT(h_state_ub, h_state_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 4194304, 131072, 16384, 128, 1, 64, 128>(h_handle + (((i_1 * 131072) + (cid * 16384)) + (vid * 8192)), 0, 0, 64, 128);
       }
-      AscendC::PipeBarrier<PIPE_ALL>();
-      AscendC::PipeBarrier<PIPE_ALL>();
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
     }
-    tl::ascend::copy_ub_to_gm<half, 128, 64>(ht[((cid * 16384) + (vid * 8192))], h_state_ub[0], 128, 64, 128);
-  }
+    tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 131072, 131072, 16384, 128, 1, 64, 128>(ht_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+#endif
 }
 
-void main_kernel_tiling() {
+extern "C" __global__ AICORE void launch_kernel(__gm__ uint8_t *h_handle, __gm__ uint8_t *k_handle, __gm__ uint8_t *v_handle, __gm__ uint8_t *w_handle, __gm__ uint8_t *g_handle, __gm__ uint8_t *v_new_handle, __gm__ uint8_t *h0_handle, __gm__ uint8_t *ht_handle, __gm__ uint8_t *cu_seqlens_handle, __gm__ uint8_t *ws_wh_handle, __gm__ uint8_t *ws_vnew_handle, __gm__ uint8_t *ws_hupd_handle, __gm__ uint8_t *ws_h_handle, uint64_t fftsAddr)
+{
+    main_kernel(reinterpret_cast<__gm__ half *>(h_handle),
+     reinterpret_cast<__gm__ half *>(k_handle),
+     reinterpret_cast<__gm__ half *>(v_handle),
+     reinterpret_cast<__gm__ half *>(w_handle),
+     reinterpret_cast<__gm__ float *>(g_handle),
+     reinterpret_cast<__gm__ half *>(v_new_handle),
+     reinterpret_cast<__gm__ half *>(h0_handle),
+     reinterpret_cast<__gm__ half *>(ht_handle),
+     reinterpret_cast<__gm__ int *>(cu_seqlens_handle),
+     reinterpret_cast<__gm__ float *>(ws_wh_handle),
+     reinterpret_cast<__gm__ half *>(ws_vnew_handle),
+     reinterpret_cast<__gm__ half *>(ws_hupd_handle),
+     reinterpret_cast<__gm__ half *>(ws_h_handle),
+     reinterpret_cast<uint64_t>(fftsAddr));
 }
 
-extern "C" void call(uint8_t* h_handle, uint8_t* k_handle, uint8_t* v_handle, uint8_t* w_handle, uint8_t* g_handle, uint8_t* v_new_handle, uint8_t* h0_handle, uint8_t* ht_handle, uint8_t* cu_seqlens_handle, uint8_t* ws_wh_handle, uint8_t* ws_vnew_handle, uint8_t* ws_hupd_handle, uint8_t* ws_h_handle, aclrtStream stream) {
-  uint32_t fftsLen{0};
-  uint64_t fftsAddr{0};
-  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
-  main_kernel_tiling();
-  main_kernel<<<8, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
+extern "C" void call(uint8_t *h_handle, uint8_t *k_handle, uint8_t *v_handle, uint8_t *w_handle, uint8_t *g_handle, uint8_t *v_new_handle, uint8_t *h0_handle, uint8_t *ht_handle, uint8_t *cu_seqlens_handle, uint8_t *ws_wh_handle, uint8_t *ws_vnew_handle, uint8_t *ws_hupd_handle, uint8_t *ws_h_handle, void *stream)
+{
+    uint32_t fftsLen{0};
+    uint64_t fftsAddr{0};
+    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+    launch_kernel<<<8, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
 }

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.cpp
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.cpp
@@ -1,0 +1,191 @@
+#include "tl_templates/ascend/common.h"
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace Catlass;
+using uint = unsigned int;
+using uchar = unsigned char;
+using ushort = unsigned short;
+
+extern "C" __global__ __aicore__ void main_kernel( GM_ADDR h_handle,  GM_ADDR k_handle,  GM_ADDR v_handle,  GM_ADDR w_handle,  GM_ADDR g_handle,  GM_ADDR v_new_handle,  GM_ADDR h0_handle,  GM_ADDR ht_handle,  GM_ADDR cu_seqlens_handle,  GM_ADDR ws_wh_handle,  GM_ADDR ws_vnew_handle,  GM_ADDR ws_hupd_handle,  GM_ADDR ws_h_handle, uint64_t fftsAddr) {
+  KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+  AscendC::TPipe pipe;
+
+  AscendC::GlobalTensor<half> h;
+  h.SetGlobalBuffer((__gm__ half*)h_handle);
+  AscendC::GlobalTensor<half> k;
+  k.SetGlobalBuffer((__gm__ half*)k_handle);
+  AscendC::GlobalTensor<half> v;
+  v.SetGlobalBuffer((__gm__ half*)v_handle);
+  AscendC::GlobalTensor<half> w;
+  w.SetGlobalBuffer((__gm__ half*)w_handle);
+  AscendC::GlobalTensor<float> g;
+  g.SetGlobalBuffer((__gm__ float*)g_handle);
+  AscendC::GlobalTensor<half> v_new;
+  v_new.SetGlobalBuffer((__gm__ half*)v_new_handle);
+  AscendC::GlobalTensor<half> h0;
+  h0.SetGlobalBuffer((__gm__ half*)h0_handle);
+  AscendC::GlobalTensor<half> ht;
+  ht.SetGlobalBuffer((__gm__ half*)ht_handle);
+  AscendC::GlobalTensor<int> cu_seqlens;
+  cu_seqlens.SetGlobalBuffer((__gm__ int*)cu_seqlens_handle);
+  AscendC::GlobalTensor<float> ws_wh;
+  ws_wh.SetGlobalBuffer((__gm__ float*)ws_wh_handle);
+  AscendC::GlobalTensor<half> ws_vnew;
+  ws_vnew.SetGlobalBuffer((__gm__ half*)ws_vnew_handle);
+  AscendC::GlobalTensor<half> ws_hupd;
+  ws_hupd.SetGlobalBuffer((__gm__ half*)ws_hupd_handle);
+  AscendC::GlobalTensor<half> ws_h;
+  ws_h.SetGlobalBuffer((__gm__ half*)ws_h_handle);
+
+  AscendC::TBuf<AscendC::TPosition::A2> ascend_l0a;
+  pipe.InitBuffer(ascend_l0a, 65536);
+  AscendC::TBuf<AscendC::TPosition::B2> ascend_l0b;
+  pipe.InitBuffer(ascend_l0b, 65536);
+  AscendC::TBuf<AscendC::TPosition::A1> ascend_l1; pipe.InitBuffer(ascend_l1, 524032);
+  AscendC::TBuf<AscendC::TPosition::CO1> ascend_l0c; pipe.InitBuffer(ascend_l0c, 131072);
+  AscendC::TBuf<AscendC::TPosition::VECCALC> ascend_ub; pipe.InitBuffer(ascend_ub, 196352);
+  pipe.Destroy();
+  auto cid = AscendC::GetBlockIdx();
+  if ASCEND_IS_AIV {
+    cid = cid / 2;
+  }
+  auto h_state_l1 = ascend_l1.GetWithOffset<half>(16384, 0);
+  auto w_chunk_l1 = ascend_l1.GetWithOffset<half>(8192, 32768);
+  auto wh_frag = ascend_l0c.GetWithOffset<float>(8192, 0);
+  auto v_new_l1 = ascend_l1.GetWithOffset<half>(8192, 49152);
+  auto k_chunk_l1 = ascend_l1.GetWithOffset<half>(8192, 65536);
+  auto hupd_frag = ascend_l0c.GetWithOffset<float>(16384, 32768);
+  auto h_state_ub = ascend_ub.GetWithOffset<half>(8192, 0);
+  auto wh_ub_float = ascend_ub.GetWithOffset<float>(4096, 16384);
+  auto v_chunk_ub = ascend_ub.GetWithOffset<half>(4096, 32768);
+  auto v_chunk_ub_float = ascend_ub.GetWithOffset<float>(4096, 40960);
+  auto v_new_ub_float = ascend_ub.GetWithOffset<float>(4096, 57344);
+  auto g_chunk_ub_all = ascend_ub.GetWithOffset<float>(64, 73728);
+  auto g_chunk_ub = ascend_ub.GetWithOffset<float>(32, 73984);
+  auto g_last_scalar = ascend_ub.GetWithOffset<float>(1, 74112);
+  auto g_exp_ub = ascend_ub.GetWithOffset<float>(32, 74144);
+  auto g_exp_ub_pad = ascend_ub.GetWithOffset<float>(64, 74272);
+  auto g_mask_ub_pad = ascend_ub.GetWithOffset<uint8_t>(8, 74528);
+  auto g_exp_ub_broc = ascend_ub.GetWithOffset<float>(4096, 74560);
+  auto tmp_ub = ascend_ub.GetWithOffset<uint8_t>(4096, 90944);
+  auto h_state_ub_float = ascend_ub.GetWithOffset<float>(8192, 95040);
+  auto v_new_ub = ascend_ub.GetWithOffset<half>(4096, 127808);
+  auto hupd_ub = ascend_ub.GetWithOffset<half>(8192, 136000);
+  auto hupd_ub_float = ascend_ub.GetWithOffset<float>(8192, 152384);
+  auto vid = AscendC::GetSubBlockIdx();
+  if ASCEND_IS_AIC {
+    AscendC::PipeBarrier<PIPE_ALL>();
+    int32_t bos = cu_seqlens.GetValue(0);
+    AscendC::PipeBarrier<PIPE_ALL>();
+    int32_t eos = cu_seqlens.GetValue(1);
+    for (int32_t i = 0; i < 32; ++i) {
+      AscendC::PipeBarrier<PIPE_ALL>();
+      if (i < (((eos + 63) - bos) / 64)) {
+        tl::ascend::copy_gm_to_l1<half, 128, 128>(h_state_l1[0], ws_h[(cid * 16384)], 128, 128, 128);
+        tl::ascend::copy_gm_to_l1<half, 64, 128>(w_chunk_l1[0], w[(((i * 65536) + (bos * 1024)) + (cid * 128))], 1024, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_M>(1);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_M>(1);
+        tl::ascend::gemm_v0<half, float, 64, 128, 128, false, false>(w_chunk_l1[0], h_state_l1[0], wh_frag[0], ascend_l0a, ascend_l0b, (bool)1);
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(2);
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(2);
+        tl::ascend::copy_l0c_to_gm<float, float, layout::RowMajor, 64, 128, 0>(ws_wh[(cid * 8192)], wh_frag[0], 128, 64, 128);
+        tl::ascend::copy_gm_to_l1<half, 64, 128>(v_new_l1[0], ws_vnew[(cid * 8192)], 128, 64, 128);
+        tl::ascend::copy_gm_to_l1<half, 64, 128>(k_chunk_l1[0], k[(((i * 32768) + (bos * 512)) + ((cid / 2) * 128))], 512, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_M>(3);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_M>(3);
+        tl::ascend::gemm_v0<half, float, 128, 128, 64, true, false>(k_chunk_l1[0], v_new_l1[0], hupd_frag[0], ascend_l0a, ascend_l0b, (bool)1);
+        AscendC::SetFlag<AscendC::HardEvent::M_FIX>(4);
+        AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(4);
+        tl::ascend::copy_l0c_to_gm<float, half, layout::RowMajor, 128, 128, 0>(ws_hupd[(cid * 16384)], hupd_frag[0], 128, 128, 128);
+      }
+      AscendC::PipeBarrier<PIPE_ALL>();
+      AscendC::PipeBarrier<PIPE_ALL>();
+    }
+  }
+  if ASCEND_IS_AIV {
+    AscendC::PipeBarrier<PIPE_ALL>();
+    int32_t bos_1 = cu_seqlens.GetValue(0);
+    AscendC::PipeBarrier<PIPE_ALL>();
+    int32_t eos_1 = cu_seqlens.GetValue(1);
+    tl::ascend::copy_gm_to_ub<half, 128, 64>(h_state_ub[0], h0[((cid * 16384) + (vid * 8192))], 128, 64, 128, half(0.000000e+00f));
+    for (int32_t i_1 = 0; i_1 < 32; ++i_1) {
+      AscendC::PipeBarrier<PIPE_ALL>();
+      if (i_1 < (((eos_1 + 63) - bos_1) / 64)) {
+        tl::ascend::copy_ub_to_gm<half, 128, 64>(ws_h[((cid * 16384) + (vid * 8192))], h_state_ub[0], 131072, 1, 128);
+        tl::ascend::copy_gm_to_ub<float, 128, 32>(wh_ub_float[0], ws_wh[((cid * 8192) + (vid * 4096))], 128, 32, 128, 0.000000e+00f);
+        tl::ascend::copy_gm_to_ub<half, 128, 32>(v_chunk_ub[0], v[((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128))], 1024, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128, half(0.000000e+00f));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(1);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(1);
+        tl::ascend::copy_ub_to_ub<float, half, 4096>(v_chunk_ub_float[0], v_chunk_ub[0]);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Sub(v_new_ub_float[0], v_chunk_ub_float[0], wh_ub_float[0], 4096);
+        tl::ascend::copy_gm_to_ub<float, 64>(g_chunk_ub_all[0], g[(((i_1 * 512) + (bos_1 * 8)) + cid)], 8, ((-2048 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-2112 < ((0 - bos_1) - (i_1 * 64))) ? ((2112 - bos_1) - (i_1 * 64)) : 0)), 1, 0.000000e+00f);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(2);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(2);
+        tl::ascend::copy_ub_to_ub<float, float, 32>(g_chunk_ub[0], g_chunk_ub_all[(vid * 32)]);
+        AscendC::PipeBarrier<PIPE_ALL>();
+        if (((i_1 * 64) + 64) <= (eos_1 - bos_1)) {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue(63));
+        } else {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue((((((int64_t)eos_1) - ((int64_t)bos_1)) - (((int64_t)i_1) * (int64_t)64)) - (int64_t)1)));
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+        tl::ascend::Fill<float>(g_exp_ub[0], g_last_scalar.GetValue(0), 32);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Sub(g_exp_ub[0], g_exp_ub[0], g_chunk_ub[0], 32);
+        AscendC::PipeBarrier<PIPE_V>();
+        tl::ascend::copy_ub_to_ub<float, float, 32>(g_exp_ub_pad[0], g_exp_ub[0]);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::CompareScalar(g_mask_ub_pad[0], g_exp_ub_pad[0], 0.000000e+00f, AscendC::CMPMODE::LE, 64);
+        AscendC::PipeBarrier<PIPE_V>();
+AscendC::Select<float, uint8_t>(g_exp_ub_pad[0], g_mask_ub_pad[0], g_exp_ub_pad[0], static_cast<float>(-CUDART_INF_F), AscendC::SELMODE::VSEL_TENSOR_SCALAR_MODE, 64);
+        AscendC::PipeBarrier<PIPE_V>();
+        tl::ascend::copy_ub_to_ub<float, float, 32>(g_exp_ub[0], g_exp_ub_pad[0]);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp(g_exp_ub[0], g_exp_ub[0], 32);
+        AscendC::PipeBarrier<PIPE_V>();
+        tl::ascend::Broadcast<float, 2, 1, false>(g_exp_ub_broc[0],g_exp_ub[0],tmp_ub,(uint32_t[]){32, 128}, (uint32_t[]){32, 1});
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Mul(v_new_ub_float[0], v_new_ub_float[0], g_exp_ub_broc[0], 4096);
+        AscendC::Exp(g_last_scalar[0], g_last_scalar[0], 1);
+        tl::ascend::copy_ub_to_ub<float, half, 8192>(h_state_ub_float[0], h_state_ub[0]);
+        AscendC::PipeBarrier<PIPE_V>();
+        {
+        AscendC::PipeBarrier<PIPE_ALL>();
+        auto g_last_scalar_scalar = g_last_scalar.GetValue(0);
+        AscendC::Muls(h_state_ub_float[0], h_state_ub_float[0], g_last_scalar_scalar, 8192);
+        }
+        tl::ascend::copy_ub_to_ub<half, float, 4096>(v_new_ub[0], v_new_ub_float[0]);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(3);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(3);
+        tl::ascend::copy_ub_to_gm<half, 128, 32>(v_new[((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128))], v_new_ub[0], 1024, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        tl::ascend::copy_ub_to_gm<half, 128, 32>(ws_vnew[((cid * 8192) + (vid * 4096))], v_new_ub[0], 65536, 1, 128);
+        tl::ascend::copy_gm_to_ub<half, 128, 64>(hupd_ub[0], ws_hupd[((cid * 16384) + (vid * 8192))], 128, 64, 128, half(0.000000e+00f));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(4);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(4);
+        tl::ascend::copy_ub_to_ub<float, half, 8192>(hupd_ub_float[0], hupd_ub[0]);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(h_state_ub_float[0], h_state_ub_float[0], hupd_ub_float[0], 8192);
+        AscendC::PipeBarrier<PIPE_V>();
+        tl::ascend::copy_ub_to_ub<half, float, 8192>(h_state_ub[0], h_state_ub_float[0]);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(5);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(5);
+        tl::ascend::copy_ub_to_gm<half, 128, 64>(h[(((i_1 * 131072) + (cid * 16384)) + (vid * 8192))], h_state_ub[0], 128, 64, 128);
+      }
+      AscendC::PipeBarrier<PIPE_ALL>();
+      AscendC::PipeBarrier<PIPE_ALL>();
+    }
+    tl::ascend::copy_ub_to_gm<half, 128, 64>(ht[((cid * 16384) + (vid * 8192))], h_state_ub[0], 128, 64, 128);
+  }
+}
+
+void main_kernel_tiling() {
+}
+
+extern "C" void call(uint8_t* h_handle, uint8_t* k_handle, uint8_t* v_handle, uint8_t* w_handle, uint8_t* g_handle, uint8_t* v_new_handle, uint8_t* h0_handle, uint8_t* ht_handle, uint8_t* cu_seqlens_handle, uint8_t* ws_wh_handle, uint8_t* ws_vnew_handle, uint8_t* ws_hupd_handle, uint8_t* ws_h_handle, aclrtStream stream) {
+  uint32_t fftsLen{0};
+  uint64_t fftsAddr{0};
+  rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+  main_kernel_tiling();
+  main_kernel<<<8, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
+}

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.py
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.py
@@ -89,7 +89,7 @@ def prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Te
 # ==========================================
 # 2. TileLang Unified Kernel (Fully 1D Packed)
 # ==========================================
-@tilelang.jit(workspace_idx=[9, 10, 11, 12], pass_configs=pass_configs)
+@tilelang.jit(workspace_idx=[9, 10, 11, 12], pass_configs=pass_configs, target="pto")
 def chunk_gated_delta_rule_fwd_kernel_unified(
     N,
     H,

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.py
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.py
@@ -1,0 +1,578 @@
+"""Copied from https://github.com/tile-ai/tilelang-ascend/blob/ascendc_pto/examples/chunk_gated_delta_rule/chunk_gated_delta_rule_varlen.py
+
+
+Commit aee2273
+fengz72hejun
+fengz72
+and
+hejun
+authored
+3 days ago
+··
+feat: enhance broadcast API with axis param and shape validation (#912)
+* feat: enhance broadcast API with axis param and shape validation
+
+- Add optional axis parameter for explicit broadcast direction
+- Support 1D→2D cross-dimension broadcasting
+- Add comprehensive shape validation for all broadcast cases
+- Replace assert with ValueError for production error handling
+
+* fix: update broadcast call for new API with axis parameter
+
+---------
+
+Co-authored-by: hejun <hejun72@outlook.com>
+
+
+"""
+import os
+import sys
+
+_KERNEL_DIR = os.path.dirname(os.path.abspath(__file__))
+_ROOT_DIR = os.path.dirname(_KERNEL_DIR)
+if _ROOT_DIR not in sys.path:
+    sys.path.insert(0, _ROOT_DIR)
+
+import tilelang
+from tilelang import language as T
+import torch
+from tilelang.jit.adapter.libgen import LibraryGenerator
+import argparse
+
+from patch_libgen import get_patched_compile_lib
+
+_SCRIPT_DIR = _KERNEL_DIR
+patched_compile_lib = get_patched_compile_lib(
+    src_dump_path="chunk_gated_delta_rule_varlen.cpp",
+    output_dir=_SCRIPT_DIR,
+)
+LibraryGenerator.compile_lib = patched_compile_lib
+tilelang.disable_cache()
+
+
+pass_configs = {
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_COMBINE: True,
+    tilelang.PassConfigKey.TL_ASCEND_AUTO_CV_SYNC: True,
+    tilelang.PassConfigKey.TL_ASCEND_MEMORY_PLANNING: True,
+}
+
+
+# ==========================================
+# 1. Helper Functions
+# ==========================================
+def prepare_chunk_offsets(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    """Compute starting offset of each sequence's chunks in output h tensor"""
+    chunk_offsets = []
+    offset = 0
+    cu_seqlens_np = cu_seqlens.cpu().numpy()
+    for i in range(len(cu_seqlens_np) - 1):
+        T_len = int(cu_seqlens_np[i + 1] - cu_seqlens_np[i])
+        NT = (T_len + chunk_size - 1) // chunk_size
+        chunk_offsets.append(offset)
+        offset += NT
+    return torch.tensor(chunk_offsets, dtype=torch.int32, device=cu_seqlens.device)
+
+
+def prepare_chunk_indices(cu_seqlens: torch.Tensor, chunk_size: int) -> torch.Tensor:
+    """Compute chunk index for each token (API reserved)"""
+    indices = []
+    cu_seqlens_np = cu_seqlens.cpu().numpy()
+    for i in range(len(cu_seqlens_np) - 1):
+        T_len = int(cu_seqlens_np[i + 1] - cu_seqlens_np[i])
+        NT = (T_len + chunk_size - 1) // chunk_size
+        for chunk_idx in range(NT):
+            indices.append(chunk_idx)
+    return torch.tensor(indices, dtype=torch.int32, device=cu_seqlens.device)
+
+
+# ==========================================
+# 2. TileLang Unified Kernel (Fully 1D Packed)
+# ==========================================
+@tilelang.jit(workspace_idx=[9, 10, 11, 12], pass_configs=pass_configs)
+def chunk_gated_delta_rule_fwd_kernel_unified(
+    N,
+    H,
+    T_total_pad,
+    Hg,
+    K,
+    V,
+    NT_max,
+    BT=64,
+    USE_G=True,
+    STORE_FINAL_STATE=True,
+    SAVE_NEW_VALUE=True,
+    dtype="float16",
+    accum_dtype="float32",
+):
+    @T.prim_func
+    def main(
+        h: T.Tensor([N, NT_max, H, K, V], dtype),
+        k: T.Tensor([T_total_pad, Hg, K], dtype),
+        v: T.Tensor([T_total_pad, H, V], dtype),
+        w: T.Tensor([T_total_pad, H, K], dtype),
+        g: T.Tensor([T_total_pad, H], accum_dtype),
+        v_new: T.Tensor([T_total_pad, H, V], dtype),
+        h0: T.Tensor([N, H, K, V], dtype),
+        ht: T.Tensor([N, H, K, V], dtype),
+        cu_seqlens: T.Tensor([N + 1], "int32"),
+        ws_wh: T.Tensor([N, H, BT, V], accum_dtype),
+        ws_vnew: T.Tensor([N, H, BT, V], dtype),
+        ws_hupd: T.Tensor([N, H, K, V], dtype),
+        ws_h: T.Tensor([N, H, K, V], dtype),
+    ):
+        with T.Kernel(N * H, is_npu=True) as (cid, vid):
+            i_n = cid // H
+            i_h = cid % H
+
+            hg_ratio = H // Hg
+            k_head = i_h // hg_ratio
+
+            bos = cu_seqlens[i_n]
+            eos = cu_seqlens[i_n + 1]
+            T_len = eos - bos
+            NT_i = T.ceildiv(T_len, BT)
+
+            h_state_ub = T.alloc_ub([K // 2, V], dtype)
+            h_state_ub_float = T.alloc_ub([K // 2, V], accum_dtype)
+            hupd_ub = T.alloc_ub([K // 2, V], dtype)
+            hupd_ub_float = T.alloc_ub([K // 2, V], accum_dtype)
+
+            k_chunk_l1 = T.alloc_L1([BT, K], dtype)
+            w_chunk_l1 = T.alloc_L1([BT, K], dtype)
+            h_state_l1 = T.alloc_L1([K, V], dtype)
+            wh_frag = T.alloc_L0C([BT, V], accum_dtype)
+            wh_ub_float = T.alloc_ub([BT // 2, V], accum_dtype)
+
+            v_chunk_ub = T.alloc_ub([BT // 2, V], dtype)
+            v_chunk_ub_float = T.alloc_ub([BT // 2, V], accum_dtype)
+            v_new_ub = T.alloc_ub([BT // 2, V], dtype)
+            v_new_ub_float = T.alloc_ub([BT // 2, V], accum_dtype)
+
+            v_new_l1 = T.alloc_L1([BT, V], dtype)
+            hupd_frag = T.alloc_L0C([K, V], accum_dtype)
+
+            T.copy(h0[i_n, i_h, K // 2 * vid : K // 2 * vid + K // 2, :], h_state_ub)
+
+            for i in T.serial(NT_max):
+                if i < NT_i:
+                    g_start = bos + i * BT
+
+                    T.copy(h_state_ub, ws_h[i_n, i_h, K // 2 * vid, :])
+                    T.copy(ws_h[i_n, i_h, :, :], h_state_l1)
+
+                    # 1. w @ h
+                    T.copy(w[g_start : g_start + BT, i_h, :], w_chunk_l1)
+                    T.gemm_v0(w_chunk_l1, h_state_l1, wh_frag, init=True)
+
+                    T.copy(wh_frag, ws_wh[i_n, i_h, :, :])
+                    T.copy(ws_wh[i_n, i_h, BT // 2 * vid : BT // 2 * vid + BT // 2, :], wh_ub_float)
+
+                    # 2. v_new = v - w @ h (float32 precision)
+                    T.copy(v[g_start + BT // 2 * vid : g_start + BT // 2 * vid + BT // 2, i_h, :], v_chunk_ub)
+                    T.copy(v_chunk_ub, v_chunk_ub_float)
+                    T.tile.sub(v_new_ub_float, v_chunk_ub_float, wh_ub_float)
+
+                    # 3. Handle Gating
+                    if USE_G:
+                        g_chunk_ub_all = T.alloc_ub([BT], accum_dtype)
+                        g_chunk_ub = T.alloc_ub([BT // 2], accum_dtype)
+                        g_last_scalar = T.alloc_ub([1], accum_dtype)
+                        g_exp_ub = T.alloc_ub([BT // 2], accum_dtype)
+                        g_exp_ub_pad = T.alloc_ub([BT], accum_dtype)
+                        g_exp_ub_broc = T.alloc_ub([BT // 2, V], accum_dtype)
+                        g_mask_ub_pad = T.alloc_ub([BT // 8], "uint8")
+
+                        T.copy(g[g_start : g_start + BT, i_h], g_chunk_ub_all)
+                        T.copy(g_chunk_ub_all[BT // 2 * vid : BT // 2 * vid + BT // 2], g_chunk_ub)
+
+                        # g_last
+                        if i * BT + BT <= T_len:
+                            g_last_scalar[0] = g_chunk_ub_all[BT - 1]
+                        else:
+                            g_last_scalar[0] = g_chunk_ub_all[T_len - i * BT - 1]
+
+                        # exp(g_last - g)
+                        T.tile.fill(g_exp_ub, g_last_scalar[0])
+                        T.tile.sub(g_exp_ub, g_exp_ub, g_chunk_ub)
+                        T.copy(g_exp_ub, g_exp_ub_pad[0 : BT // 2])
+                        T.tile.compare(g_mask_ub_pad, g_exp_ub_pad, T.float32(0), "LE")
+                        T.tile.select(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, -T.infinity(accum_dtype), "VSEL_TENSOR_SCALAR_MODE")
+                        T.copy(g_exp_ub_pad[0 : BT // 2], g_exp_ub)
+                        T.tile.exp(g_exp_ub, g_exp_ub)
+
+                        # v_new = v_new * exp(g_last - g)
+                        T.tile.broadcast(g_exp_ub_broc, g_exp_ub, axis=1)
+                        T.tile.mul(v_new_ub_float, v_new_ub_float, g_exp_ub_broc)
+
+                        # 4. h = h * exp(g_last)
+                        T.tile.exp(g_last_scalar, g_last_scalar)
+                        T.copy(h_state_ub, h_state_ub_float)
+                        T.tile.mul(h_state_ub_float, h_state_ub_float, g_last_scalar[0])
+
+                    # save v_new
+                    T.copy(v_new_ub_float, v_new_ub)
+                    if SAVE_NEW_VALUE:
+                        T.copy(v_new_ub, v_new[g_start + BT // 2 * vid : g_start + BT // 2 * vid + BT // 2, i_h, :])
+                    T.copy(v_new_ub, ws_vnew[i_n, i_h, BT // 2 * vid, :])
+                    T.copy(ws_vnew[i_n, i_h, :, :], v_new_l1)
+
+                    # 5. k @ v_new -> h_update
+                    T.copy(k[g_start : g_start + BT, k_head, :], k_chunk_l1)
+                    T.gemm_v0(k_chunk_l1, v_new_l1, hupd_frag, transpose_A=True, init=True)
+
+                    T.copy(hupd_frag, ws_hupd[i_n, i_h, :, :])
+                    T.copy(ws_hupd[i_n, i_h, K // 2 * vid : K // 2 * vid + K // 2, :], hupd_ub)
+                    T.copy(hupd_ub, hupd_ub_float)
+
+                    if not USE_G:
+                        T.copy(h_state_ub, h_state_ub_float)
+                    T.tile.add(h_state_ub_float, h_state_ub_float, hupd_ub_float)
+                    T.copy(h_state_ub_float, h_state_ub)
+
+                    # save h[t+1]
+                    T.copy(h_state_ub, h[i_n, i, i_h, K // 2 * vid : K // 2 * vid + K // 2, :])
+
+            # Epilogue: save ht
+            if STORE_FINAL_STATE:
+                T.copy(h_state_ub, ht[i_n, i_h, K // 2 * vid : K // 2 * vid + K // 2, :])
+
+    return main
+
+
+# ==========================================
+# 3. Python Wrapper Layer
+# ==========================================
+def chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    save_new_value: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    BT = chunk_size
+    is_varlen = cu_seqlens is not None
+    USE_G = g is not None
+
+    # Step 1: Flatten to [T_total, ...] format
+    if is_varlen:
+        # Varlen: Remove redundant dummy batch dimension 1
+        k_flat = k.squeeze(0)  # [T_total, Hg, K]
+        w_flat = w.squeeze(0)  # [T_total, H, K]
+        u_flat = u.squeeze(0)  # [T_total, H, V]
+        g_flat = g.squeeze(0) if g is not None else None  # [T_total, H]
+
+        T_total, Hg, K = k_flat.shape
+        _, H, V = u_flat.shape
+        N = len(cu_seqlens) - 1
+
+        if chunk_offsets is None:
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
+
+        cu_seqlens_np = cu_seqlens.cpu().numpy()
+        NT_max = 0
+        NT_total = 0
+        for i in range(N):
+            T_len = int(cu_seqlens_np[i + 1] - cu_seqlens_np[i])
+            NT = (T_len + BT - 1) // BT
+            NT_max = max(NT_max, NT)
+            NT_total += NT
+    else:
+        # Fixed-length: Flatten directly and create fake cu_seqlens
+        B, T_seq, Hg, K = k.shape
+        _, _, H, V = u.shape
+        T_total = B * T_seq
+        N = B
+
+        k_flat = k.reshape(T_total, Hg, K)
+        w_flat = w.reshape(T_total, H, K)
+        u_flat = u.reshape(T_total, H, V)
+        g_flat = g.reshape(T_total, H) if g is not None else None
+
+        cu_seqlens = torch.arange(0, T_total + 1, T_seq, dtype=torch.int32, device=k.device)
+        NT_per_seq = (T_seq + BT - 1) // BT
+        NT_total = B * NT_per_seq
+        NT_max = NT_per_seq
+        chunk_offsets = torch.arange(0, NT_total, NT_per_seq, dtype=torch.int32, device=k.device)
+
+    # Step 2: Handle Gating and add Padding protection
+    # Add padding to prevent kernel overflow when reading T_total (when T_total is not divisible by BT)
+    g_c = g_flat.float().contiguous() if g_flat is not None else torch.zeros((T_total, H), dtype=torch.float32, device=k.device)
+    v_new_flat = torch.empty((T_total, H, V), dtype=torch.float16, device=k.device)
+
+    pad_len = BT
+
+    def pad_tensor(t):
+        return torch.cat([t, torch.zeros((pad_len,) + t.shape[1:], dtype=t.dtype, device=t.device)], dim=0)
+
+    k_pad = pad_tensor(k_flat)
+    w_pad = pad_tensor(w_flat)
+    u_pad = pad_tensor(u_flat)
+    g_pad = pad_tensor(g_c)
+    v_new_pad = pad_tensor(v_new_flat)
+
+    # Allocate state outputs
+    h_out = torch.zeros((N, NT_max, H, K, V), dtype=torch.float16, device=k.device)
+    h0 = torch.zeros((N, H, K, V), dtype=torch.float16, device=k.device)
+    if initial_state is not None:
+        h0.copy_(initial_state.squeeze(0) if is_varlen else initial_state)
+
+    ht = torch.zeros((N, H, K, V), dtype=torch.float16, device=k.device)
+
+    # Step 3: Call unified kernel
+    ker = chunk_gated_delta_rule_fwd_kernel_unified(
+        N,
+        H,
+        T_total + pad_len,
+        Hg,
+        K,
+        V,
+        NT_max,
+        BT=64,
+        USE_G=USE_G,
+        STORE_FINAL_STATE=output_final_state,
+        SAVE_NEW_VALUE=save_new_value,
+    )
+    ker(h_out, k_pad, u_pad, w_pad, g_pad, v_new_pad, h0, ht, cu_seqlens.to(torch.int32))
+
+    # Remove extra dimensions added by padding
+    v_new_flat = v_new_pad[:T_total]
+
+    # Step 4: Unpack return shapes based on scenario
+    if is_varlen:
+        v_new_ret = v_new_flat.unsqueeze(0)  # [1, T_total, H, V]
+
+        # Varlen h return format: Flatten and store contiguously
+        h_ret = torch.zeros((1, NT_total, H, K, V), dtype=torch.float16, device=k.device)
+        cu_seqlens_np = cu_seqlens.cpu().numpy()
+        for i in range(N):
+            NT_i = (int(cu_seqlens_np[i + 1]) - int(cu_seqlens_np[i]) + BT - 1) // BT
+            offset = int(chunk_offsets[i].item())
+            h_ret[0, offset : offset + NT_i] = h_out[i, :NT_i]
+
+        ht_ret = ht.unsqueeze(0) if output_final_state else None
+    else:
+        v_new_ret = v_new_flat.reshape(B, T_seq, H, V)
+        h_ret = h_out.reshape(B, NT_per_seq, H, K, V)
+        ht_ret = ht if output_final_state else None
+
+    return h_ret, v_new_ret, ht_ret
+
+
+# ==========================================
+# 4. Golden Reference
+# ==========================================
+def ref_chunk_gated_delta_rule(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    BT = chunk_size
+    is_varlen = cu_seqlens is not None
+
+    k = k.float()
+    w = w.float()
+    u = u.float()
+    g = g.float() if g is not None else None
+    initial_state = initial_state.float() if initial_state is not None else None
+
+    if not is_varlen:
+        B, T_len, Hg, K = k.shape
+        _, _, H, V = u.shape
+        NT = (T_len + BT - 1) // BT
+
+        h = torch.zeros(B, NT, H, K, V, dtype=torch.float32, device=k.device)
+        v_new = torch.zeros(B, T_len, H, V, dtype=torch.float32, device=k.device)
+        final_state = torch.zeros(B, H, K, V, dtype=torch.float32, device=k.device) if output_final_state else None
+
+        for bz in range(B):
+            for by in range(H):
+                h_state = (
+                    initial_state[bz, by].clone() if initial_state is not None else torch.zeros(K, V, dtype=torch.float32, device=k.device)
+                )
+                k_head = by // (H // Hg)
+
+                for i in range(NT):
+                    t_start = i * BT
+                    t_end = min((i + 1) * BT, T_len)
+
+                    h[bz, i, by] = h_state
+                    k_chunk, w_chunk, v_chunk = k[bz, t_start:t_end, k_head, :], w[bz, t_start:t_end, by, :], u[bz, t_start:t_end, by, :]
+
+                    v_n = v_chunk - torch.matmul(w_chunk, h_state)
+                    v_new[bz, t_start:t_end, by, :] = v_n
+
+                    if g is not None:
+                        g_chunk = g[bz, t_start:t_end, by]
+                        g_last = g_chunk[-1].item()
+                        v_n = v_n * torch.exp(g_last - g_chunk)[:, None]
+                        h_state = h_state * torch.exp(torch.tensor(g_last, device=k.device))
+
+                    h_state = h_state + torch.matmul(k_chunk.transpose(-1, -2), v_n)
+
+                if output_final_state:
+                    final_state[bz, by] = h_state
+
+        return h.half(), v_new.half(), final_state.half() if final_state is not None else None
+    else:
+        # Varlen Reference
+        _, T_total, Hg, K = k.shape
+        _, _, H, V = u.shape
+        N = len(cu_seqlens) - 1
+
+        NT_total = sum([(int(cu_seqlens[i + 1]) - int(cu_seqlens[i]) + BT - 1) // BT for i in range(N)])
+
+        h = torch.zeros(1, NT_total, H, K, V, dtype=torch.float32, device=k.device)
+        v_new = torch.zeros(1, T_total, H, V, dtype=torch.float32, device=k.device)
+        final_state = torch.zeros(1, N, H, K, V, dtype=torch.float32, device=k.device) if output_final_state else None
+
+        chunk_offset = 0
+        for i_n in range(N):
+            bos, eos = int(cu_seqlens[i_n]), int(cu_seqlens[i_n + 1])
+            T_len = eos - bos
+            NT = (T_len + BT - 1) // BT
+
+            for i_h in range(H):
+                h_state = (
+                    initial_state[0, i_n, i_h].clone()
+                    if initial_state is not None
+                    else torch.zeros(K, V, dtype=torch.float32, device=k.device)
+                )
+                k_head = i_h // (H // Hg)
+
+                for i_t in range(NT):
+                    t_start = i_t * BT
+                    t_end = min((i_t + 1) * BT, T_len)
+
+                    h[0, chunk_offset + i_t, i_h] = h_state
+                    k_chunk, w_chunk, v_chunk = (
+                        k[0, bos + t_start : bos + t_end, k_head, :],
+                        w[0, bos + t_start : bos + t_end, i_h, :],
+                        u[0, bos + t_start : bos + t_end, i_h, :],
+                    )
+
+                    v_n = v_chunk - torch.matmul(w_chunk, h_state)
+                    v_new[0, bos + t_start : bos + t_end, i_h, :] = v_n
+
+                    if g is not None:
+                        g_chunk = g[0, bos + t_start : bos + t_end, i_h]
+                        g_last = g_chunk[-1].item()
+                        v_n = v_n * torch.exp(g_last - g_chunk)[:, None]
+                        h_state = h_state * torch.exp(torch.tensor(g_last, device=k.device))
+
+                    h_state = h_state + torch.matmul(k_chunk.transpose(-1, -2), v_n)
+
+                if output_final_state:
+                    final_state[0, i_n, i_h] = h_state
+            chunk_offset += NT
+
+        return h.half(), v_new.half(), final_state.half() if final_state is not None else None
+
+
+# ==========================================
+# 5. Test Functions
+# ==========================================
+def test_chunk_gated_delta_rule_fixed(B, T_len, H, Hg, K, V, use_g=True, use_initial_state=True):
+    print(f"Testing Fixed-length B={B}, T={T_len}, H={H}, Hg={Hg}, K={K}, V={V}, use_g={use_g}, use_initial_state={use_initial_state}")
+    torch.manual_seed(41)
+
+    k = torch.randn(B, T_len, Hg, K, dtype=torch.float16).npu() * 0.01
+    w = torch.randn(B, T_len, H, K, dtype=torch.float16).npu() * 0.01
+    u = torch.randn(B, T_len, H, V, dtype=torch.float16).npu() * 0.01
+    g = torch.randn(B, T_len, H, dtype=torch.float32).npu() * 0.01 if use_g else None
+    initial_state = torch.randn(B, H, K, V, dtype=torch.float16).npu() * 0.01 if use_initial_state else None
+
+    torch.npu.synchronize()
+
+    h, v_new, ht = chunk_gated_delta_rule_fwd_h(k, w, u, g, initial_state=initial_state, output_final_state=True)
+    ref_h, ref_v_new, ref_ht = ref_chunk_gated_delta_rule(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu() if g is not None else None,
+        initial_state=initial_state.cpu() if initial_state is not None else None,
+        output_final_state=True,
+    )
+
+    torch.testing.assert_close(h.cpu(), ref_h.cpu(), rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(v_new.cpu(), ref_v_new.cpu(), rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(ht.cpu(), ref_ht.cpu(), rtol=5e-2, atol=5e-2)
+    print("  Fixed-length Mode PASSED!\n")
+
+
+def test_chunk_gated_delta_rule_varlen(seqlens, H, Hg, K, V, use_g=True, use_initial_state=True):
+    print(f"Testing Varlen seqlens={seqlens}, H={H}, Hg={Hg}, K={K}, V={V}, use_g={use_g}, use_initial_state={use_initial_state}")
+    torch.manual_seed(41)
+
+    T_total = sum(seqlens)
+    N = len(seqlens)
+    cu_seqlens = torch.tensor([0] + [sum(seqlens[: i + 1]) for i in range(len(seqlens))], dtype=torch.int32).npu()
+
+    k = torch.randn(1, T_total, Hg, K, dtype=torch.float16).npu() * 0.01
+    w = torch.randn(1, T_total, H, K, dtype=torch.float16).npu() * 0.01
+    u = torch.randn(1, T_total, H, V, dtype=torch.float16).npu() * 0.01
+    g = torch.randn(1, T_total, H, dtype=torch.float32).npu() * 0.01 if use_g else None
+    initial_state = torch.randn(1, N, H, K, V, dtype=torch.float16).npu() * 0.01 if use_initial_state else None
+
+    torch.npu.synchronize()
+
+    h, v_new, ht = chunk_gated_delta_rule_fwd_h(k, w, u, g, initial_state=initial_state, output_final_state=True, cu_seqlens=cu_seqlens)
+    ref_h, ref_v_new, ref_ht = ref_chunk_gated_delta_rule(
+        k.cpu(),
+        w.cpu(),
+        u.cpu(),
+        g.cpu() if g is not None else None,
+        initial_state=initial_state.cpu() if initial_state is not None else None,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens.cpu(),
+    )
+
+    torch.testing.assert_close(h.cpu(), ref_h.cpu(), rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(v_new.cpu(), ref_v_new.cpu(), rtol=5e-2, atol=5e-2)
+    torch.testing.assert_close(ht.cpu(), ref_ht.cpu(), rtol=5e-2, atol=5e-2)
+    print("  Varlen Mode PASSED!\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test chunk gated delta rule")
+    parser.add_argument("--use_g", type=lambda x: x.lower() == "true", default=True, help="Whether to use gating (True/False)")
+    parser.add_argument(
+        "--use_initial_state", type=lambda x: x.lower() == "true", default=True, help="Whether to use initial state (True/False)"
+    )
+    parser.add_argument("--varlen", type=lambda x: x.lower() == "true", default=False, help="Whether to test varlen mode (True/False)")
+    parser.add_argument("--B", type=int, default=1, help="Batch size for fixed-length mode")
+    parser.add_argument("--T", type=int, default=2048, help="Sequence length for fixed-length mode")
+    parser.add_argument(
+        "--seqlens",
+        type=str,
+        default="512,512,512,512",
+        help="Sequence lengths for varlen mode (comma-separated, total ~2048 for performance comparison)",
+    )
+    parser.add_argument("--H", type=int, default=8, help="Number of heads")
+    parser.add_argument("--Hg", type=int, default=4, help="Number of grouped heads (must be <= H)")
+    parser.add_argument("--K", type=int, default=128, help="Key dimension")
+    parser.add_argument("--V", type=int, default=128, help="Value dimension")
+    args = parser.parse_args()
+
+    print("=" * 60)
+    if args.varlen:
+        seqlens = [int(x) for x in args.seqlens.split(",")]
+        test_chunk_gated_delta_rule_varlen(
+            seqlens=seqlens, H=args.H, Hg=args.Hg, K=args.K, V=args.V, use_g=args.use_g, use_initial_state=args.use_initial_state
+        )
+    else:
+        test_chunk_gated_delta_rule_fixed(
+            B=args.B, T_len=args.T, H=args.H, Hg=args.Hg, K=args.K, V=args.V, use_g=args.use_g, use_initial_state=args.use_initial_state
+        )
+    print("Batch Kernel Output Match!")

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen_H32.cpp
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen_H32.cpp
@@ -1,0 +1,209 @@
+#include "tl_templates/pto/common.h"
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+using namespace pto;
+
+AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ half *v_handle, __gm__ half *w_handle, __gm__ float *g_handle, __gm__ half *v_new_handle, __gm__ half *h0_handle, __gm__ half *ht_handle, __gm__ int *cu_seqlens_handle, __gm__ float *ws_wh_handle, __gm__ half *ws_vnew_handle, __gm__ half *ws_hupd_handle, __gm__ half *ws_h_handle, uint64_t ffts_Addr) {
+  auto cid = get_block_idx();
+  set_ffts_base_addr(ffts_Addr);
+
+  tl::ascend_pto::TileMatL1<half, 128, 128, 128, 128> h_state_l1;
+  TASSIGN(h_state_l1, 0);
+  tl::ascend_pto::TileMatL1<half, 64, 128, 64, 128> w_chunk_l1;
+  TASSIGN(w_chunk_l1, 32768);
+  TileAcc<float, 64, 128, 64, 128> wh_frag;
+  TASSIGN(wh_frag, 0);
+  tl::ascend_pto::TileMatL1<half, 64, 128, 64, 128> v_new_l1;
+  TASSIGN(v_new_l1, 49152);
+  tl::ascend_pto::TileMatL1<half, 64, 128, 64, 128> k_chunk_l1;
+  TASSIGN(k_chunk_l1, 65536);
+  TileAcc<float, 128, 128, 128, 128> hupd_frag;
+  TASSIGN(hupd_frag, 32768);
+  tl::ascend_pto::TileUbDataND<half, 64, 128, 64, 128> h_state_ub;
+  TASSIGN(h_state_ub, 0);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> wh_ub_float;
+  TASSIGN(wh_ub_float, 16384);
+  tl::ascend_pto::TileUbDataND<half, 32, 128, 32, 128> v_chunk_ub;
+  TASSIGN(v_chunk_ub, 32768);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> v_chunk_ub_float;
+  TASSIGN(v_chunk_ub_float, 40960);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> v_new_ub_float;
+  TASSIGN(v_new_ub_float, 57344);
+  tl::ascend_pto::TileUbDataND<float, 1, 64, 1, 64> g_chunk_ub_all;
+  TASSIGN(g_chunk_ub_all, 73728);
+  tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub;
+  TASSIGN(g_chunk_ub, 73984);
+  tl::ascend_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar;
+  TASSIGN(g_last_scalar, 74112);
+  tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub;
+  TASSIGN(g_exp_ub, 74144);
+  tl::ascend_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad;
+  TASSIGN(g_exp_ub_pad, 74272);
+  tl::ascend_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad;
+  TASSIGN(g_mask_ub_pad, 74528);
+  tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> g_exp_ub_broc;
+  TASSIGN(g_exp_ub_broc, 82752);
+  tl::ascend_pto::TileUbDataND<uint8_t, 1, 8192, 1, 8192> tmp_ub;
+  TASSIGN(tmp_ub, 74560);
+  tl::ascend_pto::TileUbDataND<float, 64, 128, 64, 128> h_state_ub_float;
+  TASSIGN(h_state_ub_float, 99136);
+  tl::ascend_pto::TileUbDataND<half, 32, 128, 32, 128> v_new_ub;
+  TASSIGN(v_new_ub, 131904);
+  tl::ascend_pto::TileUbDataND<half, 64, 128, 64, 128> hupd_ub;
+  TASSIGN(hupd_ub, 140096);
+  tl::ascend_pto::TileUbDataND<float, 64, 128, 64, 128> hupd_ub_float;
+  TASSIGN(hupd_ub_float, 156480);
+  auto vid = get_subblockid();
+#if defined(__DAV_C220_CUBE__)
+    pipe_barrier(PIPE_ALL);
+    int32_t bos = *(cu_seqlens_handle + (cid / 32));
+    pipe_barrier(PIPE_ALL);
+    int32_t eos = *(cu_seqlens_handle + ((cid / 32) + 1));
+
+  for (int32_t i = 0; i < 16; ++i) {
+      pipe_barrier(PIPE_ALL);
+      if (i < (((eos + 63) - bos) / 64)) {
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 128, 128, 1048576, 524288, 16384, 128, 1, 128, 128>(ws_h_handle + (cid * 16384), 0, 0, 128, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 8650752, 4096, 1, 64, 128>(w_handle + (((i * 262144) + (bos * 4096)) + ((cid % 32) * 128)), 32768, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
+        tl::ascend_pto::gemm_v0<half, float, 64, 128, 128, 64, 128, 128, 128, false, false>(w_chunk_l1, h_state_l1, wh_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+        tl::ascend_pto::copy_l0c_to_gm<float, float, 1, 1, 1, 64, 128, 524288, 262144, 8192, 128, 1, 64, 128>(ws_wh_handle + (cid * 8192), 0, 0, 64, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 524288, 262144, 8192, 128, 1, 64, 128>(ws_vnew_handle + (cid * 8192), 49152, 0, 64, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 4325376, 2048, 1, 64, 128>(k_handle + (((i * 131072) + (bos * 2048)) + (((cid % 32) / 2) * 128)), 65536, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
+        tl::ascend_pto::gemm_v0<half, float, 128, 128, 64, 128, 128, 64, 64, true, false>(k_chunk_l1, v_new_l1, hupd_frag, (bool)1);
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+        tl::ascend_pto::copy_l0c_to_gm<half, float, 1, 1, 1, 128, 128, 1048576, 524288, 16384, 128, 1, 128, 128>(ws_hupd_handle + (cid * 16384), 32768, 0, 128, 128);
+      }
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
+    }
+#endif
+#if defined(__DAV_C220_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    pipe_barrier(PIPE_ALL);
+    int32_t bos_1 = *(cu_seqlens_handle + (cid / 32));
+    pipe_barrier(PIPE_ALL);
+    int32_t eos_1 = *(cu_seqlens_handle + ((cid / 32) + 1));
+    tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 1048576, 524288, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(h0_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+
+  for (int32_t i_1 = 0; i_1 < 16; ++i_1) {
+      pipe_barrier(PIPE_ALL);
+      if (i_1 < (((eos_1 + 63) - bos_1) / 64)) {
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1, 1, 1, 1048576, 1, 64, 128>(ws_h_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 1, 128);
+        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 32, 128, 524288, 262144, 8192, 128, 1, 32, 128, pto::PadValue::Zero>(ws_wh_handle + ((cid * 8192) + (vid * 4096)), 16384, 0, 32, 128);
+        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 32, 128, 1, 1, 8650752, 4096, 1, 32, 128, pto::PadValue::Zero>(v_handle + ((((i_1 * 262144) + (vid * 131072)) + (bos_1 * 4096)) + ((cid % 32) * 128)), 32768, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TCVT(v_chunk_ub_float, v_chunk_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TSUB(v_new_ub_float, v_chunk_ub_float, wh_ub_float);
+        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 1, 64, 1, 1, 67584, 32, 1, 1, 64, pto::PadValue::Zero>(g_handle + (((i_1 * 2048) + (bos_1 * 32)) + (cid % 32)), 73728, 0, ((-2048 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-2112 < ((0 - bos_1) - (i_1 * 64))) ? ((2112 - bos_1) - (i_1 * 64)) : 0)), 1);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
+        tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub_all_temp_0;
+        TASSIGN(g_chunk_ub_all_temp_0, 73728 + (vid * 32) * 4);
+        TMOV(g_chunk_ub, g_chunk_ub_all_temp_0);
+        pipe_barrier(PIPE_ALL);
+        if (((i_1 * 64) + 64) <= (eos_1 - bos_1)) {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue(63));
+        } else {
+          g_last_scalar.SetValue(0, g_chunk_ub_all.GetValue((((((int64_t)eos_1) - ((int64_t)bos_1)) - (((int64_t)i_1) * (int64_t)64)) - (int64_t)1)));
+        }
+        pipe_barrier(PIPE_ALL);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        TEXPANDS(g_exp_ub, g_last_scalar.GetValue(0));
+        pipe_barrier(PIPE_V);
+        TSUB(g_exp_ub, g_exp_ub, g_chunk_ub);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_0;
+        TASSIGN(g_exp_ub_pad_temp_0, 74272 + 0 * 4);
+        TMOV(g_exp_ub_pad_temp_0, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataND<float, 1, 64, 1, 64> g_exp_ub_pad_temp_1;
+        TASSIGN(g_exp_ub_pad_temp_1, 74272 + 0 * 4);
+        tl::ascend_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad_temp_0;
+        TASSIGN(g_mask_ub_pad_temp_0, 74528 + 0 * 1);
+        tl::ascend_pto::compare_scalar(g_mask_ub_pad_temp_0, g_exp_ub_pad_temp_1, 0.000000e+00f, CmpMode::LE);
+        pipe_barrier(PIPE_V);
+        TSELS(g_exp_ub_pad, g_mask_ub_pad, g_exp_ub_pad, -CUDART_INF_F);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_exp_ub_pad_temp_2;
+        TASSIGN(g_exp_ub_pad_temp_2, 74272 + 0 * 4);
+        TMOV(g_exp_ub, g_exp_ub_pad_temp_2);
+        pipe_barrier(PIPE_V);
+        TEXP(g_exp_ub, g_exp_ub);
+        pipe_barrier(PIPE_V);
+        tl::ascend_pto::TileUbDataDN<float, 32, 1, 32, 1> g_exp_ub_temp_0;
+        TASSIGN(g_exp_ub_temp_0, 74144 + 0 * 4);
+        TROWEXPAND(g_exp_ub_broc, g_exp_ub_temp_0);
+        pipe_barrier(PIPE_V);
+        TMUL(v_new_ub_float, v_new_ub_float, g_exp_ub_broc);
+        tl::ascend_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_0;
+        TASSIGN(g_last_scalar_temp_0, 74112 + 0 * 4);
+        tl::ascend_pto::TileUbDataND<float, 1, 8, 1, 1> g_last_scalar_temp_1;
+        TASSIGN(g_last_scalar_temp_1, 74112 + 0 * 4);
+        TEXP(g_last_scalar_temp_1, g_last_scalar_temp_0);
+        TCVT(h_state_ub_float, h_state_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+        auto g_last_scalar_scalar_temp_0 = g_last_scalar.GetValue(0);
+        TMULS(h_state_ub_float, h_state_ub_float, g_last_scalar_scalar_temp_0);
+        TCVT(v_new_ub, v_new_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 8650752, 4096, 1, 32, 128>(v_new_handle + ((((i_1 * 262144) + (vid * 131072)) + (bos_1 * 4096)) + ((cid % 32) * 128)), 131904, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 1, 524288, 1, 32, 128>(ws_vnew_handle + ((cid * 8192) + (vid * 4096)), 131904, 0, 1, 128);
+        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 1048576, 524288, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(ws_hupd_handle + ((cid * 16384) + (vid * 8192)), 140096, 0, 64, 128);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
+        TCVT(hupd_ub_float, hupd_ub, pto::RoundMode::CAST_NONE);
+        pipe_barrier(PIPE_V);
+        TADD(h_state_ub_float, h_state_ub_float, hupd_ub_float);
+        pipe_barrier(PIPE_V);
+        TCVT(h_state_ub, h_state_ub_float, pto::RoundMode::CAST_NONE);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 8388608, 524288, 16384, 128, 1, 64, 128>(h_handle + (((((cid / 32) * 8388608) + (i_1 * 524288)) + ((cid % 32) * 16384)) + (vid * 8192)), 0, 0, 64, 128);
+      }
+      pipe_barrier(PIPE_ALL);
+      pipe_barrier(PIPE_ALL);
+    }
+    tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1048576, 524288, 16384, 128, 1, 64, 128>(ht_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+#endif
+}
+
+extern "C" __global__ AICORE void launch_kernel(__gm__ uint8_t *h_handle, __gm__ uint8_t *k_handle, __gm__ uint8_t *v_handle, __gm__ uint8_t *w_handle, __gm__ uint8_t *g_handle, __gm__ uint8_t *v_new_handle, __gm__ uint8_t *h0_handle, __gm__ uint8_t *ht_handle, __gm__ uint8_t *cu_seqlens_handle, __gm__ uint8_t *ws_wh_handle, __gm__ uint8_t *ws_vnew_handle, __gm__ uint8_t *ws_hupd_handle, __gm__ uint8_t *ws_h_handle, uint64_t fftsAddr)
+{
+    main_kernel(reinterpret_cast<__gm__ half *>(h_handle),
+     reinterpret_cast<__gm__ half *>(k_handle),
+     reinterpret_cast<__gm__ half *>(v_handle),
+     reinterpret_cast<__gm__ half *>(w_handle),
+     reinterpret_cast<__gm__ float *>(g_handle),
+     reinterpret_cast<__gm__ half *>(v_new_handle),
+     reinterpret_cast<__gm__ half *>(h0_handle),
+     reinterpret_cast<__gm__ half *>(ht_handle),
+     reinterpret_cast<__gm__ int *>(cu_seqlens_handle),
+     reinterpret_cast<__gm__ float *>(ws_wh_handle),
+     reinterpret_cast<__gm__ half *>(ws_vnew_handle),
+     reinterpret_cast<__gm__ half *>(ws_hupd_handle),
+     reinterpret_cast<__gm__ half *>(ws_h_handle),
+     reinterpret_cast<uint64_t>(fftsAddr));
+}
+
+extern "C" void call(uint8_t *h_handle, uint8_t *k_handle, uint8_t *v_handle, uint8_t *w_handle, uint8_t *g_handle, uint8_t *v_new_handle, uint8_t *h0_handle, uint8_t *ht_handle, uint8_t *cu_seqlens_handle, uint8_t *ws_wh_handle, uint8_t *ws_vnew_handle, uint8_t *ws_hupd_handle, uint8_t *ws_h_handle, void *stream)
+{
+    uint32_t fftsLen{0};
+    uint64_t fftsAddr{0};
+    rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
+    launch_kernel<<<64, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
+}

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen_H48.cpp
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen_H48.cpp
@@ -43,9 +43,9 @@ AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ hal
   tl::ascend_pto::TileUbDataND<uint8_t, 1, 32, 1, 8> g_mask_ub_pad;
   TASSIGN(g_mask_ub_pad, 74528);
   tl::ascend_pto::TileUbDataND<float, 32, 128, 32, 128> g_exp_ub_broc;
-  TASSIGN(g_exp_ub_broc, 74560);
+  TASSIGN(g_exp_ub_broc, 82752);
   tl::ascend_pto::TileUbDataND<uint8_t, 1, 8192, 1, 8192> tmp_ub;
-  TASSIGN(tmp_ub, 90944);
+  TASSIGN(tmp_ub, 74560);
   tl::ascend_pto::TileUbDataND<float, 64, 128, 64, 128> h_state_ub_float;
   TASSIGN(h_state_ub_float, 99136);
   tl::ascend_pto::TileUbDataND<half, 32, 128, 32, 128> v_new_ub;
@@ -57,29 +57,29 @@ AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ hal
   auto vid = get_subblockid();
 #if defined(__DAV_C220_CUBE__)
     pipe_barrier(PIPE_ALL);
-    int32_t bos = *(cu_seqlens_handle + 0);
+    int32_t bos = *(cu_seqlens_handle + (cid / 48));
     pipe_barrier(PIPE_ALL);
-    int32_t eos = *(cu_seqlens_handle + 1);
+    int32_t eos = *(cu_seqlens_handle + ((cid / 48) + 1));
 
-  for (int32_t i = 0; i < 32; ++i) {
+  for (int32_t i = 0; i < 4; ++i) {
       pipe_barrier(PIPE_ALL);
       if (i < (((eos + 63) - bos) / 64)) {
-        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 128, 128, 131072, 131072, 16384, 128, 1, 128, 128>(ws_h_handle + (cid * 16384), 0, 0, 128, 128);
-        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 2162688, 1024, 1, 64, 128>(w_handle + (((i * 65536) + (bos * 1024)) + (cid * 128)), 32768, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 128, 128, 3932160, 786432, 16384, 128, 1, 128, 128>(ws_h_handle + (cid * 16384), 0, 0, 128, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 3489792, 6144, 1, 64, 128>(w_handle + (((i * 393216) + (bos * 6144)) + ((cid % 48) * 128)), 32768, 0, ((-504 <= ((0 - bos) - (i * 64))) ? 64 : ((-568 < ((0 - bos) - (i * 64))) ? ((568 - bos) - (i * 64)) : 0)), 128);
         set_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID1);
         tl::ascend_pto::gemm_v0<half, float, 64, 128, 128, 64, 128, 128, 128, false, false>(w_chunk_l1, h_state_l1, wh_frag, (bool)1);
         set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
         wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
-        tl::ascend_pto::copy_l0c_to_gm<float, float, 1, 1, 1, 64, 128, 65536, 65536, 8192, 128, 1, 64, 128>(ws_wh_handle + (cid * 8192), 0, 0, 64, 128);
-        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 65536, 65536, 8192, 128, 1, 64, 128>(ws_vnew_handle + (cid * 8192), 49152, 0, 64, 128);
-        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 1081344, 512, 1, 64, 128>(k_handle + (((i * 32768) + (bos * 512)) + ((cid / 2) * 128)), 65536, 0, ((-2048 <= ((0 - bos) - (i * 64))) ? 64 : ((-2112 < ((0 - bos) - (i * 64))) ? ((2112 - bos) - (i * 64)) : 0)), 128);
+        tl::ascend_pto::copy_l0c_to_gm<float, float, 1, 1, 1, 64, 128, 1966080, 393216, 8192, 128, 1, 64, 128>(ws_wh_handle + (cid * 8192), 0, 0, 64, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1966080, 393216, 8192, 128, 1, 64, 128>(ws_vnew_handle + (cid * 8192), 49152, 0, 64, 128);
+        tl::ascend_pto::copy_gm_to_l1<half, half, 1, 1, 1, 64, 128, 1, 1, 1163264, 2048, 1, 64, 128>(k_handle + (((i * 131072) + (bos * 2048)) + (((cid % 48) / 3) * 128)), 65536, 0, ((-504 <= ((0 - bos) - (i * 64))) ? 64 : ((-568 < ((0 - bos) - (i * 64))) ? ((568 - bos) - (i * 64)) : 0)), 128);
         set_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
         wait_flag(PIPE_MTE2, PIPE_M, EVENT_ID3);
         tl::ascend_pto::gemm_v0<half, float, 128, 128, 64, 128, 128, 64, 64, true, false>(k_chunk_l1, v_new_l1, hupd_frag, (bool)1);
         set_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
         wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
-        tl::ascend_pto::copy_l0c_to_gm<half, float, 1, 1, 1, 128, 128, 131072, 131072, 16384, 128, 1, 128, 128>(ws_hupd_handle + (cid * 16384), 32768, 0, 128, 128);
+        tl::ascend_pto::copy_l0c_to_gm<half, float, 1, 1, 1, 128, 128, 3932160, 786432, 16384, 128, 1, 128, 128>(ws_hupd_handle + (cid * 16384), 32768, 0, 128, 128);
       }
       pipe_barrier(PIPE_ALL);
       pipe_barrier(PIPE_ALL);
@@ -89,23 +89,23 @@ AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ hal
     set_mask_norm();
     set_vector_mask(-1, -1);
     pipe_barrier(PIPE_ALL);
-    int32_t bos_1 = *(cu_seqlens_handle + 0);
+    int32_t bos_1 = *(cu_seqlens_handle + (cid / 48));
     pipe_barrier(PIPE_ALL);
-    int32_t eos_1 = *(cu_seqlens_handle + 1);
-    tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 131072, 131072, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(h0_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+    int32_t eos_1 = *(cu_seqlens_handle + ((cid / 48) + 1));
+    tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 3932160, 786432, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(h0_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
 
-  for (int32_t i_1 = 0; i_1 < 32; ++i_1) {
+  for (int32_t i_1 = 0; i_1 < 4; ++i_1) {
       pipe_barrier(PIPE_ALL);
       if (i_1 < (((eos_1 + 63) - bos_1) / 64)) {
-        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1, 1, 131072, 131072, 1, 64, 128>(ws_h_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 1, 128);
-        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 32, 128, 65536, 65536, 8192, 128, 1, 32, 128, pto::PadValue::Zero>(ws_wh_handle + ((cid * 8192) + (vid * 4096)), 16384, 0, 32, 128);
-        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 32, 128, 1, 1, 2162688, 1024, 1, 32, 128, pto::PadValue::Zero>(v_handle + ((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128)), 32768, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 1, 1, 1, 3932160, 1, 64, 128>(ws_h_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 1, 128);
+        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 32, 128, 1966080, 393216, 8192, 128, 1, 32, 128, pto::PadValue::Zero>(ws_wh_handle + ((cid * 8192) + (vid * 4096)), 16384, 0, 32, 128);
+        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 32, 128, 1, 1, 3489792, 6144, 1, 32, 128, pto::PadValue::Zero>(v_handle + ((((i_1 * 393216) + (vid * 196608)) + (bos_1 * 6144)) + ((cid % 48) * 128)), 32768, 0, ((-536 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-568 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((568 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         TCVT(v_chunk_ub_float, v_chunk_ub, pto::RoundMode::CAST_NONE);
         pipe_barrier(PIPE_V);
         TSUB(v_new_ub_float, v_chunk_ub_float, wh_ub_float);
-        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 1, 64, 1, 1, 16896, 8, 1, 1, 64, pto::PadValue::Zero>(g_handle + (((i_1 * 512) + (bos_1 * 8)) + cid), 73728, 0, ((-2048 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-2112 < ((0 - bos_1) - (i_1 * 64))) ? ((2112 - bos_1) - (i_1 * 64)) : 0)), 1);
+        tl::ascend_pto::copy_gm_to_ub<float, float, 1, 1, 1, 1, 64, 1, 1, 27264, 48, 1, 1, 64, pto::PadValue::Zero>(g_handle + (((i_1 * 3072) + (bos_1 * 48)) + (cid % 48)), 73728, 0, ((-504 <= ((0 - bos_1) - (i_1 * 64))) ? 64 : ((-568 < ((0 - bos_1) - (i_1 * 64))) ? ((568 - bos_1) - (i_1 * 64)) : 0)), 1);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID2);
         tl::ascend_pto::TileUbDataND<float, 1, 32, 1, 32> g_chunk_ub_all_temp_0;
@@ -161,9 +161,9 @@ AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ hal
         TCVT(v_new_ub, v_new_ub_float, pto::RoundMode::CAST_NONE);
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID3);
-        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 2162688, 1024, 1, 32, 128>(v_new_handle + ((((i_1 * 65536) + (vid * 32768)) + (bos_1 * 1024)) + (cid * 128)), 131904, 0, ((-2080 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-2112 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((2112 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
-        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 65536, 65536, 1, 32, 128>(ws_vnew_handle + ((cid * 8192) + (vid * 4096)), 131904, 0, 1, 128);
-        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 131072, 131072, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(ws_hupd_handle + ((cid * 16384) + (vid * 8192)), 140096, 0, 64, 128);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 3489792, 6144, 1, 32, 128>(v_new_handle + ((((i_1 * 393216) + (vid * 196608)) + (bos_1 * 6144)) + ((cid % 48) * 128)), 131904, 0, ((-536 <= (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? 32 : ((-568 < (((0 - bos_1) - (vid * 32)) - (i_1 * 64))) ? (((568 - bos_1) - (vid * 32)) - (i_1 * 64)) : 0)), 128);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 32, 128, 1, 1, 1, 1966080, 1, 32, 128>(ws_vnew_handle + ((cid * 8192) + (vid * 4096)), 131904, 0, 1, 128);
+        tl::ascend_pto::copy_gm_to_ub<half, half, 1, 1, 1, 64, 128, 3932160, 786432, 16384, 128, 1, 64, 128, pto::PadValue::Zero>(ws_hupd_handle + ((cid * 16384) + (vid * 8192)), 140096, 0, 64, 128);
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID4);
         TCVT(hupd_ub_float, hupd_ub, pto::RoundMode::CAST_NONE);
@@ -173,12 +173,12 @@ AICORE void main_kernel(__gm__ half *h_handle, __gm__ half *k_handle, __gm__ hal
         TCVT(h_state_ub, h_state_ub_float, pto::RoundMode::CAST_NONE);
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID5);
-        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 4194304, 131072, 16384, 128, 1, 64, 128>(h_handle + (((i_1 * 131072) + (cid * 16384)) + (vid * 8192)), 0, 0, 64, 128);
+        tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 3145728, 786432, 16384, 128, 1, 64, 128>(h_handle + (((((cid / 48) * 3145728) + (i_1 * 786432)) + ((cid % 48) * 16384)) + (vid * 8192)), 0, 0, 64, 128);
       }
       pipe_barrier(PIPE_ALL);
       pipe_barrier(PIPE_ALL);
     }
-    tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 131072, 131072, 16384, 128, 1, 64, 128>(ht_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
+    tl::ascend_pto::copy_ub_to_gm<half, half, 1, 1, 1, 64, 128, 3932160, 786432, 16384, 128, 1, 64, 128>(ht_handle + ((cid * 16384) + (vid * 8192)), 0, 0, 64, 128);
 #endif
 }
 
@@ -205,5 +205,5 @@ extern "C" void call(uint8_t *h_handle, uint8_t *k_handle, uint8_t *v_handle, ui
     uint32_t fftsLen{0};
     uint64_t fftsAddr{0};
     rtGetC2cCtrlAddr(&fftsAddr, &fftsLen);
-    launch_kernel<<<8, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
+    launch_kernel<<<240, nullptr, stream>>>(h_handle, k_handle, v_handle, w_handle, g_handle, v_new_handle, h0_handle, ht_handle, cu_seqlens_handle, ws_wh_handle, ws_vnew_handle, ws_hupd_handle, ws_h_handle, fftsAddr);
 }

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/test_chunk_gated_delta_rule_varlen.sh
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/test_chunk_gated_delta_rule_varlen.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Unit test of tile-lang on test cases from https://github.com/fla-org/flash-linear-attention/blob/main/tests/ops/test_gated_delta.py#L89-L100
+
+# Example given by tilelang-ascend
+python chunk_gated_delta_rule_varlen.py --B 1 --T 204 --H 8 --Hg 4 --K 128 --V 128
+python chunk_gated_delta_rule_varlen.py --T 204 --H 8 --Hg 4 --K 128 --V 128 --varlen true
+
+# non-GVA (HV == H)
+# (B, T, H, HV, D, scale, gate_logit_norm, mask_p, use_qk_l2norm, dtype)
+# (2, 75, 4, 4, 64, 1, 0.01, 0, False, torch.float16),
+# (2, 500, 3, 3, 60, 1, 1, 0, False, torch.float16),
+# (2, 1000, 3, 3, 64, 0.1, 1, 0.5, False, torch.float16),
+# (3, 1024, 4, 4, 100, 1, 0.1, 0, False, torch.float16),
+# (4, 1024, 4, 4, 128, 0.1, 1, 0, True, torch.float16),
+# (2, 1500, 4, 4, 128, 0.1, 10, 0, False, torch.float16),
+# (4, 2048, 8, 8, 64, 0.1, 1, 0, False, torch.float16),
+
+python chunk_gated_delta_rule_varlen.py --B 2 --T 75 --H 4 --Hg 4 --K 64 --V 64 #PASS
+# python chunk_gated_delta_rule_varlen.py --B 2 --T 500 --H 3 --Hg 3 --K 60 --V 60 # error: static assertion failed due to requirement '(Loc == TileType::Vec) || (1024 == TileConfig::fractalMxSize) || (60 == 1) || (Rows % InnerRows == 0)': Layout rows must be divisible by inner box row
+python chunk_gated_delta_rule_varlen.py --B 2 --T 1000 --H 3 --Hg 3 --K 64 --V 64 # PASS
+# python chunk_gated_delta_rule_varlen.py --B 3 --T 1024 --H 4 --Hg 4 --K 100 --V 100 # FAIL: error: static assertion failed due to requirement '(Loc == TileType::Vec) || (1024 == TileConfig::fractalMxSize) || (100 == 1) || (Rows % InnerRows == 0)': Layout rows must be divisible by inner box rows
+# python chunk_gated_delta_rule_varlen.py --B 4 --T 1024 --H 4 --Hg 4 --K 128 --V 128 # PASS
+python chunk_gated_delta_rule_varlen.py --B 2 --T 1500 --H 4 --Hg 4 --K 128 --V 128 # FAIL(accuracy): Mismatched elements: 1295770 / 3145728 (41.2%)
+python chunk_gated_delta_rule_varlen.py --B 4 --T 2048 --H 8 --Hg 8 --K 64 --V 64
+
+################
+# GVA (HV > H) #
+################
+# (B, T, H, HV, D, scale, gate_logit_norm, mask_p, use_qk_l2norm, dtype)
+# (2, 256, 2, 4, 64, 1, 1, 0, False, torch.float16),
+# (2, 512, 2, 8, 64, 1, 0.1, 0, True, torch.float16),
+# (2, 1024, 4, 8, 128, 0.1, 1, 0, False, torch.float16),
+
+# python chunk_gated_delta_rule_varlen.py --B 2 --T 256 --H 2 --Hg 4 --K 64 --V 64 # FAIL(compile): InternalError: Check failed: pb->value != 0 (0 vs. 0) : Divide by zero
+# python chunk_gated_delta_rule_varlen.py --B 2 --T 512 --H 2 --Hg 8 --K 64 --V 64 # FAIL(compile): InternalError: Check failed: pb->value != 0 (0 vs. 0) : Divide by zero
+# python chunk_gated_delta_rule_varlen.py --B 2 --T 1024 --H 4 --Hg 8 --K 128 --V 128 # FAIL(compile): InternalError: Check failed: pb->value != 0 (0 vs. 0) : Divide by zero
+
+

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/test_chunk_gated_delta_rule_varlen.sh
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/test_chunk_gated_delta_rule_varlen.sh
@@ -32,8 +32,12 @@ python chunk_gated_delta_rule_varlen.py --B 4 --T 2048 --H 8 --Hg 8 --K 64 --V 6
 # (2, 512, 2, 8, 64, 1, 0.1, 0, True, torch.float16),
 # (2, 1024, 4, 8, 128, 0.1, 1, 0, False, torch.float16),
 
-# python chunk_gated_delta_rule_varlen.py --B 2 --T 256 --H 2 --Hg 4 --K 64 --V 64 # FAIL(compile): InternalError: Check failed: pb->value != 0 (0 vs. 0) : Divide by zero
-# python chunk_gated_delta_rule_varlen.py --B 2 --T 512 --H 2 --Hg 8 --K 64 --V 64 # FAIL(compile): InternalError: Check failed: pb->value != 0 (0 vs. 0) : Divide by zero
-# python chunk_gated_delta_rule_varlen.py --B 2 --T 1024 --H 4 --Hg 8 --K 128 --V 128 # FAIL(compile): InternalError: Check failed: pb->value != 0 (0 vs. 0) : Divide by zero
+# Qwen3.6-27B shape https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/config.json#L88-L91
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 7,32,159,256,50 --H 48 --Hg 16 --K 128 --V 128 # PASS -- dumps to `chunk_gated_delta_rule_varlen_H32.cpp`
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 512,512 --H 48 --Hg 16 --K 128 --V 128 #  1.8% mismatch, due to accumulating error by too many steps?
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 2048,2048 --H 48 --Hg 16 --K 128 --V 128 # 27.2% mismatch
 
-
+# Qwen3.5-9B shape https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/config.json#L54-L57
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 7,32,159,256,50 --H 32 --Hg 16 --K 128 --V 128 # PASS -- dumps to `chunk_gated_delta_rule_varlen_H48.cpp`
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 512,512 --H 32 --Hg 16 --K 128 --V 128 # 1.6% mismatch, due to accumulating error by too many steps?
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 1024,1024 --H 32 --Hg 16 --K 128 --V 128  # 1.8 mismatch

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/test_chunk_gated_delta_rule_varlen.sh
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/test_chunk_gated_delta_rule_varlen.sh
@@ -33,11 +33,11 @@ python chunk_gated_delta_rule_varlen.py --B 4 --T 2048 --H 8 --Hg 8 --K 64 --V 6
 # (2, 1024, 4, 8, 128, 0.1, 1, 0, False, torch.float16),
 
 # Qwen3.6-27B shape https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/config.json#L88-L91
-python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 7,32,159,256,50 --H 48 --Hg 16 --K 128 --V 128 # PASS -- dumps to `chunk_gated_delta_rule_varlen_H32.cpp`
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 7,32,159,256,50 --H 48 --Hg 16 --K 128 --V 128 # PASS -- dumps to `chunk_gated_delta_rule_varlen_H48.cpp`
 python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 512,512 --H 48 --Hg 16 --K 128 --V 128 #  1.8% mismatch, due to accumulating error by too many steps?
 python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 2048,2048 --H 48 --Hg 16 --K 128 --V 128 # 27.2% mismatch
 
 # Qwen3.5-9B shape https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/config.json#L54-L57
-python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 7,32,159,256,50 --H 32 --Hg 16 --K 128 --V 128 # PASS -- dumps to `chunk_gated_delta_rule_varlen_H48.cpp`
+python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 7,32,159,256,50 --H 32 --Hg 16 --K 128 --V 128 # PASS -- dumps to `chunk_gated_delta_rule_varlen_H32.cpp`
 python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 512,512 --H 32 --Hg 16 --K 128 --V 128 # 1.6% mismatch, due to accumulating error by too many steps?
 python chunk_gated_delta_rule_varlen.py --varlen true --seqlens 1024,1024 --H 32 --Hg 16 --K 128 --V 128  # 1.8 mismatch

--- a/examples/jit_cpp/chunk_gdn/tilelang_codegen/scripts/dump_all_kernels.sh
+++ b/examples/jit_cpp/chunk_gdn/tilelang_codegen/scripts/dump_all_kernels.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/../kernels"
 for py in \
+  chunk_gated_delta_rule_varlen.py \
   opt_gdn_chunk_cumsum.py \
   opt_gdn_chunk_h.py \
   opt_gdn_chunk_o.py \


### PR DESCRIPTION

WIP: We need to update the gdn-tri-inv docker image so that it contains the latest tile-lang:

```
Running chunk_gated_delta_rule_varlen.py ...
============================================================
Testing Fixed-length B=1, T=2048, H=8, Hg=4, K=128, V=128, use_g=True, use_initial_state=True
error: broadcast() got an unexpected keyword argument 'axis'
 --> /workspace/pto-kernels/examples/jit_cpp/chunk_gdn/tilelang_codegen/kernels/chunk_gated_delta_rule_varlen.py:178:25
     |  
 178 |                          T.tile.broadcast(g_exp_ub_broc, g_exp_ub, axis=1)
     |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: run with `TVM_BACKTRACE=1` environment variable to display a backtrace.
[ERROR] 2026-04-27-07:40:53 (PID:2479, Device:0, RankID:-1) ERR99999 UNKNOWN applicaiton exception

```