### PR TITLE
(GDN) integrate chunk_sumsum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ ascendc_library(
   SHARED
   csrc/kernel/kernel_tri_inv_col_sweep.cpp
   csrc/kernel/kernel_abs.cpp
+  csrc/kernel/kernel_chunk_cumsum.cpp
   csrc/kernel/kernel_csr_gather.cpp
   csrc/kernel/kernel_scan_ul1.cpp
   csrc/kernel/kernel_simple_matmul.cpp

--- a/csrc/host/pybind11.cpp
+++ b/csrc/host/pybind11.cpp
@@ -11,6 +11,7 @@ for the full License text.
 
 #include "torch_abs.h"
 #include "torch_batch_matrix_square.h"
+#include "torch_chunk_cumsum.h"
 #include "torch_csr_gather.h"
 #include "torch_scan_ul1.h"
 #include "torch_simple_matmul.h"
@@ -38,6 +39,9 @@ PYBIND11_MODULE(pto_kernels_ops, m) {
       },
       pybind11::arg("device_id") = 0);
   m.def("pto_abs", &pto_isa_ops::run_abs);
+  m.def("pto_chunk_cumsum", &pto_isa_ops::run_chunk_cumsum, py::arg("g"),
+        py::arg("batch_size"), py::arg("seq_len"),
+        py::arg("cu_seqlens") = at::zeros({1}));
   m.def("pto_batch_matrix_square", &pto_isa_ops::run_batch_matrix_square);
   m.def("pto_csr_gather", &pto_isa_ops::run_csr_gather);
   m.def("pto_scan_ul1", &pto_isa_ops::run_scan_ul1);

