### PR TITLE
(makefile) introduce 'make compile_<kernel_name>'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ compile_%:
 		-I$(CSRC_KERNEL_DIR) \
 		-I$(PTO_LIB_PATH)/include \
 		--npu-arch=dav-2201 \
-	        -Wno-ignored-attributes \
+	    -Wno-ignored-attributes \
 		$(CSRC_KERNEL_DIR)/kernel_$*.cpp \
 		-o libkernel_$*.so
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 # https://github.com/huawei-csl/pto-kernels/
 # for the full License text.
 # --------------------------------------------------------------------------------
+PTO_LIB_PATH    ?= $(ASCEND_TOOLKIT_HOME)
+CSRC_KERNEL_DIR := csrc/kernel
+
 .PHONY: clean setup_once build_cmake build_wheel install docs test test_tri_inv
 
 clean:
@@ -19,6 +22,17 @@ build_cmake: clean
 
 build_wheel:
 	export CMAKE_GENERATOR="Unix Makefiles" && pip wheel -v  . --extra-index-url https://download.pytorch.org/whl/cpu
+
+
+# 'make compile_abs' will quickly compile 'kernel_abs.cpp' into 'libkernel_abs.so' without
+# building the whole wheel package. This is useful for development and debugging of individual kernels.
+compile_%:
+	bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
+		-I$(CSRC_KERNEL_DIR) \
+		-I$(PTO_LIB_PATH)/include \
+		--npu-arch=dav-2201 \
+		$(CSRC_KERNEL_DIR)/kernel_$*.cpp \
+		-o libkernel_$*.so
 
 install:
 	python3 -m pip install --force-reinstall pto_kernels-*.whl

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,11 @@ build_wheel:
 
 # 'make compile_abs' compiles 'kernel_abs.cpp' into 'libkernel_abs.so' without building the whole wheel package.
 # This is useful for development and debugging of individual kernels.
-compile_aiv_%:
+compile_%:
 	bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
 		-I$(CSRC_KERNEL_DIR) \
 		-I$(PTO_LIB_PATH)/include \
-		-isystem \
 		--npu-arch=dav-2201 \
-	        --cce-aicore-arch=dav-c220-vec \
 	        -Wno-ignored-attributes \
 		$(CSRC_KERNEL_DIR)/kernel_$*.cpp \
 		-o libkernel_$*.so

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,19 @@ build_wheel:
 	export CMAKE_GENERATOR="Unix Makefiles" && pip wheel -v  . --extra-index-url https://download.pytorch.org/whl/cpu
 
 
-# 'make compile_abs' will quickly compile 'kernel_abs.cpp' into 'libkernel_abs.so' without
-# building the whole wheel package. This is useful for development and debugging of individual kernels.
-compile_%:
+# 'make compile_abs' compiles 'kernel_abs.cpp' into 'libkernel_abs.so' without building the whole wheel package.
+# This is useful for development and debugging of individual kernels.
+compile_aiv_%:
 	bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
 		-I$(CSRC_KERNEL_DIR) \
 		-I$(PTO_LIB_PATH)/include \
+		-isystem \
 		--npu-arch=dav-2201 \
+	        --cce-aicore-arch=dav-c220-vec \
+	        -Wno-ignored-attributes \
 		$(CSRC_KERNEL_DIR)/kernel_$*.cpp \
 		-o libkernel_$*.so
+
 
 install:
 	python3 -m pip install --force-reinstall pto_kernels-*.whl

--- a/csrc/kernel/constants.h
+++ b/csrc/kernel/constants.h
@@ -26,7 +26,9 @@ for s in [16, 32, 64, 128]:
  */
 #pragma once
 
+#ifndef MEMORY_BASE
 #define MEMORY_BASE
+#endif
 #include <pto/pto-inst.hpp>
 
 #define CONST_HALF_TO_GM(x) \

--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -129,3 +129,8 @@ extern "C" __global__ AICORE void vabs_fp32(GM_ADDR x, GM_ADDR z,
   (void)in_length;
 #endif
 }
+
+extern "C" void call_vabs_fp16(uint32_t blockDim, void* stream, uint8_t* x,
+                               uint8_t* y, uint32_t in_length) {
+  vabs_fp16<<<blockDim * 2, nullptr, stream>>>(x, y, in_length);
+}


### PR DESCRIPTION
Allows for faster compilation of kernel code. 

Example `make compile_abs` will output `libkernel_abs.so` in < 1 second.


### Compilation latency


```
(venv) zouzias@bz-vnl-910b:~/github-repos/pto-kernels$ time make compile_abs
bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
        -Icsrc/kernel \
        -I/usr/local/Ascend/cann-9.0.0-beta.2/include \
        --npu-arch=dav-2201 \
        csrc/kernel/kernel_abs.cpp \
        -o libkernel_abs.so

real    0m0.715s
user    0m0.575s
sys     0m0.167s
(venv) zouzias@bz-vnl-910b:~/github-repos/pto-kernels$ time make compile_tri_inv_rec_unroll
bisheng -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
        -Icsrc/kernel \
        -I/usr/local/Ascend/cann-9.0.0-beta.2/include \
        --npu-arch=dav-2201 \
        csrc/kernel/kernel_tri_inv_rec_unroll.cpp \
        -o libkernel_tri_inv_rec_unroll.so

real    0m3.518s
user    0m3.358s
sys     0m0.205s
```