--- a/csrc/host/torch_chunk_cumsum.h
+++ b/csrc/host/torch_chunk_cumsum.h
@@ -50,10 +50,12 @@ at::Tensor run_chunk_cumsum(const at::Tensor& g, int64_t batch_size,
   TORCH_CHECK(batch_size > 0,
               "pto_chunk_cumsum: batch_size must be positive, got ",
               batch_size);
-  TORCH_CHECK(seq_len > 0, "pto_chunk_cumsum: seq_len must be positive, got ",
+  TORCH_CHECK(cu_seqlens.numel() > 1 || seq_len > 0,
+              "pto_chunk_cumsum: seq_len must be positive if no cu_seqlens "
+              "provided, got ",
               seq_len);
 
-  at::Tensor g_sum = at::empty_like(g);
+  const at::Tensor g_sum = at::empty_like(g);
 
   const uint32_t block_dim = GetNumVectorCores();
 

--- a/csrc/host/torch_chunk_cumsum.h
+++ b/csrc/host/torch_chunk_cumsum.h
@@ -1,0 +1,71 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+#pragma once
+
+#include <ATen/ATen.h>
+#include <torch/library.h>
+
+#include "aclrtlaunch_chunk_cumsum_fp32.h"
+#include "utils.h"
+
+namespace pto_isa_ops {
+
+/**
+ * @brief Computes a chunked prefix sum (cumulative sum) of gate values along
+ * the time dimension.
+ *
+ * Per chunk of GDN_C tokens, independently per head h:
+ *   g_sum[t, h] = sum_{i=0}^{t} g[i, h]   for t = 0 .. valid-1
+ *
+ * This enables downstream kernels to compute exponential decay coefficients:
+ *   exp(g_sum[i] - g_sum[j]) gives the cumulative gate from token j to i.
+ *
+ * @param [in] g          Float32 input tensor with shape [total_tokens, H].
+ * @param [in] batch_size Number of sequences in the batch.
+ * @param [in] seq_len    Sequence length (tokens per sequence). Used only when
+ *                        cu_seqlens has a single element (fixed-length path).
+ * @param [in] cu_seqlens Optional cumulative sequence lengths tensor of shape
+ *                        [batch_size + 1], dtype int32. When provided (numel >
+ * 1) the variable-length path is taken.
+ * @return at::Tensor Float32 output tensor with shape [total_tokens, H]
+ *                    containing the per-chunk prefix sums.
+ */
+at::Tensor run_chunk_cumsum(const at::Tensor& g, int64_t batch_size,
+                            int64_t seq_len,
+                            const at::Tensor& cu_seqlens = at::zeros({1})) {
+  TORCH_CHECK(g.device().type() == DEVICE_TYPE,
+              "pto_chunk_cumsum: tensor must be on NPU, got ", g.device());
+  TORCH_CHECK(g.scalar_type() == at::kFloat,
+              "pto_chunk_cumsum: g must be float32, got ", g.scalar_type());
+  TORCH_CHECK(g.dim() == 2,
+              "pto_chunk_cumsum: g must be 2D [total_tokens, H], got ", g.dim(),
+              "D");
+  TORCH_CHECK(g.is_contiguous(), "pto_chunk_cumsum: g must be contiguous");
+  TORCH_CHECK(batch_size > 0,
+              "pto_chunk_cumsum: batch_size must be positive, got ",
+              batch_size);
+  TORCH_CHECK(seq_len > 0, "pto_chunk_cumsum: seq_len must be positive, got ",
+              seq_len);
+
+  at::Tensor g_sum = at::empty_like(g);
+
+  const uint32_t block_dim = GetNumVectorCores();
+
+  void* cu_seqlens_ptr = nullptr;
+  if (cu_seqlens.numel() != 1) {
+    cu_seqlens_ptr = ConvertType(cu_seqlens);
+  }
+
+  EXEC_KERNEL_CMD(chunk_cumsum_fp32, block_dim, g, g_sum, cu_seqlens_ptr,
+                  batch_size, seq_len);
+
+  return g_sum;
+}
+
+}  // namespace pto_isa_ops

--- a/csrc/kernel/kernel_chunk_cumsum.cpp
+++ b/csrc/kernel/kernel_chunk_cumsum.cpp
@@ -96,9 +96,9 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor, RV,
 #endif
 
 template <int32_t NumHeads, int32_t ChunkSize>
-AICORE void cumsum_kernel(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
-                          __gm__ int32_t* cu_seqlens, int64_t batch_size,
-                          int64_t seq_len) {
+AICORE void cumsum_kernel_varlen(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
+                                 __gm__ int32_t* cu_seqlens, int64_t batch_size,
+                                 int64_t seq_len) {
   // get_block_idx(): Returns this AI core's index (0..block_num-1).
   //   Like blockIdx.x in CUDA — identifies which core this code runs on.
   // get_block_num(): Total number of AI cores launched (like gridDim.x in
@@ -109,13 +109,12 @@ AICORE void cumsum_kernel(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
   auto block_num = get_block_num();
   auto vid = get_subblockid();
 
-// #if defined(__DAV_C220_VEC__): This block only compiles for the Vec core
-// pass. The bisheng compiler makes 3 passes over the same source file:
-//   Pass 1: __DAV_C220_VEC__  defined → compiles Vec (SIMD) code
-//   Pass 2: __DAV_C220_CUBE__ defined → compiles Cube (matrix) code
-//   Pass 3: neither defined → compiles host (CPU) launcher code
-// Using these guards lets us put Vec, Cube, and host code in one file.
-#if defined(__DAV_C220_VEC__)
+  // #if defined(__DAV_C220_VEC__): This block only compiles for the Vec core
+  // pass. The bisheng compiler makes 3 passes over the same source file:
+  //   Pass 1: __DAV_C220_VEC__  defined → compiles Vec (SIMD) code
+  //   Pass 2: __DAV_C220_CUBE__ defined → compiles Cube (matrix) code
+  //   Pass 3: neither defined → compiles host (CPU) launcher code
+  // Using these guards lets us put Vec, Cube, and host code in one file.
   if (vid != 0) return;
 
   // set_mask_norm(): Reset Vec mask to normal mode (all lanes active).
@@ -174,239 +173,316 @@ AICORE void cumsum_kernel(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
 
   int64_t num_seqs = batch_size;
 
-  // ── Fixed-length sequence path (cu_seqlens == nullptr) ────────────────
-  if (cu_seqlens == nullptr) {
-    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
-    int64_t total_chunks = num_seqs * chunks_per_seq;
-
-    // Work distribution: Each AI core processes chunks in a round-robin
-    // pattern. Core `cid` handles chunks cid, cid+block_num, cid+2*block_num,
-    // ... This is the NPU equivalent of CUDA's grid-stride loop:
-    //   for (int i = blockIdx.x; i < total; i += gridDim.x)
-    for (int64_t gi = static_cast<int64_t>(cid); gi < total_chunks;
-         gi += static_cast<int64_t>(block_num)) {
-      int64_t seq_idx = gi / chunks_per_seq;
-      int64_t local_chunk = gi % chunks_per_seq;
-      int64_t bos = seq_idx * seq_len;
-      int64_t chunk_start = bos + local_chunk * ChunkSize;
-      int64_t remaining = seq_len - local_chunk * ChunkSize;
-      int32_t valid =
-          static_cast<int32_t>(remaining < ChunkSize ? remaining : ChunkSize);
-
-      // ── DMA: load g[chunk_start .. +valid] from GM → UB (MTE2 pipe) ──
-      // Constructs a GlobalTensor view over the g array, loads into UB,
-      // then zero-pads the tail region (rows beyond `valid`, cols beyond
-      // NumHeads up to the 8-aligned HTC) so downstream Vec ops see zeros.
-      {
-        GmShape gs;
-        gs.shape[3] = valid;
-        gs.shape[4] = NumHeads;
-        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
-        UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero> g_load(
-            valid, NumHeads);
-        TASSIGN(g_load, GUbAddr);
-        // TLOAD(ub_tile, gm_tensor): DMA transfer from GM → UB.
-        // Equivalent to: ub_tile[:valid, :NumHeads] = gm_tensor[:valid,
-        // :NumHeads] This is an ASYNC operation on the MTE2 pipe — the CPU/Vec
-        // engine can do other work while DMA is in progress. You must call
-        // set_flag/wait_flag before reading the loaded data.
-        TLOAD(g_load, g_gm);
-        if (valid != ChunkSize || NumHeads != HTC) {
-          UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
-          TASSIGN(g_pad, GUbAddr);
-          // TFILLPAD_INPLACE(full_tile, partial_tile): Zero-fills the region
-          // outside the valid area of partial_tile. Equivalent to:
-          //   full_tile[valid:ChunkSize, :] = 0  # zero rows beyond valid
-          //   full_tile[:, NumHeads:HTC] = 0     # zero cols beyond NumHeads
-          //   (alignment padding)
-          // This ensures downstream Vec operations see clean zeros in padded
-          // regions.
-          TFILLPAD_INPLACE(g_pad, g_load);
-        }
-      }
-      // ── Synchronization: MTE2 → Vec ────────────────────────────────────
-      // set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Signal from MTE2 (DMA load
-      //   engine) to Vec (SIMD engine) that the DMA transfer is complete.
-      // wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Vec waits here until MTE2
-      //   has set the flag. After this, UB data from TLOAD is safe to read.
-      // Think of it as: torch.cuda.synchronize() but fine-grained per pipe.
-      // EVENT_ID0 is a semaphore index (0-7 available).
-      // MTE2 → Vec sync: wait for DMA load to finish before Vec reads UB
-      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-
-      // ── Vec compute: prefix sum over rows (all H heads in parallel) ───
-      // Row 0: acc[h] = g[0,h];  g_sum[0,h] = acc[h]
-      UbND<float, 1, HTC> g_row_0;
-      TASSIGN(g_row_0, GUbAddr);
-      // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
-      TMOV(acc_ub, g_row_0);
-      // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations
-      // complete before the next Vec instruction begins. Needed because Vec ops
-      // are pipelined and may not finish in order. Think of it as a local
-      // __syncthreads() for the Vec engine only. Much lighter than
-      // set_flag/wait_flag (which sync across different hardware units).
-      pipe_barrier(PIPE_V);
-
-      UbND<float, 1, HTC> s_row_0;
-      TASSIGN(s_row_0, SUbAddr);
-      TMOV(s_row_0, acc_ub);
-      pipe_barrier(PIPE_V);
-
-      // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
-      for (int32_t i = 1; i < valid; ++i) {
-        UbND<float, 1, HTC> g_row_i;
-        TASSIGN(g_row_i, GUbAddr + i * RowBytes);
-        // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
-        // Operates on all HTC elements in parallel (SIMD).
-        TADD(acc_ub, acc_ub, g_row_i);
-        pipe_barrier(PIPE_V);
-
-        UbND<float, 1, HTC> s_row_i;
-        TASSIGN(s_row_i, SUbAddr + i * RowBytes);
-        TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_V);
-      }
-
-      // Zero-fill rows beyond valid (tail padding for downstream kernels)
-      // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
-      // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
-      TEXPANDS(acc_ub, 0.0f);
-      pipe_barrier(PIPE_V);
-      for (int32_t i = valid; i < ChunkSize; ++i) {
-        UbND<float, 1, HTC> s_row_i;
-        TASSIGN(s_row_i, SUbAddr + i * RowBytes);
-        TMOV(s_row_i, acc_ub);
-        pipe_barrier(PIPE_V);
-      }
-
-      // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
-      // ── Synchronization: Vec → MTE3 ───────────────────────────────────
-      // Vec signals MTE3 that computation is done and UB data is ready to
-      // store. MTE3 (DMA store engine) waits for this before reading UB for
-      // TSTORE. Without this sync, MTE3 might read stale/partial data from UB.
-      // Vec → MTE3 sync: ensure Vec writes to UB are visible before DMA
-      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-
-      {
-        GmShape ss;
-        ss.shape[3] = valid;
-        ss.shape[4] = NumHeads;
-        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
-        UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid, NumHeads);
-        TASSIGN(s_store, SUbAddr);
-        // TSTORE(gm_tensor, ub_tile): DMA transfer from UB → GM.
-        // Equivalent to: gm_tensor[:valid, :NumHeads] = ub_tile[:valid,
-        // :NumHeads] Async on MTE3 pipe. Must sync (Vec→MTE3) before calling,
-        // and sync (MTE3→Vec) after if reusing the same UB region.
-        TSTORE(gs_gm, s_store);
-      }
-      // ── Synchronization: MTE3 → Vec ───────────────────────────────────
-      // MTE3 signals Vec that the DMA store is complete and UB can be reused.
-      // Vec waits before starting the next iteration's TLOAD into the same UB
-      // region. Without this, the next TLOAD could overwrite data still being
-      // stored. MTE3 → Vec sync: wait for DMA store before reusing UB next iter
-      set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-    }
-  }
   // ── Variable-length sequence path (cu_seqlens != nullptr) ─────────────
-  else {
-    int64_t gi = 0;
-    for (int64_t si = 0; si < num_seqs; ++si) {
-      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
-      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
-      int64_t slen = eos - bos;
-      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+  int64_t gi = 0;
+  for (int64_t si = 0; si < num_seqs; ++si) {
+    int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+    int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+    int64_t slen = eos - bos;
+    int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
-      for (int64_t c = 0; c < nc; ++c) {
-        if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
-          int64_t chunk_start = bos + c * ChunkSize;
-          int64_t remaining = slen - c * ChunkSize;
-          int32_t valid = static_cast<int32_t>(
-              remaining < ChunkSize ? remaining : ChunkSize);
+    for (int64_t c = 0; c < nc; ++c) {
+      if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
+        int64_t chunk_start = bos + c * ChunkSize;
+        int64_t remaining = slen - c * ChunkSize;
+        int32_t valid =
+            static_cast<int32_t>(remaining < ChunkSize ? remaining : ChunkSize);
 
-          // Load g chunk from GM → UB, zero-padded
-          {
-            GmShape gs;
-            gs.shape[3] = valid;
-            gs.shape[4] = NumHeads;
-            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
-            UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
-                g_load(valid, NumHeads);
-            TASSIGN(g_load, GUbAddr);
-            TLOAD(g_load, g_gm);
-            if (valid != ChunkSize || NumHeads != HTC) {
-              UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
-              TASSIGN(g_pad, GUbAddr);
-              TFILLPAD_INPLACE(g_pad, g_load);
-            }
+        // Load g chunk from GM → UB, zero-padded
+        {
+          GmShape gs;
+          gs.shape[3] = valid;
+          gs.shape[4] = NumHeads;
+          GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+          UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero> g_load(
+              valid, NumHeads);
+          TASSIGN(g_load, GUbAddr);
+          TLOAD(g_load, g_gm);
+          if (valid != ChunkSize || NumHeads != HTC) {
+            UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
+            TASSIGN(g_pad, GUbAddr);
+            TFILLPAD_INPLACE(g_pad, g_load);
           }
-          set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-          wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-
-          // Prefix sum: acc = g[0]; g_sum[0] = acc
-          UbND<float, 1, HTC> g_row_0;
-          TASSIGN(g_row_0, GUbAddr);
-          TMOV(acc_ub, g_row_0);
-          pipe_barrier(PIPE_V);
-
-          UbND<float, 1, HTC> s_row_0;
-          TASSIGN(s_row_0, SUbAddr);
-          TMOV(s_row_0, acc_ub);
-          pipe_barrier(PIPE_V);
-
-          // acc += g[i]; g_sum[i] = acc
-          for (int32_t i = 1; i < valid; ++i) {
-            UbND<float, 1, HTC> g_row_i;
-            TASSIGN(g_row_i, GUbAddr + i * RowBytes);
-            TADD(acc_ub, acc_ub, g_row_i);
-            pipe_barrier(PIPE_V);
-
-            UbND<float, 1, HTC> s_row_i;
-            TASSIGN(s_row_i, SUbAddr + i * RowBytes);
-            TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_V);
-          }
-
-          // Zero-fill padding rows
-          TEXPANDS(acc_ub, 0.0f);
-          pipe_barrier(PIPE_V);
-          for (int32_t i = valid; i < ChunkSize; ++i) {
-            UbND<float, 1, HTC> s_row_i;
-            TASSIGN(s_row_i, SUbAddr + i * RowBytes);
-            TMOV(s_row_i, acc_ub);
-            pipe_barrier(PIPE_V);
-          }
-
-          // Store g_sum to GM
-          set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-          wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-
-          {
-            GmShape ss;
-            ss.shape[3] = valid;
-            ss.shape[4] = NumHeads;
-            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
-            UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid,
-                                                                  NumHeads);
-            TASSIGN(s_store, SUbAddr);
-            TSTORE(gs_gm, s_store);
-          }
-          set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
-          wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
         }
-        gi++;
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        // Prefix sum: acc = g[0]; g_sum[0] = acc
+        UbND<float, 1, HTC> g_row_0;
+        TASSIGN(g_row_0, GUbAddr);
+        TMOV(acc_ub, g_row_0);
+        pipe_barrier(PIPE_V);
+
+        UbND<float, 1, HTC> s_row_0;
+        TASSIGN(s_row_0, SUbAddr);
+        TMOV(s_row_0, acc_ub);
+        pipe_barrier(PIPE_V);
+
+        // acc += g[i]; g_sum[i] = acc
+        for (int32_t i = 1; i < valid; ++i) {
+          UbND<float, 1, HTC> g_row_i;
+          TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+          TADD(acc_ub, acc_ub, g_row_i);
+          pipe_barrier(PIPE_V);
+
+          UbND<float, 1, HTC> s_row_i;
+          TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+          TMOV(s_row_i, acc_ub);
+          pipe_barrier(PIPE_V);
+        }
+
+        // Zero-fill padding rows
+        TEXPANDS(acc_ub, 0.0f);
+        pipe_barrier(PIPE_V);
+        for (int32_t i = valid; i < ChunkSize; ++i) {
+          UbND<float, 1, HTC> s_row_i;
+          TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+          TMOV(s_row_i, acc_ub);
+          pipe_barrier(PIPE_V);
+        }
+
+        // Store g_sum to GM
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+        {
+          GmShape ss;
+          ss.shape[3] = valid;
+          ss.shape[4] = NumHeads;
+          GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+          UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid,
+                                                                NumHeads);
+          TASSIGN(s_store, SUbAddr);
+          TSTORE(gs_gm, s_store);
+        }
+        set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
       }
+      gi++;
     }
   }
-#endif
+}
+
+template <int32_t NumHeads, int32_t ChunkSize>
+AICORE void cumsum_kernel_static(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
+                                 int64_t batch_size, int64_t seq_len) {
+  // get_block_idx(): Returns this AI core's index (0..block_num-1).
+  //   Like blockIdx.x in CUDA — identifies which core this code runs on.
+  // get_block_num(): Total number of AI cores launched (like gridDim.x in
+  // CUDA). get_subblockid(): Returns 0 or 1 — selects which Vec sub-block
+  // within the core.
+  //   Each AI core has 2 Vec sub-blocks that can run in parallel.
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
+  auto vid = get_subblockid();
+
+  // #if defined(__DAV_C220_VEC__): This block only compiles for the Vec core
+  // pass. The bisheng compiler makes 3 passes over the same source file:
+  //   Pass 1: __DAV_C220_VEC__  defined → compiles Vec (SIMD) code
+  //   Pass 2: __DAV_C220_CUBE__ defined → compiles Cube (matrix) code
+  //   Pass 3: neither defined → compiles host (CPU) launcher code
+  // Using these guards lets us put Vec, Cube, and host code in one file.
+  if (vid != 0) return;
+
+  // set_mask_norm(): Reset Vec mask to normal mode (all lanes active).
+  // set_vector_mask(-1, -1): Enable all SIMD lanes (128 lanes for fp32).
+  //   The -1 sets all 64 bits to 1 in each of the two 64-bit mask registers.
+  //   This is like setting torch's computation to operate on all elements.
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // HeadTileCols: NumHeads rounded up to 8-element alignment (32B for float)
+  // HTC = NumHeads rounded up to nearest multiple of 8.
+  // Why? The Vec engine processes data in 32-byte granularity.
+  // For float (4 bytes), that's 8 elements per SIMD "word".
+  // Rounding up ensures every row is a whole number of SIMD words,
+  // avoiding partial-lane issues. The extra columns are zero-padded.
+  // Example: NumHeads=16 → HTC=16 (already aligned), NumHeads=13 → HTC=16.
+  constexpr int32_t HTC = ((NumHeads + 7) / 8) * 8;
+  constexpr int32_t BlockBytes =
+      ChunkSize * HTC * static_cast<int32_t>(sizeof(float));
+  constexpr int32_t RowBytes = HTC * static_cast<int32_t>(sizeof(float));
+
+  // ── UB memory layout ──────────────────────────────────────────────────
+  //  [0            .. BlockBytes)     = g input  (ChunkSize × HTC floats)
+  //  [BlockBytes   .. 2*BlockBytes)   = g_sum output
+  //  [2*BlockBytes .. 2*BlockBytes+RowBytes) = row accumulator (1 × HTC)
+  constexpr int32_t GUbAddr = 0;
+  constexpr int32_t SUbAddr = BlockBytes;
+  constexpr int32_t AccUbAddr = BlockBytes * 2;
+
+  // GlobalTensor types for g/g_sum in [total_tokens, NumHeads] layout.
+  // 5D shape with last two dims dynamic; stride encodes row pitch.
+  //
+  // GlobalTensor is a "view" into GM (Global Memory), like
+  // torch.as_strided().
+  //   GlobalTensor<dtype, Shape, Stride>(base_ptr, shape)
+  // Shape<1,1,1,DYNAMIC,DYNAMIC> = 5D shape where first 3 dims are 1
+  // (unused),
+  //   last 2 dims are set at runtime (valid rows × NumHeads).
+  // Stride<1,1,1,NumHeads,1> = stride between elements. The 4th stride =
+  // NumHeads
+  //   means consecutive rows in GM are NumHeads elements apart (BSND layout:
+  //   token[t] at offset t*NumHeads, head[h] at offset h within that token).
+  // This is equivalent to:
+  //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads],
+  //   stride=[NumHeads, 1])
+  using GmShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GmStride = Stride<1, 1, 1, NumHeads, 1>;
+  using GmFloat = GlobalTensor<float, GmShape, GmStride>;
+
+  // Pre-assign row accumulator at fixed UB address
+  // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address
+  // in UB. Think of it as: tile = ub_memory[address:address+sizeof(tile)]
+  // This does NOT allocate or move data — it just tells the hardware where
+  // the tile lives. We manually manage UB memory layout (like a memory pool)
+  // via compile-time addresses.
+  UbND<float, 1, HTC> acc_ub;
+  TASSIGN(acc_ub, AccUbAddr);
+
+  int64_t num_seqs = batch_size;
+
+  // ── Fixed-length sequence path (cu_seqlens == nullptr) ────────────────
+  int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+  int64_t total_chunks = num_seqs * chunks_per_seq;
+
+  // Work distribution: Each AI core processes chunks in a round-robin
+  // pattern. Core `cid` handles chunks cid, cid+block_num, cid+2*block_num,
+  // ... This is the NPU equivalent of CUDA's grid-stride loop:
+  //   for (int i = blockIdx.x; i < total; i += gridDim.x)
+  for (int64_t gi = static_cast<int64_t>(cid); gi < total_chunks;
+       gi += static_cast<int64_t>(block_num)) {
+    int64_t seq_idx = gi / chunks_per_seq;
+    int64_t local_chunk = gi % chunks_per_seq;
+    int64_t bos = seq_idx * seq_len;
+    int64_t chunk_start = bos + local_chunk * ChunkSize;
+    int64_t remaining = seq_len - local_chunk * ChunkSize;
+    int32_t valid =
+        static_cast<int32_t>(remaining < ChunkSize ? remaining : ChunkSize);
+
+    // ── DMA: load g[chunk_start .. +valid] from GM → UB (MTE2 pipe) ──
+    // Constructs a GlobalTensor view over the g array, loads into UB,
+    // then zero-pads the tail region (rows beyond `valid`, cols beyond
+    // NumHeads up to the 8-aligned HTC) so downstream Vec ops see zeros.
+    {
+      GmShape gs;
+      gs.shape[3] = valid;
+      gs.shape[4] = NumHeads;
+      GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+      UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero> g_load(
+          valid, NumHeads);
+      TASSIGN(g_load, GUbAddr);
+      // TLOAD(ub_tile, gm_tensor): DMA transfer from GM → UB.
+      // Equivalent to: ub_tile[:valid, :NumHeads] = gm_tensor[:valid,
+      // :NumHeads] This is an ASYNC operation on the MTE2 pipe — the CPU/Vec
+      // engine can do other work while DMA is in progress. You must call
+      // set_flag/wait_flag before reading the loaded data.
+      TLOAD(g_load, g_gm);
+      if (valid != ChunkSize || NumHeads != HTC) {
+        UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
+        TASSIGN(g_pad, GUbAddr);
+        // TFILLPAD_INPLACE(full_tile, partial_tile): Zero-fills the region
+        // outside the valid area of partial_tile. Equivalent to:
+        //   full_tile[valid:ChunkSize, :] = 0  # zero rows beyond valid
+        //   full_tile[:, NumHeads:HTC] = 0     # zero cols beyond NumHeads
+        //   (alignment padding)
+        // This ensures downstream Vec operations see clean zeros in padded
+        // regions.
+        TFILLPAD_INPLACE(g_pad, g_load);
+      }
+    }
+    // ── Synchronization: MTE2 → Vec ────────────────────────────────────
+    // set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Signal from MTE2 (DMA load
+    //   engine) to Vec (SIMD engine) that the DMA transfer is complete.
+    // wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Vec waits here until MTE2
+    //   has set the flag. After this, UB data from TLOAD is safe to read.
+    // Think of it as: torch.cuda.synchronize() but fine-grained per pipe.
+    // EVENT_ID0 is a semaphore index (0-7 available).
+    // MTE2 → Vec sync: wait for DMA load to finish before Vec reads UB
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // ── Vec compute: prefix sum over rows (all H heads in parallel) ───
+    // Row 0: acc[h] = g[0,h];  g_sum[0,h] = acc[h]
+    UbND<float, 1, HTC> g_row_0;
+    TASSIGN(g_row_0, GUbAddr);
+    // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
+    TMOV(acc_ub, g_row_0);
+    // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations
+    // complete before the next Vec instruction begins. Needed because Vec ops
+    // are pipelined and may not finish in order. Think of it as a local
+    // __syncthreads() for the Vec engine only. Much lighter than
+    // set_flag/wait_flag (which sync across different hardware units).
+    pipe_barrier(PIPE_V);
+
+    UbND<float, 1, HTC> s_row_0;
+    TASSIGN(s_row_0, SUbAddr);
+    TMOV(s_row_0, acc_ub);
+    pipe_barrier(PIPE_V);
+
+    // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
+    for (int32_t i = 1; i < valid; ++i) {
+      UbND<float, 1, HTC> g_row_i;
+      TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+      // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
+      // Operates on all HTC elements in parallel (SIMD).
+      TADD(acc_ub, acc_ub, g_row_i);
+      pipe_barrier(PIPE_V);
+
+      UbND<float, 1, HTC> s_row_i;
+      TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+      TMOV(s_row_i, acc_ub);
+      pipe_barrier(PIPE_V);
+    }
+
+    // Zero-fill rows beyond valid (tail padding for downstream kernels)
+    // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
+    // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
+    TEXPANDS(acc_ub, 0.0f);
+    pipe_barrier(PIPE_V);
+    for (int32_t i = valid; i < ChunkSize; ++i) {
+      UbND<float, 1, HTC> s_row_i;
+      TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+      TMOV(s_row_i, acc_ub);
+      pipe_barrier(PIPE_V);
+    }
+
+    // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
+    // ── Synchronization: Vec → MTE3 ───────────────────────────────────
+    // Vec signals MTE3 that computation is done and UB data is ready to
+    // store. MTE3 (DMA store engine) waits for this before reading UB for
+    // TSTORE. Without this sync, MTE3 might read stale/partial data from UB.
+    // Vec → MTE3 sync: ensure Vec writes to UB are visible before DMA
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+    {
+      GmShape ss;
+      ss.shape[3] = valid;
+      ss.shape[4] = NumHeads;
+      GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+      UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid, NumHeads);
+      TASSIGN(s_store, SUbAddr);
+      // TSTORE(gm_tensor, ub_tile): DMA transfer from UB → GM.
+      // Equivalent to: gm_tensor[:valid, :NumHeads] = ub_tile[:valid,
+      // :NumHeads] Async on MTE3 pipe. Must sync (Vec→MTE3) before calling,
+      // and sync (MTE3→Vec) after if reusing the same UB region.
+      TSTORE(gs_gm, s_store);
+    }
+    // ── Synchronization: MTE3 → Vec ───────────────────────────────────
+    // MTE3 signals Vec that the DMA store is complete and UB can be reused.
+    // Vec waits before starting the next iteration's TLOAD into the same UB
+    // region. Without this, the next TLOAD could overwrite data still being
+    // stored. MTE3 → Vec sync: wait for DMA store before reusing UB next iter
+    set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+  }
 }
 
 // ── Device-side kernel entry point ─────────────────────────────────
 // extern "C" __global__ AICORE: marks this as an NPU kernel function
-//   (like __global__ in CUDA). Each AI core runs one instance of this function.
+//   (like __global__ in CUDA). Each AI core runs one instance of this
+//   function.
 // Parameters are passed as uint8_t* (raw bytes) and reinterpret_cast'd to
 // typed pointers — this is the standard NPU kernel calling convention.
 extern "C" __global__ AICORE void chunk_cumsum_fp32(__gm__ uint8_t* g_ptr,
@@ -414,23 +490,17 @@ extern "C" __global__ AICORE void chunk_cumsum_fp32(__gm__ uint8_t* g_ptr,
                                                     __gm__ uint8_t* cu_seqlens,
                                                     int64_t batch_size,
                                                     int64_t seq_len) {
-  cumsum_kernel<GDN_H, GDN_C>(reinterpret_cast<__gm__ float*>(g_ptr),
-                              reinterpret_cast<__gm__ float*>(g_sum_ptr),
-                              reinterpret_cast<__gm__ int32_t*>(cu_seqlens),
-                              batch_size, seq_len);
-}
+#if defined(__DAV_C220_VEC__)
 
-// ── Host-side launcher (called via ACLRT_LAUNCH_KERNEL from the host header)
-// ── call_chunk_cumsum(): CPU function that launches the NPU kernel.
-//   block_dim = number of AI cores to use (like CUDA grid size)
-//   stream = NPU stream for async execution (like CUDA stream)
-//   rtGetC2cCtrlAddr: gets the FFTS control address for cross-core sync
-//   <<<block_dim, nullptr, stream>>>: NPU kernel launch syntax (like CUDA
-//   <<<>>>)
-extern "C" void call_chunk_cumsum(uint32_t block_dim, void* stream,
-                                  uint8_t* g_ptr, uint8_t* g_sum_ptr,
-                                  uint8_t* cu_seqlens, int64_t batch_size,
-                                  int64_t seq_len) {
-  chunk_cumsum_fp32<<<block_dim, nullptr, stream>>>(
-      g_ptr, g_sum_ptr, cu_seqlens, batch_size, seq_len);
+  if (cu_seqlens == nullptr) {
+    cumsum_kernel_static<GDN_H, GDN_C>(
+        reinterpret_cast<__gm__ float*>(g_ptr),
+        reinterpret_cast<__gm__ float*>(g_sum_ptr), batch_size, seq_len);
+  } else {
+    cumsum_kernel_varlen<GDN_H, GDN_C>(
+        reinterpret_cast<__gm__ float*>(g_ptr),
+        reinterpret_cast<__gm__ float*>(g_sum_ptr),
+        reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len);
+  }
+#endif
 }

--- a/csrc/kernel/kernel_chunk_cumsum.cpp
+++ b/csrc/kernel/kernel_chunk_cumsum.cpp
@@ -1,0 +1,436 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+
+// ============================================================================
+// kernel_chunk_cumsum.cpp — Prefix sum of gate values G along time dimension
+//
+// Mathematical operation (per chunk of C tokens, independently per head h):
+//   g_sum[t, h] = Σ_{i=0}^{t} g[i, h]    for t = 0 .. valid-1
+//
+// Input:  g     [total_tokens, H]  float, BSND layout  — raw gate values
+// Output: g_sum [total_tokens, H]  float               — cumulative sums
+//
+// The prefix sum enables downstream kernels to compute exponential decay
+// coefficients:  exp(g_sum[i] - g_sum[j])  gives the cumulative gate
+// from token j to token i within a chunk.
+//
+// Architecture: Vec-only kernel (no Cube/GEMM). Single Vec sub-block.
+// Pipeline: MTE2(load) → Vec(compute) → MTE3(store), serialized per chunk.
+//
+// NPU memory hierarchy used:
+//   GM (Global Memory) → UB (Unified Buffer, on-chip SRAM, Vec-accessible)
+//
+// ─── PTO / NPU Primer for This Kernel ──────────────────────────────────────
+//
+// AI Core: The basic processing unit of an NPU, analogous to a Streaming
+//   Multiprocessor (SM) on a GPU. A single chip has many AI cores, and each
+//   core runs the same kernel code on different data (SPMD model).
+//
+// Memory hierarchy (outer → inner):
+//   GM  (Global Memory) — Off-chip DRAM, like GPU HBM. Large (several GB)
+//       but high latency. All AI cores share GM.
+//   UB  (Unified Buffer) — On-chip SRAM, ~256 KB per AI core. Like GPU
+//       shared memory. Very fast, but small. The Vec engine can only operate
+//       on data that lives in UB, so every tensor must be DMA'd in first.
+//
+// Hardware pipes (execute in parallel, like independent GPU warps):
+//   Vec   — SIMD vector processor. Performs element-wise math (add, mul, etc.)
+//           on data already in UB. Think of it as a wide SIMD ALU.
+//   MTE2  — DMA engine for loads: copies data from GM → UB.
+//   MTE3  — DMA engine for stores: copies data from UB → GM.
+//   Cube  — Matrix engine for GEMMs (not used in this kernel).
+//
+// Synchronization (set_flag / wait_flag):
+//   Because Vec, MTE2, and MTE3 run in parallel on separate hardware, you
+//   must explicitly synchronize them to ensure data is ready:
+//     set_flag(SRC_PIPE, DST_PIPE, event): SRC signals that it is done.
+//     wait_flag(SRC_PIPE, DST_PIPE, event): DST blocks until the signal.
+//   Example: After MTE2 loads data into UB, Vec must wait_flag before reading
+//   it. This is like a fine-grained torch.cuda.synchronize() between pipes.
+//   Events (EVENT_ID0 .. EVENT_ID7) are semaphore indices.
+//
+// ============================================================================
+
+#include "kernel_utils.h"
+
+using namespace pto;
+
+// GDN_H, GDN_C: Compile-time constants injected by the build system.
+//   GDN_H = number of attention heads (e.g., 16)
+//   GDN_C = chunk size in tokens (e.g., 128)
+// Using compile-time constants allows the compiler to optimize tile sizes,
+// unroll loops, and compute UB addresses at compile time.
+#ifndef GDN_H
+#define GDN_H 16
+#endif
+
+#ifndef GDN_C
+#define GDN_C 128
+#endif
+
+// ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
+// UB tile in row-major (ND) layout, used by Vec engine.
+// T=dtype, R×C=static shape, RV×CV=valid region, P=pad value for TLOAD.
+//
+// Think of UbND as: torch.empty((R, C), dtype=T) allocated in on-chip SRAM
+// (UB).
+//   - TileType::Vec  = this tile lives in UB, operated on by the Vec (SIMD)
+//   engine
+//   - BLayout::RowMajor = row-major storage, like C arrays or numpy default
+//   - RV, CV = "valid" region within the R×C buffer (for handling partial/tail
+//   chunks)
+//   - PadValue = what to fill outside the valid region during TLOAD (Zero or
+//   Null)
+//   - 512 = alignment in bytes (hardware requirement for efficient DMA)
+#ifdef __CCE_AICORE__
+template <typename T, int R, int C, int RV = R, int CV = C,
+          pto::PadValue P = pto::PadValue::Null>
+using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor, RV,
+                       CV, pto::SLayout::NoneBox, 512, P>;
+#endif
+
+template <int32_t NumHeads, int32_t ChunkSize>
+AICORE void cumsum_kernel(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
+                          __gm__ int32_t* cu_seqlens, int64_t batch_size,
+                          int64_t seq_len) {
+  // get_block_idx(): Returns this AI core's index (0..block_num-1).
+  //   Like blockIdx.x in CUDA — identifies which core this code runs on.
+  // get_block_num(): Total number of AI cores launched (like gridDim.x in
+  // CUDA). get_subblockid(): Returns 0 or 1 — selects which Vec sub-block
+  // within the core.
+  //   Each AI core has 2 Vec sub-blocks that can run in parallel.
+  auto cid = get_block_idx();
+  auto block_num = get_block_num();
+  auto vid = get_subblockid();
+
+// #if defined(__DAV_C220_VEC__): This block only compiles for the Vec core
+// pass. The bisheng compiler makes 3 passes over the same source file:
+//   Pass 1: __DAV_C220_VEC__  defined → compiles Vec (SIMD) code
+//   Pass 2: __DAV_C220_CUBE__ defined → compiles Cube (matrix) code
+//   Pass 3: neither defined → compiles host (CPU) launcher code
+// Using these guards lets us put Vec, Cube, and host code in one file.
+#if defined(__DAV_C220_VEC__)
+  if (vid != 0) return;
+
+  // set_mask_norm(): Reset Vec mask to normal mode (all lanes active).
+  // set_vector_mask(-1, -1): Enable all SIMD lanes (128 lanes for fp32).
+  //   The -1 sets all 64 bits to 1 in each of the two 64-bit mask registers.
+  //   This is like setting torch's computation to operate on all elements.
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  // HeadTileCols: NumHeads rounded up to 8-element alignment (32B for float)
+  // HTC = NumHeads rounded up to nearest multiple of 8.
+  // Why? The Vec engine processes data in 32-byte granularity.
+  // For float (4 bytes), that's 8 elements per SIMD "word".
+  // Rounding up ensures every row is a whole number of SIMD words,
+  // avoiding partial-lane issues. The extra columns are zero-padded.
+  // Example: NumHeads=16 → HTC=16 (already aligned), NumHeads=13 → HTC=16.
+  constexpr int32_t HTC = ((NumHeads + 7) / 8) * 8;
+  constexpr int32_t BlockBytes =
+      ChunkSize * HTC * static_cast<int32_t>(sizeof(float));
+  constexpr int32_t RowBytes = HTC * static_cast<int32_t>(sizeof(float));
+
+  // ── UB memory layout ──────────────────────────────────────────────────
+  //  [0            .. BlockBytes)     = g input  (ChunkSize × HTC floats)
+  //  [BlockBytes   .. 2*BlockBytes)   = g_sum output
+  //  [2*BlockBytes .. 2*BlockBytes+RowBytes) = row accumulator (1 × HTC)
+  constexpr int32_t GUbAddr = 0;
+  constexpr int32_t SUbAddr = BlockBytes;
+  constexpr int32_t AccUbAddr = BlockBytes * 2;
+
+  // GlobalTensor types for g/g_sum in [total_tokens, NumHeads] layout.
+  // 5D shape with last two dims dynamic; stride encodes row pitch.
+  //
+  // GlobalTensor is a "view" into GM (Global Memory), like torch.as_strided().
+  //   GlobalTensor<dtype, Shape, Stride>(base_ptr, shape)
+  // Shape<1,1,1,DYNAMIC,DYNAMIC> = 5D shape where first 3 dims are 1 (unused),
+  //   last 2 dims are set at runtime (valid rows × NumHeads).
+  // Stride<1,1,1,NumHeads,1> = stride between elements. The 4th stride =
+  // NumHeads
+  //   means consecutive rows in GM are NumHeads elements apart (BSND layout:
+  //   token[t] at offset t*NumHeads, head[h] at offset h within that token).
+  // This is equivalent to:
+  //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads], stride=[NumHeads,
+  //   1])
+  using GmShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
+  using GmStride = Stride<1, 1, 1, NumHeads, 1>;
+  using GmFloat = GlobalTensor<float, GmShape, GmStride>;
+
+  // Pre-assign row accumulator at fixed UB address
+  // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address in
+  // UB. Think of it as: tile = ub_memory[address:address+sizeof(tile)] This
+  // does NOT allocate or move data — it just tells the hardware where the tile
+  // lives. We manually manage UB memory layout (like a memory pool) via
+  // compile-time addresses.
+  UbND<float, 1, HTC> acc_ub;
+  TASSIGN(acc_ub, AccUbAddr);
+
+  int64_t num_seqs = batch_size;
+
+  // ── Fixed-length sequence path (cu_seqlens == nullptr) ────────────────
+  if (cu_seqlens == nullptr) {
+    int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
+    int64_t total_chunks = num_seqs * chunks_per_seq;
+
+    // Work distribution: Each AI core processes chunks in a round-robin
+    // pattern. Core `cid` handles chunks cid, cid+block_num, cid+2*block_num,
+    // ... This is the NPU equivalent of CUDA's grid-stride loop:
+    //   for (int i = blockIdx.x; i < total; i += gridDim.x)
+    for (int64_t gi = static_cast<int64_t>(cid); gi < total_chunks;
+         gi += static_cast<int64_t>(block_num)) {
+      int64_t seq_idx = gi / chunks_per_seq;
+      int64_t local_chunk = gi % chunks_per_seq;
+      int64_t bos = seq_idx * seq_len;
+      int64_t chunk_start = bos + local_chunk * ChunkSize;
+      int64_t remaining = seq_len - local_chunk * ChunkSize;
+      int32_t valid =
+          static_cast<int32_t>(remaining < ChunkSize ? remaining : ChunkSize);
+
+      // ── DMA: load g[chunk_start .. +valid] from GM → UB (MTE2 pipe) ──
+      // Constructs a GlobalTensor view over the g array, loads into UB,
+      // then zero-pads the tail region (rows beyond `valid`, cols beyond
+      // NumHeads up to the 8-aligned HTC) so downstream Vec ops see zeros.
+      {
+        GmShape gs;
+        gs.shape[3] = valid;
+        gs.shape[4] = NumHeads;
+        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+        UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero> g_load(
+            valid, NumHeads);
+        TASSIGN(g_load, GUbAddr);
+        // TLOAD(ub_tile, gm_tensor): DMA transfer from GM → UB.
+        // Equivalent to: ub_tile[:valid, :NumHeads] = gm_tensor[:valid,
+        // :NumHeads] This is an ASYNC operation on the MTE2 pipe — the CPU/Vec
+        // engine can do other work while DMA is in progress. You must call
+        // set_flag/wait_flag before reading the loaded data.
+        TLOAD(g_load, g_gm);
+        if (valid != ChunkSize || NumHeads != HTC) {
+          UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
+          TASSIGN(g_pad, GUbAddr);
+          // TFILLPAD_INPLACE(full_tile, partial_tile): Zero-fills the region
+          // outside the valid area of partial_tile. Equivalent to:
+          //   full_tile[valid:ChunkSize, :] = 0  # zero rows beyond valid
+          //   full_tile[:, NumHeads:HTC] = 0     # zero cols beyond NumHeads
+          //   (alignment padding)
+          // This ensures downstream Vec operations see clean zeros in padded
+          // regions.
+          TFILLPAD_INPLACE(g_pad, g_load);
+        }
+      }
+      // ── Synchronization: MTE2 → Vec ────────────────────────────────────
+      // set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Signal from MTE2 (DMA load
+      //   engine) to Vec (SIMD engine) that the DMA transfer is complete.
+      // wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0): Vec waits here until MTE2
+      //   has set the flag. After this, UB data from TLOAD is safe to read.
+      // Think of it as: torch.cuda.synchronize() but fine-grained per pipe.
+      // EVENT_ID0 is a semaphore index (0-7 available).
+      // MTE2 → Vec sync: wait for DMA load to finish before Vec reads UB
+      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+      // ── Vec compute: prefix sum over rows (all H heads in parallel) ───
+      // Row 0: acc[h] = g[0,h];  g_sum[0,h] = acc[h]
+      UbND<float, 1, HTC> g_row_0;
+      TASSIGN(g_row_0, GUbAddr);
+      // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
+      TMOV(acc_ub, g_row_0);
+      // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations
+      // complete before the next Vec instruction begins. Needed because Vec ops
+      // are pipelined and may not finish in order. Think of it as a local
+      // __syncthreads() for the Vec engine only. Much lighter than
+      // set_flag/wait_flag (which sync across different hardware units).
+      pipe_barrier(PIPE_V);
+
+      UbND<float, 1, HTC> s_row_0;
+      TASSIGN(s_row_0, SUbAddr);
+      TMOV(s_row_0, acc_ub);
+      pipe_barrier(PIPE_V);
+
+      // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
+      for (int32_t i = 1; i < valid; ++i) {
+        UbND<float, 1, HTC> g_row_i;
+        TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+        // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
+        // Operates on all HTC elements in parallel (SIMD).
+        TADD(acc_ub, acc_ub, g_row_i);
+        pipe_barrier(PIPE_V);
+
+        UbND<float, 1, HTC> s_row_i;
+        TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+        TMOV(s_row_i, acc_ub);
+        pipe_barrier(PIPE_V);
+      }
+
+      // Zero-fill rows beyond valid (tail padding for downstream kernels)
+      // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
+      // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
+      TEXPANDS(acc_ub, 0.0f);
+      pipe_barrier(PIPE_V);
+      for (int32_t i = valid; i < ChunkSize; ++i) {
+        UbND<float, 1, HTC> s_row_i;
+        TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+        TMOV(s_row_i, acc_ub);
+        pipe_barrier(PIPE_V);
+      }
+
+      // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
+      // ── Synchronization: Vec → MTE3 ───────────────────────────────────
+      // Vec signals MTE3 that computation is done and UB data is ready to
+      // store. MTE3 (DMA store engine) waits for this before reading UB for
+      // TSTORE. Without this sync, MTE3 might read stale/partial data from UB.
+      // Vec → MTE3 sync: ensure Vec writes to UB are visible before DMA
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+      {
+        GmShape ss;
+        ss.shape[3] = valid;
+        ss.shape[4] = NumHeads;
+        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+        UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid, NumHeads);
+        TASSIGN(s_store, SUbAddr);
+        // TSTORE(gm_tensor, ub_tile): DMA transfer from UB → GM.
+        // Equivalent to: gm_tensor[:valid, :NumHeads] = ub_tile[:valid,
+        // :NumHeads] Async on MTE3 pipe. Must sync (Vec→MTE3) before calling,
+        // and sync (MTE3→Vec) after if reusing the same UB region.
+        TSTORE(gs_gm, s_store);
+      }
+      // ── Synchronization: MTE3 → Vec ───────────────────────────────────
+      // MTE3 signals Vec that the DMA store is complete and UB can be reused.
+      // Vec waits before starting the next iteration's TLOAD into the same UB
+      // region. Without this, the next TLOAD could overwrite data still being
+      // stored. MTE3 → Vec sync: wait for DMA store before reusing UB next iter
+      set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+    }
+  }
+  // ── Variable-length sequence path (cu_seqlens != nullptr) ─────────────
+  else {
+    int64_t gi = 0;
+    for (int64_t si = 0; si < num_seqs; ++si) {
+      int64_t bos = static_cast<int64_t>(cu_seqlens[si]);
+      int64_t eos = static_cast<int64_t>(cu_seqlens[si + 1]);
+      int64_t slen = eos - bos;
+      int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
+
+      for (int64_t c = 0; c < nc; ++c) {
+        if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
+          int64_t chunk_start = bos + c * ChunkSize;
+          int64_t remaining = slen - c * ChunkSize;
+          int32_t valid = static_cast<int32_t>(
+              remaining < ChunkSize ? remaining : ChunkSize);
+
+          // Load g chunk from GM → UB, zero-padded
+          {
+            GmShape gs;
+            gs.shape[3] = valid;
+            gs.shape[4] = NumHeads;
+            GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+            UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero>
+                g_load(valid, NumHeads);
+            TASSIGN(g_load, GUbAddr);
+            TLOAD(g_load, g_gm);
+            if (valid != ChunkSize || NumHeads != HTC) {
+              UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
+              TASSIGN(g_pad, GUbAddr);
+              TFILLPAD_INPLACE(g_pad, g_load);
+            }
+          }
+          set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+          wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+          // Prefix sum: acc = g[0]; g_sum[0] = acc
+          UbND<float, 1, HTC> g_row_0;
+          TASSIGN(g_row_0, GUbAddr);
+          TMOV(acc_ub, g_row_0);
+          pipe_barrier(PIPE_V);
+
+          UbND<float, 1, HTC> s_row_0;
+          TASSIGN(s_row_0, SUbAddr);
+          TMOV(s_row_0, acc_ub);
+          pipe_barrier(PIPE_V);
+
+          // acc += g[i]; g_sum[i] = acc
+          for (int32_t i = 1; i < valid; ++i) {
+            UbND<float, 1, HTC> g_row_i;
+            TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+            TADD(acc_ub, acc_ub, g_row_i);
+            pipe_barrier(PIPE_V);
+
+            UbND<float, 1, HTC> s_row_i;
+            TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+            TMOV(s_row_i, acc_ub);
+            pipe_barrier(PIPE_V);
+          }
+
+          // Zero-fill padding rows
+          TEXPANDS(acc_ub, 0.0f);
+          pipe_barrier(PIPE_V);
+          for (int32_t i = valid; i < ChunkSize; ++i) {
+            UbND<float, 1, HTC> s_row_i;
+            TASSIGN(s_row_i, SUbAddr + i * RowBytes);
+            TMOV(s_row_i, acc_ub);
+            pipe_barrier(PIPE_V);
+          }
+
+          // Store g_sum to GM
+          set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+          wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+          {
+            GmShape ss;
+            ss.shape[3] = valid;
+            ss.shape[4] = NumHeads;
+            GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+            UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid,
+                                                                  NumHeads);
+            TASSIGN(s_store, SUbAddr);
+            TSTORE(gs_gm, s_store);
+          }
+          set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+          wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+        }
+        gi++;
+      }
+    }
+  }
+#endif
+}
+
+// ── Device-side kernel entry point ─────────────────────────────────
+// extern "C" __global__ AICORE: marks this as an NPU kernel function
+//   (like __global__ in CUDA). Each AI core runs one instance of this function.
+// Parameters are passed as uint8_t* (raw bytes) and reinterpret_cast'd to
+// typed pointers — this is the standard NPU kernel calling convention.
+extern "C" __global__ AICORE void chunk_cumsum_fp32(__gm__ uint8_t* g_ptr,
+                                                    __gm__ uint8_t* g_sum_ptr,
+                                                    __gm__ uint8_t* cu_seqlens,
+                                                    int64_t batch_size,
+                                                    int64_t seq_len) {
+  cumsum_kernel<GDN_H, GDN_C>(reinterpret_cast<__gm__ float*>(g_ptr),
+                              reinterpret_cast<__gm__ float*>(g_sum_ptr),
+                              reinterpret_cast<__gm__ int32_t*>(cu_seqlens),
+                              batch_size, seq_len);
+}
+
+// ── Host-side launcher (called via ACLRT_LAUNCH_KERNEL from the host header)
+// ── call_chunk_cumsum(): CPU function that launches the NPU kernel.
+//   block_dim = number of AI cores to use (like CUDA grid size)
+//   stream = NPU stream for async execution (like CUDA stream)
+//   rtGetC2cCtrlAddr: gets the FFTS control address for cross-core sync
+//   <<<block_dim, nullptr, stream>>>: NPU kernel launch syntax (like CUDA
+//   <<<>>>)
+extern "C" void call_chunk_cumsum(uint32_t block_dim, void* stream,
+                                  uint8_t* g_ptr, uint8_t* g_sum_ptr,
+                                  uint8_t* cu_seqlens, int64_t batch_size,
+                                  int64_t seq_len) {
+  chunk_cumsum_fp32<<<block_dim, nullptr, stream>>>(
+      g_ptr, g_sum_ptr, cu_seqlens, batch_size, seq_len);
+}

--- a/tests/test_chunk_cumsum.py
+++ b/tests/test_chunk_cumsum.py
@@ -1,0 +1,239 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# All rights reserved.
+# See LICENSE in the root of the software repository:
+# https://github.com/huawei-csl/pto-kernels/
+# for the full License text.
+# --------------------------------------------------------------------------------
+#
+# Tests for pto_chunk_cumsum — chunked prefix-sum of gate values G along the
+# time dimension, independently per head h:
+#   g_sum[t, h] = Σ_{i=0}^{t} g[i, h]   for t = 0 .. valid-1
+#
+# Reference test cases adapted from:
+# https://github.com/huawei-csl/megagdn-pto/blob/dev/tests/test_single_kernels.py
+# (test_cumsum function)
+
+import random
+
+import pytest
+import torch
+
+from pto_kernels import pto_chunk_cumsum
+
+# Compile-time constants — must match GDN_H and GDN_C baked into the kernel binary.
+GDN_H = 16  # number of attention heads
+GDN_C = 128  # chunk size in tokens
+
+random.seed(42)
+torch.manual_seed(42)
+
+
+# ---------------------------------------------------------------------------
+# CPU float32 reference
+# ---------------------------------------------------------------------------
+
+
+def ref_chunk_cumsum(
+    g: torch.Tensor,
+    chunk_size: int,
+    cu_seqlens=None,
+    batch_size: int = 1,
+    seq_len: int = 0,
+) -> torch.Tensor:
+    """Chunk-local cumulative sum of gate values (CPU float32 reference).
+
+    g : [total_tokens, H] float32
+    returns [total_tokens, H] float32 with the same chunk boundaries as the kernel.
+    """
+    out = torch.zeros_like(g, dtype=torch.float32)
+    gf = g.float()
+    if cu_seqlens is None:
+        for b in range(batch_size):
+            bos = b * seq_len
+            for j in range(0, seq_len, chunk_size):
+                s = bos + j
+                e = min(s + chunk_size, bos + seq_len)
+                out[s:e] = gf[s:e].cumsum(dim=0)
+    else:
+        cu = cu_seqlens.tolist() if hasattr(cu_seqlens, "tolist") else list(cu_seqlens)
+        for i in range(len(cu) - 1):
+            bos, eos = cu[i], cu[i + 1]
+            for j in range(0, eos - bos, chunk_size):
+                s = bos + j
+                e = min(s + chunk_size, eos)
+                out[s:e] = gf[s:e].cumsum(dim=0)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building cu_seqlens
+# ---------------------------------------------------------------------------
+
+
+def _cu_from_seqlens(seqlens: list[int]) -> list[int]:
+    cu = [0]
+    for s in seqlens:
+        cu.append(cu[-1] + s)
+    return cu
+
+
+def _rand_cu_aligned(n_seq: int, total: int, chunk_size: int) -> list[int]:
+    """Random cu_seqlens with all boundaries aligned to chunk_size (seed=42)."""
+    rng = random.Random(42)
+    if n_seq == 1:
+        aligned_total = ((total + chunk_size - 1) // chunk_size) * chunk_size
+        return [0, aligned_total]
+    raw = sorted(rng.sample(range(1, total), n_seq - 1))
+    aligned: list[int] = [0]
+    for v in raw:
+        v_aligned = ((v + chunk_size - 1) // chunk_size) * chunk_size
+        aligned.append(max(v_aligned, aligned[-1] + chunk_size))
+    total_aligned = max(total, aligned[-1] + chunk_size)
+    total_aligned = ((total_aligned + chunk_size - 1) // chunk_size) * chunk_size
+    aligned.append(total_aligned)
+    return aligned
+
+
+# ---------------------------------------------------------------------------
+# Fixed-length sequence tests
+# (reference: TestCase with cu_seqlens_list=None, T in [128,256,385,512,1024])
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("T", [128, 256, 385, 512, 1024])
+@pytest.mark.parametrize("H", [GDN_H])
+def test_chunk_cumsum_fixed_length(T: int, H: int):
+    """Single batch, fixed sequence length T — exercises the cu_seqlens==nullptr path."""
+    torch.manual_seed(42)
+    g_cpu = torch.randn(T, H, dtype=torch.float32)
+    g_npu = g_cpu.npu()
+
+    result = pto_chunk_cumsum(g_npu, batch_size=1, seq_len=T).cpu()
+    torch.npu.synchronize()
+
+    expected = ref_chunk_cumsum(g_cpu, chunk_size=GDN_C, batch_size=1, seq_len=T)
+    torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Variable-length (varlen) sequence tests
+# (reference: seqlens lists from build_test_cases())
+# ---------------------------------------------------------------------------
+
+_VARLEN_SEQLENS = [
+    [128],
+    [256],
+    [384],
+    [512],
+    [256, 256],
+    [128, 256],
+    [384, 128],
+    [128, 128, 128],
+    [256, 128, 384],
+]
+
+
+@pytest.mark.parametrize(
+    "seqlens",
+    _VARLEN_SEQLENS,
+    ids=[str(s) for s in _VARLEN_SEQLENS],
+)
+@pytest.mark.parametrize("H", [GDN_H])
+def test_chunk_cumsum_varlen(seqlens: list[int], H: int):
+    """Variable-length sequences via cu_seqlens — exercises the non-null cu_seqlens path."""
+    cu_list = _cu_from_seqlens(seqlens)
+    total_tokens = cu_list[-1]
+    N_seq = len(seqlens)
+
+    torch.manual_seed(42)
+    g_cpu = torch.randn(total_tokens, H, dtype=torch.float32)
+    g_npu = g_cpu.npu()
+    cu_npu = torch.tensor(cu_list, dtype=torch.int32).npu()
+
+    result = pto_chunk_cumsum(
+        g_npu, batch_size=N_seq, seq_len=0, cu_seqlens=cu_npu
+    ).cpu()
+    torch.npu.synchronize()
+
+    expected = ref_chunk_cumsum(g_cpu, chunk_size=GDN_C, cu_seqlens=cu_list)
+    torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Boundary-heavy varlen tests
+# (reference: seqlens with 1-token seqs and values crossing chunk boundaries)
+# ---------------------------------------------------------------------------
+
+_BOUNDARY_SEQLENS = [
+    [1, 63, 64, 65, 127, 128, 129, 447],
+    [1, 17, 31, 32, 33, 95, 127, 128, 129, 191, 192, 193, 367],
+]
+
+
+@pytest.mark.parametrize(
+    "seqlens",
+    _BOUNDARY_SEQLENS,
+    ids=[f"boundary_{i}" for i in range(len(_BOUNDARY_SEQLENS))],
+)
+@pytest.mark.parametrize("H", [GDN_H])
+def test_chunk_cumsum_boundary(seqlens: list[int], H: int):
+    """Sequences with lengths that straddle chunk boundaries and include single-token seqs."""
+    cu_list = _cu_from_seqlens(seqlens)
+    total_tokens = cu_list[-1]
+    N_seq = len(seqlens)
+
+    torch.manual_seed(42)
+    g_cpu = torch.randn(total_tokens, H, dtype=torch.float32)
+    g_npu = g_cpu.npu()
+    cu_npu = torch.tensor(cu_list, dtype=torch.int32).npu()
+
+    result = pto_chunk_cumsum(
+        g_npu, batch_size=N_seq, seq_len=0, cu_seqlens=cu_npu
+    ).cpu()
+    torch.npu.synchronize()
+
+    expected = ref_chunk_cumsum(g_cpu, chunk_size=GDN_C, cu_seqlens=cu_list)
+    torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Randomly-generated chunk-aligned varlen tests (seed=42, mirrors reference)
+# ---------------------------------------------------------------------------
+
+_RAND_VARLEN_PARAMS = [
+    (3, 768),
+    (7, 1792),
+    (10, 2560),
+]
+_RAND_VARLEN_CU = [
+    _rand_cu_aligned(n, total, GDN_C) for n, total in _RAND_VARLEN_PARAMS
+]
+
+
+@pytest.mark.parametrize(
+    "cu_list",
+    _RAND_VARLEN_CU,
+    ids=[
+        f"rand_{n}seq_T{cu[-1]}"
+        for (n, _), cu in zip(_RAND_VARLEN_PARAMS, _RAND_VARLEN_CU)
+    ],
+)
+@pytest.mark.parametrize("H", [GDN_H])
+def test_chunk_cumsum_random_varlen(cu_list: list[int], H: int):
+    """Randomly-generated chunk-aligned varlen shapes (seed=42, 3/7/10 sequences)."""
+    total_tokens = cu_list[-1]
+    N_seq = len(cu_list) - 1
+
+    torch.manual_seed(42)
+    g_cpu = torch.randn(total_tokens, H, dtype=torch.float32)
+    g_npu = g_cpu.npu()
+    cu_npu = torch.tensor(cu_list, dtype=torch.int32).npu()
+
+    result = pto_chunk_cumsum(
+        g_npu, batch_size=N_seq, seq_len=0, cu_seqlens=cu_npu
+    ).cpu()
+    torch.npu.synchronize()
+
+    expected = ref_chunk_cumsum(g_cpu, chunk_size=GDN_C, cu_seqlens=cu_list)
+    torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-4)

--- a/tests/test_chunk_cumsum.py
+++ b/tests/test_chunk_cumsum.py
@@ -29,11 +29,6 @@ random.seed(42)
 torch.manual_seed(42)
 
 
-# ---------------------------------------------------------------------------
-# CPU float32 reference
-# ---------------------------------------------------------------------------
-
-
 def ref_chunk_cumsum(
     g: torch.Tensor,
     chunk_size: int,
@@ -99,8 +94,6 @@ def _rand_cu_aligned(n_seq: int, total: int, chunk_size: int) -> list[int]:
 # Fixed-length sequence tests
 # (reference: TestCase with cu_seqlens_list=None, T in [128,256,385,512,1024])
 # ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("T", [128, 256, 385, 512, 1024])
 @pytest.mark.parametrize("H", [GDN_H])
 def test_chunk_cumsum_fixed_length(T: int, H: int):
@@ -120,7 +113,6 @@ def test_chunk_cumsum_fixed_length(T: int, H: int):
 # Variable-length (varlen) sequence tests
 # (reference: seqlens lists from build_test_cases())
 # ---------------------------------------------------------------------------
-
 _VARLEN_SEQLENS = [
     [128],
     [256],


### PR DESCRIPTION
Back-porting of this https://github.com/huawei-csl/megagdn-pto/blob/dev/kernels/pto/chunk_cumsum.cpp into PyTorch infra.


Unit test pass, I had to drop the ffts methods from the mega-kernel.

```
pytest tests/test_chunk_cumsum.py 
=================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.10.12, pytest-8.3.4, pluggy-1.6.0
rootdir: /home/zouzias/github-repos/pto-kernels
configfile: pytest.ini
collected 19 items                                                                                                                                                                                                        

tests/test_chunk_cumsum.py ...................                                                                                                                                                                      [100%]

=================================================================================================== 19 passed in 0.07s ====================================================================================================
```