### PR TITLE
add PTO kernel testing skills

### DIFF
--- a/.skills/testing-pto-kernels/.gitignore
+++ b/.skills/testing-pto-kernels/.gitignore
@@ -1,0 +1,9 @@
+# Build artifacts from bisheng / pybind extension builds
+reference/**/build/
+
+# Simulator and profiler outputs (msprof, cannsim, benchmark CSV)
+reference/**/outputs/
+
+# Python cache
+**/__pycache__/
+*.py[cod]

--- a/.skills/testing-pto-kernels/SKILL.md
+++ b/.skills/testing-pto-kernels/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: testing-pto-kernels
+description: Compile, run, and verify PTO kernels on Ascend A2A3/910B and A5/950. Use when developing PTO-ISA kernels, testing jit_cpp examples, choosing bisheng flags, launching through ctypes/pybind/ACL, or running CA-model simulator smoke tests.
+---
+
+# PTO Kernel Testing
+
+## Definition Of Done
+
+For PTO kernel work, code is not done until all applicable checks are complete:
+
+1. Compile the kernel with `bisheng` for the target architecture and core type.
+2. Launch it through a real runtime path: ctypes/JIT, pybind/AOT, ACL C++, or CA-model simulator.
+3. Compare against a PyTorch, NumPy, or golden-file reference.
+4. Record exact commands and results in the relevant `README.md` or verification log.
+
+Do not ask the user to compile or verify new kernel code manually as a substitute for running it yourself. If hardware, simulator libraries, or Python packages are missing, record the exact blocker.
+
+## Reference Layout
+
+Use `reference/` as the self-contained testing cookbook:
+
+```text
+reference/
+  third_party/pto-isa/
+  static_single_core/a2a3/
+  static_single_core/a5/
+  dynamic_multi_core/a2a3/
+  dynamic_multi_core/a5/
+  inference_integration/
+  training_integration/
+```
+
+Keep the A2A3 and A5 demo directories structurally similar, but do not assume every directory supports every launch path. Real-device versus CA-model is a launch mode, not a directory name.
+
+| Directory | Main purpose | Verified launch paths |
+| --- | --- | --- |
+| `static_single_core/a2a3` | Minimal fixed-shape A2A3 syntax | ctypes, pybind, ACL host, `msprof` CA model |
+| `static_single_core/a5` | Minimal fixed-shape A5 + CA model | ctypes under `msprof`, pybind (+ pip package), `matmul_add` mix, linked `runtime_camodel`, `cannsim` |
+| `dynamic_multi_core/a2a3` | Production-style A2A3 iteration | ctypes, pybind, mix, benchmark, `msprof` CA model |
+| `dynamic_multi_core/a5` | A5 CA-model dynamic smoke | ctypes under `msprof`, pybind, `cannsim`, mix |
+
+Read these first:
+
+- `reference/README.md` for the map of verified examples.
+- `reference/launch-methods.md` for ctypes, pybind, ACL C++, `msprof`, `cannsim`, and `-lruntime_camodel`.
+- `reference/synchronization-and-architecture.md` for A2A3/A5 differences and mix-kernel sync pitfalls.
+- `reference/verification-log.md` for commands that were actually run.
+
+## Prerequisites
+
+Before compiling or running examples:
+
+```bash
+source /usr/local/Ascend/cann-9.0.0/bin/setenv.bash
+```
+
+Confirm `bisheng`, `python3`, `torch_npu`, and either an idle NPU or the A5 simulator are available. Pick an idle device with `npu-smi info`; avoid running multiple kernel tests on the same `NPU_DEVICE` concurrently. If a kernel fault leaves an NPU in a persistent `507035`/vector-core error state, switch to a clean idle NPU or reset the device before trusting follow-up failures.
+
+**`cannsim` teardown quirk:** On A5, `cannsim record` may segfault during process cleanup after the kernel has already written valid PASS JSON. Use `./run_sim.sh cannsim` (not a raw `cannsim` one-liner) unless you manually check the JSON output. A `[FAILED] cannsim record execution failed!` message with PASS JSON on disk is a known false alarm.
+
+Run the bundled smoke script after skill changes:
+
+```bash
+cd reference && NPU_DEVICE=npu:0 ./reproduce.sh
+```
+
+## Static vs Dynamic Examples
+
+`static_single_core/*` follows the PTO-ISA official unit-test style: one small kernel, fixed testcase shapes, direct `<<<1, nullptr, stream>>>` launch, and deterministic host/golden smoke. This style is good for learning instruction syntax and validating minimal ACL/C++ simulator linking, but each new shape usually requires recompiling or instantiating another kernel template.
+
+`dynamic_multi_core/*` follows the local jit-style production-development demos: Python compiles and loads the kernel, chooses `block_dim`, allocates torch tensors, passes `torch.npu.current_stream()._as_parameter_`, and sweeps runtime shapes. Production kernels should support the dimensions that vary in real workloads to avoid recompiling for every input shape.
+
+For LLM inference kernels, `batch` and `sequence` dimensions are usually dynamic because they change across requests and batches. `hidden_dim` or the innermost channel dimension is usually static because fixed tiling reduces scalar calculation overhead and keeps vector/cube tile shapes simple. `num_head` can be dynamic or static depending on the model family and deployment shape contract.
+
+When reporting a delivered kernel, explicitly state which dimensions are dynamic and which are compile-time/static, for example: `B` and `S` dynamic, `H` static, `D=128` static.
+
+## Architecture And Compiler Flags
+
+Only A2A3 and A5 are in scope.
+
+| Target | Device names | PTO dirs | Vector flag | Cube flag | Mix flag | Memory macro |
+| --- | --- | --- | --- | --- | --- | --- |
+| A2A3 / DAV_2201 | `Ascend910B*`, `Ascend910_93` | `a2a3` | `--cce-aicore-arch=dav-c220-vec` | `--cce-aicore-arch=dav-c220-cube` | `--cce-aicore-arch=dav-c220` | `-DMEMORY_BASE` |
+| A5 / DAV_3510 | `Ascend950PR`, `Ascend950DT` | `a5` | `--cce-aicore-arch=dav-c310-vec` | `--cce-aicore-arch=dav-c310-cube` | `--cce-aicore-arch=dav-c310` | `-DREGISTER_BASE` |
+
+Prefer runtime queries over hardcoded core counts or buffer sizes. Typical 910B2 has 24 Cube cores and 48 Vector cores; A5 variants differ by SKU.
+
+## PTO-ISA Header Choice
+
+Use CANN headers for stable APIs:
+
+```bash
+export PTO_LIB_PATH="${ASCEND_HOME_PATH}"
+```
+
+Use a pinned checkout or submodule when samples need new APIs (`TALLOC`, newer A5 helpers, etc.):
+
+```bash
+export PTO_LIB_PATH=/path/to/pto-isa
+```
+
+The actual include is usually `-I${PTO_LIB_PATH}/include`; if `pto/pto-inst.hpp` lives directly under the path, use `-I${PTO_LIB_PATH}`.
+
+## Launch Methods
+
+- ctypes/JIT: default for fast iteration. Build one `.so`, load with `ctypes.CDLL`, pass NPU tensor pointers and stream pointer.
+- pybind/CMake AOT: preferred for formal deliverables and packaged ops. Follow the local pybind sample before claiming an AOT path works.
+- ACL C++: use `main.cpp` when testing host-side ACL allocation, memcpy, stream, and `-lruntime_camodel` linking.
+- CA model: use `msprof op simulator`, `cannsim record`, or direct `-lruntime_camodel` linking when the target device is not physically available, or when simulator/profiling traces are needed. If a real target NPU is available, prefer real-device execution for correctness and performance acceptance; use CA model as an additional debugging/profiling tool, not as a required substitute.
+
+Launch syntax is `kernel<<<block_dim, nullptr, stream>>>(...)`. For persistent NPU kernels, set `block_dim` to the physical core count or a small bounded value, then loop over data inside the kernel. Do not scale `block_dim` with tensor size like CUDA grid launches.
+
+UB capacity is a per-core hardware limit and is independent of total `block_dim`; query it for the current target instead of hardcoding it. On CANN installs with platform config files, use `grep -A 18 "AICoreSpec" "${ASCEND_HOME_PATH}/arm64-linux/data/platform_config/<soc>.ini"` and check `ub_size`; production code should prefer runtime platform APIs when available. For every A2A3 vector kernel compiled with `dav-c220-vec`, initialize vector mask state before vector instructions:
+
+```cpp
+set_mask_norm();
+set_vector_mask(-1, -1);
+```
+
+This mask state affects vector instruction semantics broadly; missing it can surface as misleading runtime faults such as UB out-of-bounds, even when the real bug is not UB capacity or `block_idx` partitioning. Always document each kernel's verified `block_dim` policy in its example README or delivery report.
+
+## Device Discovery
+
+Use one or more:
+
+```bash
+npu-smi info
+```
+
+```python
+import acl
+print(acl.get_soc_name())
+```
+
+```python
+import torch, torch_npu
+props = torch.npu.get_device_properties(torch.npu.current_device())
+print(props.name, props.cube_core_num, props.vector_core_num)
+```
+
+On some A5 systems `npu-smi` can fail while ACL and torch-npu still work; treat ACL/torch-npu success as stronger evidence.
+
+Choose the launch method from the detected target:
+
+| Host SOC | A2A3 kernels | A5 kernels |
+| --- | --- | --- |
+| Ascend910B (A2A3 hardware) | `direct` — ctypes, pybind, ACL on real NPU | **CA model only** — `msprof`, `cannsim`, or `-lruntime_camodel`. **Never** `./run_sim.sh direct` or bare ctypes on the 910B NPU (`507035` vector-core fault). |
+| Ascend950 (A5 hardware) | CA model or cross-compile only | `direct` on real NPU; CA model for traces |
+| No matching NPU | CA model for the target arch with tiny inputs | Same |
+| CPU-only + CANN simulator | CA-model paths only | Same |
+
+- Real A2A3 / Ascend910B available: compile with A2A3 flags and run on NPU through ctypes, pybind, or ACL C++.
+- Real A5 / Ascend950 available: compile with A5 flags and run on the A5 NPU directly; use CA model only when detailed simulator traces are useful.
+- No matching target NPU available: compile for the target architecture and use CA model (`msprof op simulator`, `cannsim`, or `-lruntime_camodel`) with tiny inputs.
+- CPU-only host with CANN simulator installed: use only CA-model paths; do not claim real-device performance.
+
+### CA-Model Timeouts
+
+Set `MSPROF_TIMEOUT` when simulator runs are slow. Suggested values: A5 vector/matmul smoke 60 s; A5 mix kernels 120–180 s; A2A3 static/dynamic smoke 120 s. See `reference/launch-methods.md` for the full table.
+
+## Correctness Rules
+
+### Numeric Thresholds
+
+Use the same relative/absolute tolerances as `torch.testing.assert_close` defaults. Reference runners call `pto_demo_utils.assert_close`, which applies:
+
+| dtype | rtol | atol |
+| --- | --- | --- |
+| `float16` | `1e-3` | `1e-5` |
+| `bfloat16` | `1.6e-2` | `1e-5` |
+| `float32` | `1.3e-6` | `1e-5` |
+
+Relax thresholds only when a kernel has a documented numerical reason (for example accumulation order or a known approximation). Relax gradually and record the exception in the deliverable README or verification log. Do not use `atol=1e-2`; loose absolute tolerance can mark incorrect kernels as PASS.
+
+For outlier-heavy kernels, also report RMSE relative to output magnitude and R²; do not rely on max-error alone.
+
+### Shape Coverage
+
+Test edge shapes: one tile, two tiles, non-multiple tails, and at least one shape with more logical work than physical cores.
+
+### Repeat Policy (Real Device vs Simulator)
+
+| Mode | Repeats | Rationale |
+| --- | --- | --- |
+| Real NPU (`direct`, ctypes, pybind, ACL) | **5** (default) | Surfaces nondeterministic sync bugs such as missing `set_flag`/`wait_flag` pairs or `pipe_barrier` |
+| CA model (`msprof`, `cannsim`, `-lruntime_camodel`) | **1** | Simulation is deterministic and slow |
+
+`run_sim.sh` sets `PTO_SIMULATOR=1` so reference runners skip extra repeats under CA model. Override with `PTO_DEVICE_REPEATS=<n>` when needed.
+
+### Hang Detection
+
+Sync bugs can deadlock instead of producing a numeric mismatch. Use **two** timeout layers:
+
+| Layer | What it guards | Default | Override |
+| --- | --- | --- | --- |
+| Whole process | compile, launch, driver/runtime stalls, hangs before `synchronize()` | **60 s** real device; **1800 s** simulator | `PTO_PROCESS_TIMEOUT_S` via `reference/run_with_timeout.sh` |
+| Per-sync | `torch.npu.synchronize()` deadlocks inside a repeat loop | **60 s** | `PTO_SYNC_TIMEOUT_S` via `pto_demo_utils.synchronize_device()` |
+
+A per-sync timeout alone is not sufficient: a bad kernel can hang during `bisheng` compile, ACL allocation, the launch call itself, or process teardown without ever reaching `synchronize()`. Wrap every real-device runner invocation with `run_with_timeout.sh` (or an equivalent whole-process `timeout`); `reproduce.sh` and `run_sim.sh direct` do this by default. CA-model paths launched through `msprof op simulator --timeout=...` already inherit a process-level bound from msprof. Raise `PTO_PROCESS_TIMEOUT_S` for large on-device benchmarks or long mix-kernel sweeps; the 60 s device default targets smoke-sized runs.
+
+After a whole-process timeout, treat the NPU as suspect; switch `NPU_DEVICE` or reset the device before the next smoke.
+
+## Performance Rules
+
+- Time kernels with `torch.npu.Event(enable_timing=True)` and synchronize the end event.
+- Cache `stream_ptr` outside inner timing loops and repeated launch helpers. Querying `torch.npu.current_stream()` / `.npu_stream` / `._as_parameter_` has visible runtime cost; get it once per benchmark shape or request path and pass the cached value into every launch.
+- Include warmup and repeated trials; report median or distribution, not one sample.
+- Flush or perturb cache when measuring HBM bandwidth-sensitive kernels.
+- Compare against simple roofline expectations; results far above roofline usually mean the timer missed async work or cache reuse is being counted as bandwidth.
+- Use `reference/dynamic_multi_core/a2a3/benchmark.py` as the concrete timing template: it shows warmup, repeats, `torch.npu.Event`, end-event synchronization, median/stdev reporting, optional cache flush, and CSV output.
+
+## Current TODOs
+
+- ACLgraph launch examples are not verified in this environment. Add a local demo only after it compiles and runs.
+- End-to-end vLLM/SGLang/TorchTitan/autograd integration is intentionally left for a future environment with those packages installed.

--- a/.skills/testing-pto-kernels/reference/.gitignore
+++ b/.skills/testing-pto-kernels/reference/.gitignore
@@ -1,0 +1,32 @@
+# Local build products
+build/
+*.so
+*.o
+*.a
+*.core
+core
+core.*
+__pycache__/
+*.egg-info/
+.eggs/
+dist/
+
+# Simulator/profiling outputs
+outputs/
+OPPROF_*/
+cannsim_*/
+log_ca/
+camodel_log/
+extra-info/
+*.dump
+core*_summary_log
+profile_*_log*.toml
+profile_network_log*.toml
+route_table.txt
+rtb_debug.txt
+instr.bin
+.soc-version
+
+# Benchmark outputs
+*.csv
+*.png

--- a/.skills/testing-pto-kernels/reference/README.md
+++ b/.skills/testing-pto-kernels/reference/README.md
@@ -1,0 +1,106 @@
+# PTO Kernel Testing Reference
+
+This directory is the reproducible companion to `../SKILL.md`. Future agents should be able to test kernels from here without reading the raw material repositories.
+
+## Reproduction Checklist
+
+Source CANN, pick an idle NPU, then run the path that matches your host.
+
+```bash
+source /usr/local/Ascend/cann-9.0.0/bin/setenv.bash
+npu-smi info   # pick an idle NPU_DEVICE
+export NPU_DEVICE=npu:0
+```
+
+### Ascend910B host (A2A3 hardware + A5 simulator)
+
+```bash
+cd reference
+
+# Full sequential smoke (recommended after skill changes)
+./reproduce.sh
+
+# Or run individually:
+cd dynamic_multi_core/a2a3
+NPU_DEVICE=npu:0 python3 run_kernel_ctypes.py --kernel all --n 4096 --m 128
+NPU_DEVICE=npu:0 python3 run_mix_ctypes.py --kernel all --rounds 1
+
+cd ../../static_single_core/a2a3
+MSPROF_SOC_VERSION=Ascend910B2 MSPROF_TIMEOUT=120 ./run_sim.sh msprof --kernel all
+
+cd ../../dynamic_multi_core/a5
+MSPROF_TIMEOUT=60 ./run_sim.sh msprof --n 128 --block-dim 8
+./run_sim.sh cannsim --output-json outputs/add_cannsim.json
+
+cd ../../static_single_core/a5
+MSPROF_TIMEOUT=60 ./run_sim.sh msprof --kernel all
+./run_sim.sh linked
+```
+
+Do **not** run A5 `./run_sim.sh direct` on a 910B host. A5 kernels require CA-model launch there.
+
+### Ascend950 host (A5 hardware)
+
+```bash
+cd reference/dynamic_multi_core/a5
+NPU_DEVICE=npu:0 python3 run_kernel_ctypes.py --n 128 --block-dim 8
+```
+
+Use `msprof` or `cannsim` when simulator traces are needed.
+
+### CPU-only host (CANN simulator installed)
+
+Use only `./run_sim.sh msprof`, `./run_sim.sh cannsim`, or `./run_sim.sh linked` paths. Do not claim real-device performance.
+
+Record commands and results in `verification-log.md` or a dated report under the skill root.
+
+Real-device runners should be launched through `run_with_timeout.sh` (default **60 s** on NPU, **1800 s** under `PTO_SIMULATOR=1`; override with `PTO_PROCESS_TIMEOUT_S`) in addition to the in-process `PTO_SYNC_TIMEOUT_S` guard around `torch.npu.synchronize()`.
+
+## Directory Map
+
+```text
+reference/
+  pto_demo_utils.py                 # shared helpers: assert_close thresholds, device repeats, sync timeout
+  reproduce.sh                      # sequential smoke script
+  run_with_timeout.sh               # whole-process timeout wrapper for runners
+  third_party/pto-isa/              # how to find or pin PTO-ISA headers
+  static_single_core/a2a3/          # PTO-ISA ST-style A2A3 samples
+  static_single_core/a5/            # PTO-ISA ST-style A5 samples
+  dynamic_multi_core/a2a3/          # jit_cpp-style A2A3 samples
+  dynamic_multi_core/a5/            # jit_cpp-style A5 samples
+  inference_integration/            # TODO stub
+  training_integration/             # TODO stub
+  launch-methods.md
+  synchronization-and-architecture.md
+  verification-log.md
+```
+
+Generated `build/` and `outputs/` directories are ephemeral; see `../.gitignore`.
+
+## Which Example To Use
+
+| Goal | Start here | Why |
+| --- | --- | --- |
+| Learn minimal PTO instruction/test anatomy | `static_single_core/a2a3` or `static_single_core/a5` | Fixed-shape `tadd`-style kernels are easiest to read. |
+| Iterate on real A2A3 hardware | `dynamic_multi_core/a2a3` | ctypes/JIT launch on torch-npu is the fastest loop. |
+| Test A2A3 kernels without a free NPU | `static_single_core/a2a3` or `dynamic_multi_core/a2a3` | `./run_sim.sh msprof` with `Ascend910B2` simulator. |
+| Test A5 behavior on this A2A3 host | `dynamic_multi_core/a5` | Uses A5 flags plus CPU CA-model launch modes. |
+| Compare launch methods | `launch-methods.md` | ctypes, pybind, ACL C++, `msprof`, `cannsim`, and `-lruntime_camodel`. |
+| Work on Cube/Vector sync | `synchronization-and-architecture.md` | A2A3 raw FFTS and A5 direct `TMOV`/`TINSERT` patterns. |
+
+## Quick Decision Flow
+
+1. Learning PTO syntax? Start with `static_single_core/a2a3`.
+2. Iterating on an A2A3 production-style kernel? Use `dynamic_multi_core/a2a3`.
+3. Preparing a deliverable Python package? Use pybind/CMake, especially the pip package under `static_single_core/a5/pybind_package`.
+4. Need A2A3 CA-model smoke without tying up a real NPU? Use `static_single_core/a2a3` or `dynamic_multi_core/a2a3` with `./run_sim.sh msprof`.
+5. Need A5 behavior without A5 hardware? Use `dynamic_multi_core/a5` or `static_single_core/a5` with `msprof op simulator`.
+6. Debugging Cube/Vector handoff? Read `synchronization-and-architecture.md`, then run the mix examples one direction at a time.
+
+## Verification Policy
+
+Only commands that were actually executed are listed in `verification-log.md`. A command shown in a demo `README.md` is a runnable target; if it was not runnable in this environment, the blocker must be recorded.
+
+Keep simulator inputs tiny. A5 CA-model runs are much slower than real NPU runs; start with vector smoke shapes such as SiLU `T=128`, SwiGLU `batch=1,input_n=256`, stream `num_iters=4`, and mix `rounds=1`.
+
+Run examples sequentially on a chosen `NPU_DEVICE`. Parallel tests on the same NPU can leave the device in a persistent fault state after a bad kernel launch.

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/README.md
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/README.md
@@ -1,0 +1,79 @@
+# Dynamic Multi-Core A2A3
+
+This directory is the real-device A2A3 jit-style demo. It keeps the file roles used across the reference tree while using small smoke shapes.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `add.cpp` | Vector kernel: `y = x + z`, dynamic length, persistent `block_dim`. |
+| `matmul.cpp` | Cube kernel role, operation name `simple_matmul`: `C[M,128] = A[M,128] @ B[128,128]`. |
+| `matmul_add.cpp`, `add_matmul.cpp` | Self-contained A2A3 mix kernels for C2V and V2C handoff. |
+| `compile.sh` | Raw `bisheng` command for `add` or `matmul`. |
+| `run_kernel_ctypes.py` | Main verified quick-test path. |
+| `pybind.cpp`, `run_kernel_pybind.py` | Local pybind launcher alternative to `run_kernel_ctypes.py`; public C++ API takes `at::Tensor`. |
+| `run_mix_ctypes.py` | Reduced `rounds=1` smoke for both mix directions. |
+| `benchmark.py` | Concrete timing example using NPU events, warmup, repeats, median, optional cache flush, and CSV output. |
+| `run_sim.sh` | `msprof` or `direct` wrapper for A2A3 CA-model / real-device ctypes smoke. |
+
+## Real-Device Smoke
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+NPU_DEVICE=npu:0 python3 run_kernel_ctypes.py --kernel all --n 4096 --m 128
+```
+
+## A2A3 CA-Model Smoke
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+./run_sim.sh msprof --kernel add --n 4096
+./run_sim.sh msprof --kernel all --n 4096 --m 128
+```
+
+Default simulator SOC is `Ascend910B2`. Override with `MSPROF_SOC_VERSION` when your CANN install uses a different A2A3 simulator package.
+
+`./run_sim.sh direct` runs the same ctypes path on a real Ascend910B device.
+
+Expected output:
+
+```text
+PASS add n=4096 block_dim=48
+PASS simple_matmul m=128 ...
+```
+
+## Pybind AOT Smoke
+
+This directory includes `pybind.cpp` as a local importable launcher module that calls the same device libraries as the ctypes path.
+
+```bash
+NPU_DEVICE=npu:0 python3 run_kernel_pybind.py --kernel all --n 4096 --m 128
+```
+
+Use pybind for deliverables; use ctypes for fast local kernel iteration.
+
+## Benchmark Smoke
+
+```bash
+NPU_DEVICE=npu:0 python3 benchmark.py --kernel all --warmup 2 --repeats 5 \
+  --add-sizes 4096 65536 --matmul-m 128 1024 \
+  --csv outputs/benchmark_smoke.csv
+```
+
+Use `--flush-cache` for bandwidth-sensitive measurements where L2 reuse would otherwise dominate.
+
+## Block Dim Policy
+
+- `add.cpp` is a pure vector kernel compiled with `dav-c220-vec`. It initializes A2A3 vector mask state with `set_mask_norm(); set_vector_mask(-1, -1);`, uses only `block_idx`, and is verified with `block_dim=vector_core_num=48` on 910B2.
+- `matmul.cpp` is a cube kernel and uses `block_dim=min(cube_core_num, M / 128)`.
+- Mix kernels use `get_subblockid()` for Cube/Vector pairing and use Cube-oriented `block_dim`.
+
+## Mix Kernels
+
+Run the local mix smoke:
+
+```bash
+NPU_DEVICE=npu:0 python3 run_mix_ctypes.py --kernel all --rounds 1
+```
+
+For first smoke or CA-model attempts, reduce to one seed and `rounds=1`.

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add.cpp
@@ -1,0 +1,73 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr uint32_t UB_BYTES_PER_TILE = 32 * 1024;
+constexpr uint32_t ELEMS_PER_TILE = UB_BYTES_PER_TILE / sizeof(half);
+constexpr unsigned X_UB = 0x00000;
+constexpr unsigned Z_UB = 0x08000;
+constexpr unsigned Y_UB = 0x10000;
+
+template <typename T>
+AICORE void run_add(__gm__ T *y, __gm__ T *x, __gm__ T *z, uint32_t n) {
+#if defined(__DAV_C220_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  const uint32_t num_cores = block_num;
+  const uint32_t core = block_idx;
+  const uint32_t per_core = (n + num_cores - 1) / num_cores;
+  const uint32_t base = core * per_core;
+  if (base >= n) return;
+
+  uint32_t remaining_core = per_core;
+  if (base + remaining_core > n) remaining_core = n - base;
+
+  using Shape = pto::Shape<1, 1, 1, 1, ELEMS_PER_TILE>;
+  using Stride = pto::Stride<1, 1, 1, 1, 1>;
+  using Global = pto::GlobalTensor<T, Shape, Stride>;
+  using VecTile =
+      Tile<TileType::Vec, T, 1, ELEMS_PER_TILE, BLayout::RowMajor, -1, -1>;
+
+  Global x_g(x + base);
+  Global z_g(z + base);
+  Global y_g(y + base);
+  VecTile x_t, z_t, y_t;
+  TASSIGN(x_t, X_UB);
+  TASSIGN(z_t, Z_UB);
+  TASSIGN(y_t, Y_UB);
+
+  for (uint32_t done = 0; done < remaining_core; done += ELEMS_PER_TILE) {
+    const uint32_t cols =
+        (remaining_core - done > ELEMS_PER_TILE) ? ELEMS_PER_TILE
+                                                 : (remaining_core - done);
+    VecTile x_cur(1, cols), z_cur(1, cols), y_cur(1, cols);
+    TASSIGN(x_cur, X_UB);
+    TASSIGN(z_cur, Z_UB);
+    TASSIGN(y_cur, Y_UB);
+    TASSIGN(x_g, x + base + done);
+    TASSIGN(z_g, z + base + done);
+    TASSIGN(y_g, y + base + done);
+
+    TLOAD(x_cur, x_g);
+    TLOAD(z_cur, z_g);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(y_cur, x_cur, z_cur);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(y_g, y_cur);
+    pipe_barrier(PIPE_ALL);
+  }
+#endif
+}
+
+extern "C" __global__ AICORE void add_kernel(__gm__ void *y, __gm__ void *x,
+                                             __gm__ void *z, uint32_t n) {
+  run_add<half>((__gm__ half *)y, (__gm__ half *)x, (__gm__ half *)z, n);
+}
+
+extern "C" void call_add(uint32_t block_dim, void *stream, uint8_t *y,
+                         uint8_t *x, uint8_t *z, uint32_t n) {
+  add_kernel<<<block_dim, nullptr, stream>>>(y, x, z, n);
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add.cpp
@@ -38,9 +38,9 @@ AICORE void run_add(__gm__ T *y, __gm__ T *x, __gm__ T *z, uint32_t n) {
   TASSIGN(y_t, Y_UB);
 
   for (uint32_t done = 0; done < remaining_core; done += ELEMS_PER_TILE) {
-    const uint32_t cols =
-        (remaining_core - done > ELEMS_PER_TILE) ? ELEMS_PER_TILE
-                                                 : (remaining_core - done);
+    const uint32_t cols = (remaining_core - done > ELEMS_PER_TILE)
+                              ? ELEMS_PER_TILE
+                              : (remaining_core - done);
     VecTile x_cur(1, cols), z_cur(1, cols), y_cur(1, cols);
     TASSIGN(x_cur, X_UB);
     TASSIGN(z_cur, Z_UB);

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add_matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add_matmul.cpp
@@ -1,0 +1,289 @@
+// =============================================================================
+// add_matmul_v2c.cpp — Persistent kernel: C = (A + B) @ D (Vector-to-Cube stream)
+//
+// Computes  C[batch, T] = (A[batch, T] + B[batch, T]) @ D[T, T]  (fp16)
+// where T = TILE_SIZE = 128.
+//
+// Algorithm (persistent kernel, block_dim == num_cube_cores):
+//
+//   Vec sub-block (vid ∈ {0,1}), each owns HALF_TILE = T/2 rows — PRODUCER:
+//     For each round r:
+//       Load A slice → a_ub, Load B slice → b_ub  (prefetch, no dependency on ws)
+//       TADD  a_ub = a_ub + b_ub
+//       if r > 0: WaitCrossFlag(FLAG_C2V)  ← Cube freed workspace (loaded into L1)
+//       TSTORE a_ub → workspace[cid*T + vid*HT :]  (MTE3 pipe)
+//       SetCrossFlag FLAG_V2C              ← signal Cube: workspace tile written
+//
+//   Cube core (cid) — CONSUMER:
+//     Load D → d_l1 → d_l0  (once, constant weight)
+//     For each round r:
+//       WaitCrossFlag(FLAG_V2C)            ← Vec wrote workspace
+//       TLOAD workspace[cid*T:] → ab_l1   (MTE2 pipe)
+//       SetCrossFlag<PIPE_MTE2> FLAG_C2V   ← signal Vec: workspace freed (right
+//                                            after TLOAD, while GEMM is in flight)
+//       TMOV ab_l1 → ab_l0  (L1 → L0A)
+//       TMATMUL c_l0 = ab_l0 @ d_l0       (GEMM: (A+B) @ D)
+//       TSTORE c_l0 → C[row_c:]            (fp32 → fp16, FIX pipe)
+//
+// Cross-core flags (FFTS):
+//   FLAG_V2C = 1  Vec → Cube: workspace tile written, safe to read
+//   FLAG_C2V = 0  Cube → Vec: workspace tile consumed into L1, safe to overwrite
+//
+// Cube signals Vec via PIPE_MTE2 immediately after the workspace TLOAD — this
+// lets Vec begin loading A and B and computing A+B for the next round while Cube
+// is still executing the GEMM on the already-captured a_l1 data.
+//
+// Memory budget (per core):
+//   L1 (512 KB): d_l1 (32 KB at 0) + ab_l1 (32 KB at 32 KB) = 64 KB used
+//   L0A ( 64 KB): ab_l0 (32 KB at 0)
+//   L0B ( 64 KB): d_l0  (32 KB at 0)
+//   L0C (128 KB): c_l0  (64 KB at 0)
+//   UB  (192 KB): a_ub  (16 KB at 0) + b_ub (16 KB at 16 KB) = 32 KB used
+// =============================================================================
+
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+
+using namespace pto;
+
+// ── Tile dimensions ────────────────────────────────────────────────────────────
+#define TILE_SIZE 128   // rows/cols per matrix tile
+#define HALF_TILE  64   // rows per Vec sub-block  (TILE_SIZE / VEC_NUM)
+#define VEC_NUM     2   // Vec sub-blocks per Cube core
+
+#ifdef __CCE_AICORE__
+
+// ── On-chip buffer base addresses (bytes) ─────────────────────────────────────
+// L1: d_l1 (constant weight D) followed by ab_l1 (workspace: A+B result)
+constexpr uint32_t L1_D_OFFSET  = 0u;
+constexpr uint32_t L1_AB_OFFSET = TILE_SIZE * TILE_SIZE * sizeof(half);  // 32 KB
+
+// L0A / L0B / L0C are independent scratchpads; each starts at byte 0
+constexpr uint32_t L0_OFFSET = 0u;
+
+// UB: a_ub and b_ub for the Vec add
+constexpr uint32_t UB_A_OFFSET = 0u;
+constexpr uint32_t UB_B_OFFSET = HALF_TILE * TILE_SIZE * sizeof(half);   // 16 KB
+
+// ── Cross-core FFTS flags ──────────────────────────────────────────────────────
+constexpr int32_t FLAG_C2V = 0;  // Cube → Vec: workspace slot consumed into L1
+constexpr int32_t FLAG_V2C = 1;  // Vec → Cube: workspace tile written to GM
+
+// ── Tile type aliases ──────────────────────────────────────────────────────────
+// L1 tile — NZ (ColMajor/RowMajor) layout required by the Cube engine
+using TileL1 = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE,
+                    BLayout::ColMajor, TILE_SIZE, TILE_SIZE,
+                    SLayout::RowMajor, 512, PadValue::Zero>;
+
+// L0 tiles — one per independent Cube scratchpad
+using TileL0A = TileLeft<half,  TILE_SIZE, TILE_SIZE>;
+using TileL0B = TileRight<half, TILE_SIZE, TILE_SIZE>;
+using TileL0C = TileAcc<float,  TILE_SIZE, TILE_SIZE>;  // fp32 accumulator
+
+// UB Vec tile — row-major, HALF_TILE rows × TILE_SIZE cols, fp16
+using TileVecUB = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE,
+                       BLayout::RowMajor, HALF_TILE, TILE_SIZE,
+                       SLayout::NoneBox, 512, PadValue::Null>;
+
+// GlobalTensor aliases — contiguous 2D row-major in GM
+using TileGlobal =
+    GlobalTensor<half,
+                 TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
+
+using HalfTileGlobal =
+    GlobalTensor<half,
+                 TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
+
+// ── Cross-core sync helpers ────────────────────────────────────────────────────
+template <pipe_t Pipe>
+AICORE inline void SetCrossFlag(int32_t flag) {
+    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+}
+
+AICORE inline void WaitCrossFlag(int32_t flag) {
+    wait_flag_dev(flag);
+}
+
+// ── Intra-pipe sync helpers ────────────────────────────────────────────────────
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void SetFlag(uint32_t id) {
+    set_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void WaitFlag(uint32_t id) {
+    wait_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+// ── Kernel implementation ──────────────────────────────────────────────────────
+AICORE void run_add_matmul_v2c(
+    __gm__ half    *A,          // [batch, TILE_SIZE]              input
+    __gm__ half    *B,          // [batch, TILE_SIZE]              input
+    __gm__ half    *C,          // [batch, TILE_SIZE]              output
+    __gm__ half    *D,          // [TILE_SIZE, TILE_SIZE]          weight (constant)
+    __gm__ half    *workspace,  // [num_cores*TILE_SIZE, TILE_SIZE] V2C buffer
+    int64_t         batch,
+    uint64_t        ffts_addr)
+{
+    const int32_t cid       = static_cast<int32_t>(get_block_idx());   // Cube core id
+    const int32_t vid       = static_cast<int32_t>(get_subblockid());  // Vec sub-block: 0 or 1
+    const int32_t num_cores = static_cast<int32_t>(block_num);         // launched Cube cores
+
+    set_ffts_base_addr(ffts_addr);
+
+    const int32_t wave_rows  = num_cores * TILE_SIZE;
+    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+
+    // ── Allocate on-chip buffers ───────────────────────────────────────────────
+    TileL1  d_l1, ab_l1;
+    TASSIGN(d_l1,  L1_D_OFFSET);
+    TASSIGN(ab_l1, L1_AB_OFFSET);
+
+    TileL0A ab_l0;
+    TileL0B d_l0;
+    TileL0C c_l0;
+    TASSIGN(ab_l0, L0_OFFSET);
+    TASSIGN(d_l0,  L0_OFFSET);
+    TASSIGN(c_l0,  L0_OFFSET);
+
+    TileVecUB a_ub, b_ub;
+    TASSIGN(a_ub, UB_A_OFFSET);
+    TASSIGN(b_ub, UB_B_OFFSET);
+
+    // ── Cube core: GEMM ───────────────────────────────────────────────────────
+#if defined(__DAV_C220_CUBE__)
+
+    // Load the constant weight D once — reused for every round.
+    TileGlobal d_global(D);
+    TLOAD(d_l1, d_global);
+    SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    TMOV(d_l0, d_l1);                   // L1 → L0B (MTE1 pipe)
+    SetFlag<PIPE_MTE1, PIPE_M>(0);
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+
+        // Wait for both Vec sub-blocks to write their halves of the workspace tile.
+        WaitCrossFlag(FLAG_V2C);
+
+        // Load workspace (A+B sum) from GM → ab_l1  (MTE2 pipe).
+        TileGlobal ws_in(workspace + cid * TILE_SIZE * TILE_SIZE);
+        TLOAD(ab_l1, ws_in);
+
+        // Signal Vec immediately after workspace TLOAD (via MTE2): the workspace slot
+        // is now captured in L1, Vec can overwrite it for the next round.
+        // This fires in the MTE2 pipe right after the preceding TLOAD — the GEMM and
+        // C store (MTE1, M, FIX pipes) run concurrently with Vec's next A+B load.
+        SetCrossFlag<PIPE_MTE2>(FLAG_C2V);
+
+        // Sync MTE2 → MTE1: wait for TLOAD to finish before TMOV reads L1.
+        SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+        WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+
+        TMOV(ab_l0, ab_l1);             // L1 → L0A  (MTE1 pipe)
+        SetFlag<PIPE_MTE1, PIPE_M>(0);
+        WaitFlag<PIPE_MTE1, PIPE_M>(0); // M pipe waits for ab_l0 to be ready
+
+        // GEMM: c_l0 = (A+B) @ D  (initialises c_l0)
+        TMATMUL(c_l0, ab_l0, d_l0);
+        SetFlag<PIPE_M, PIPE_FIX>(0);
+        WaitFlag<PIPE_M, PIPE_FIX>(0);  // M→FIX: c_l0 ready for TSTORE
+
+        // Store result (fp32 → fp16) to global memory C.
+        TileGlobal c_global(C + row_c * TILE_SIZE);
+        TSTORE(c_global, c_l0);
+        // Drain FIX pipe before the loop back-edge (or kernel exit on the last
+        // round): the next TMATMUL writes c_l0, so FIX must finish reading it.
+        // Back-to-back benchmark invocations would otherwise trigger an L0C
+        // read/write conflict (same pattern that raw_flag matmul_add_c2v avoids
+        // with its pipe_barrier before SetCrossFlag).
+        pipe_barrier(PIPE_ALL);
+    }
+    // pipe_barrier(PIPE_ALL) inside the loop already drained the last round.
+
+#endif  // __DAV_C220_CUBE__
+
+    // ── Vec sub-block: element-wise add + store to workspace ──────────────────
+#if defined(__DAV_C220_VEC__)
+
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+
+    // This sub-block's fixed workspace row offset (constant across rounds).
+    const int32_t ws_row = cid * TILE_SIZE + vid * HALF_TILE;
+
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+
+        // Load A and B slices — independent of the workspace handshake; prefetch
+        // them while Cube may still be draining the previous round's workspace.
+        HalfTileGlobal a_global(A + row_v * TILE_SIZE);
+        TLOAD(a_ub, a_global);
+
+        HalfTileGlobal b_global(B + row_v * TILE_SIZE);
+        TLOAD(b_ub, b_global);
+
+        pipe_barrier(PIPE_ALL);  // MTE2→V: both TLOADs done before TADD
+
+        // Compute element-wise sum: a_ub = A + B
+        TADD(a_ub, a_ub, b_ub);
+        pipe_barrier(PIPE_ALL);  // V→MTE3: TADD done before TSTORE
+
+        // Wait for Cube to signal that it has loaded the previous workspace tile
+        // into L1 (slot is free to overwrite). Round 0: no previous tile, skip.
+        if (r > 0) {
+            WaitCrossFlag(FLAG_C2V);
+            pipe_barrier(PIPE_ALL);
+        }
+
+        // Write (A+B) sum to the workspace slot for this sub-block.
+        HalfTileGlobal ws_out(workspace + ws_row * TILE_SIZE);
+        TSTORE(ws_out, a_ub);
+        pipe_barrier(PIPE_ALL);  // MTE3: TSTORE complete before SetCrossFlag
+
+        // Signal Cube: workspace tile is fully written, safe to read.
+        SetCrossFlag<PIPE_MTE3>(FLAG_V2C);
+    }
+
+#endif  // __DAV_C220_VEC__
+}
+
+#endif  // __CCE_AICORE__
+
+// ── Kernel entry point ─────────────────────────────────────────────────────────
+extern "C" __global__ AICORE void add_matmul_v2c_kernel(
+    __gm__ uint8_t *A,
+    __gm__ uint8_t *B,
+    __gm__ uint8_t *C,
+    __gm__ uint8_t *D,
+    __gm__ uint8_t *workspace,
+    int64_t         batch,
+    uint64_t        ffts_addr)
+{
+    run_add_matmul_v2c(
+        reinterpret_cast<__gm__ half *>(A),
+        reinterpret_cast<__gm__ half *>(B),
+        reinterpret_cast<__gm__ half *>(C),
+        reinterpret_cast<__gm__ half *>(D),
+        reinterpret_cast<__gm__ half *>(workspace),
+        batch, ffts_addr);
+}
+
+// ── Host-side launcher (called from Python via ctypes) ─────────────────────────
+extern "C" void call(uint32_t block_dim, void *stream,
+                     uint8_t *A, uint8_t *B, uint8_t *C,
+                     uint8_t *D, uint8_t *workspace, int64_t batch)
+{
+    uint32_t ffts_len  = 0;
+    uint64_t ffts_addr = 0;
+    rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
+    add_matmul_v2c_kernel<<<block_dim, nullptr, stream>>>(
+        A, B, C, D, workspace, batch, ffts_addr);
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add_matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/add_matmul.cpp
@@ -1,5 +1,6 @@
 // =============================================================================
-// add_matmul_v2c.cpp — Persistent kernel: C = (A + B) @ D (Vector-to-Cube stream)
+// add_matmul_v2c.cpp — Persistent kernel: C = (A + B) @ D (Vector-to-Cube
+// stream)
 //
 // Computes  C[batch, T] = (A[batch, T] + B[batch, T]) @ D[T, T]  (fp16)
 // where T = TILE_SIZE = 128.
@@ -8,11 +9,11 @@
 //
 //   Vec sub-block (vid ∈ {0,1}), each owns HALF_TILE = T/2 rows — PRODUCER:
 //     For each round r:
-//       Load A slice → a_ub, Load B slice → b_ub  (prefetch, no dependency on ws)
-//       TADD  a_ub = a_ub + b_ub
-//       if r > 0: WaitCrossFlag(FLAG_C2V)  ← Cube freed workspace (loaded into L1)
-//       TSTORE a_ub → workspace[cid*T + vid*HT :]  (MTE3 pipe)
-//       SetCrossFlag FLAG_V2C              ← signal Cube: workspace tile written
+//       Load A slice → a_ub, Load B slice → b_ub  (prefetch, no dependency on
+//       ws) TADD  a_ub = a_ub + b_ub if r > 0: WaitCrossFlag(FLAG_C2V)  ← Cube
+//       freed workspace (loaded into L1) TSTORE a_ub → workspace[cid*T + vid*HT
+//       :]  (MTE3 pipe) SetCrossFlag FLAG_V2C              ← signal Cube:
+//       workspace tile written
 //
 //   Cube core (cid) — CONSUMER:
 //     Load D → d_l1 → d_l0  (once, constant weight)
@@ -20,18 +21,20 @@
 //       WaitCrossFlag(FLAG_V2C)            ← Vec wrote workspace
 //       TLOAD workspace[cid*T:] → ab_l1   (MTE2 pipe)
 //       SetCrossFlag<PIPE_MTE2> FLAG_C2V   ← signal Vec: workspace freed (right
-//                                            after TLOAD, while GEMM is in flight)
+//                                            after TLOAD, while GEMM is in
+//                                            flight)
 //       TMOV ab_l1 → ab_l0  (L1 → L0A)
 //       TMATMUL c_l0 = ab_l0 @ d_l0       (GEMM: (A+B) @ D)
 //       TSTORE c_l0 → C[row_c:]            (fp32 → fp16, FIX pipe)
 //
 // Cross-core flags (FFTS):
 //   FLAG_V2C = 1  Vec → Cube: workspace tile written, safe to read
-//   FLAG_C2V = 0  Cube → Vec: workspace tile consumed into L1, safe to overwrite
+//   FLAG_C2V = 0  Cube → Vec: workspace tile consumed into L1, safe to
+//   overwrite
 //
 // Cube signals Vec via PIPE_MTE2 immediately after the workspace TLOAD — this
-// lets Vec begin loading A and B and computing A+B for the next round while Cube
-// is still executing the GEMM on the already-captured a_l1 data.
+// lets Vec begin loading A and B and computing A+B for the next round while
+// Cube is still executing the GEMM on the already-captured a_l1 data.
 //
 // Memory budget (per core):
 //   L1 (512 KB): d_l1 (32 KB at 0) + ab_l1 (32 KB at 32 KB) = 64 KB used
@@ -41,249 +44,247 @@
 //   UB  (192 KB): a_ub  (16 KB at 0) + b_ub (16 KB at 16 KB) = 32 KB used
 // =============================================================================
 
-#include <pto/pto-inst.hpp>
-#include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+
+#include <pto/pto-inst.hpp>
+
+#include "acl/acl.h"
 
 using namespace pto;
 
-// ── Tile dimensions ────────────────────────────────────────────────────────────
-#define TILE_SIZE 128   // rows/cols per matrix tile
-#define HALF_TILE  64   // rows per Vec sub-block  (TILE_SIZE / VEC_NUM)
-#define VEC_NUM     2   // Vec sub-blocks per Cube core
+// ── Tile dimensions
+// ────────────────────────────────────────────────────────────
+#define TILE_SIZE 128  // rows/cols per matrix tile
+#define HALF_TILE 64   // rows per Vec sub-block  (TILE_SIZE / VEC_NUM)
+#define VEC_NUM 2      // Vec sub-blocks per Cube core
 
 #ifdef __CCE_AICORE__
 
-// ── On-chip buffer base addresses (bytes) ─────────────────────────────────────
-// L1: d_l1 (constant weight D) followed by ab_l1 (workspace: A+B result)
-constexpr uint32_t L1_D_OFFSET  = 0u;
-constexpr uint32_t L1_AB_OFFSET = TILE_SIZE * TILE_SIZE * sizeof(half);  // 32 KB
+// ── On-chip buffer base addresses (bytes)
+// ───────────────────────────────────── L1: d_l1 (constant weight D) followed
+// by ab_l1 (workspace: A+B result)
+constexpr uint32_t L1_D_OFFSET = 0u;
+constexpr uint32_t L1_AB_OFFSET =
+    TILE_SIZE * TILE_SIZE * sizeof(half);  // 32 KB
 
 // L0A / L0B / L0C are independent scratchpads; each starts at byte 0
 constexpr uint32_t L0_OFFSET = 0u;
 
 // UB: a_ub and b_ub for the Vec add
 constexpr uint32_t UB_A_OFFSET = 0u;
-constexpr uint32_t UB_B_OFFSET = HALF_TILE * TILE_SIZE * sizeof(half);   // 16 KB
+constexpr uint32_t UB_B_OFFSET = HALF_TILE * TILE_SIZE * sizeof(half);  // 16 KB
 
-// ── Cross-core FFTS flags ──────────────────────────────────────────────────────
+// ── Cross-core FFTS flags
+// ──────────────────────────────────────────────────────
 constexpr int32_t FLAG_C2V = 0;  // Cube → Vec: workspace slot consumed into L1
 constexpr int32_t FLAG_V2C = 1;  // Vec → Cube: workspace tile written to GM
 
-// ── Tile type aliases ──────────────────────────────────────────────────────────
-// L1 tile — NZ (ColMajor/RowMajor) layout required by the Cube engine
-using TileL1 = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE,
-                    BLayout::ColMajor, TILE_SIZE, TILE_SIZE,
-                    SLayout::RowMajor, 512, PadValue::Zero>;
+// ── Tile type aliases
+// ────────────────────────────────────────────────────────── L1 tile — NZ
+// (ColMajor/RowMajor) layout required by the Cube engine
+using TileL1 =
+    Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::ColMajor,
+         TILE_SIZE, TILE_SIZE, SLayout::RowMajor, 512, PadValue::Zero>;
 
 // L0 tiles — one per independent Cube scratchpad
-using TileL0A = TileLeft<half,  TILE_SIZE, TILE_SIZE>;
+using TileL0A = TileLeft<half, TILE_SIZE, TILE_SIZE>;
 using TileL0B = TileRight<half, TILE_SIZE, TILE_SIZE>;
-using TileL0C = TileAcc<float,  TILE_SIZE, TILE_SIZE>;  // fp32 accumulator
+using TileL0C = TileAcc<float, TILE_SIZE, TILE_SIZE>;  // fp32 accumulator
 
 // UB Vec tile — row-major, HALF_TILE rows × TILE_SIZE cols, fp16
-using TileVecUB = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE,
-                       BLayout::RowMajor, HALF_TILE, TILE_SIZE,
-                       SLayout::NoneBox, 512, PadValue::Null>;
+using TileVecUB =
+    Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::RowMajor,
+         HALF_TILE, TILE_SIZE, SLayout::NoneBox, 512, PadValue::Null>;
 
 // GlobalTensor aliases — contiguous 2D row-major in GM
 using TileGlobal =
-    GlobalTensor<half,
-                 TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+    GlobalTensor<half, TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
                  BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
                  Layout::ND>;
 
 using HalfTileGlobal =
-    GlobalTensor<half,
-                 TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+    GlobalTensor<half, TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
                  BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
                  Layout::ND>;
 
-// ── Cross-core sync helpers ────────────────────────────────────────────────────
+// ── Cross-core sync helpers
+// ────────────────────────────────────────────────────
 template <pipe_t Pipe>
 AICORE inline void SetCrossFlag(int32_t flag) {
-    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+  ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
 }
 
-AICORE inline void WaitCrossFlag(int32_t flag) {
-    wait_flag_dev(flag);
-}
+AICORE inline void WaitCrossFlag(int32_t flag) { wait_flag_dev(flag); }
 
-// ── Intra-pipe sync helpers ────────────────────────────────────────────────────
+// ── Intra-pipe sync helpers
+// ────────────────────────────────────────────────────
 template <pipe_t Src, pipe_t Dst>
 AICORE inline void SetFlag(uint32_t id) {
-    set_flag(Src, Dst, static_cast<event_t>(id));
+  set_flag(Src, Dst, static_cast<event_t>(id));
 }
 
 template <pipe_t Src, pipe_t Dst>
 AICORE inline void WaitFlag(uint32_t id) {
-    wait_flag(Src, Dst, static_cast<event_t>(id));
+  wait_flag(Src, Dst, static_cast<event_t>(id));
 }
 
-// ── Kernel implementation ──────────────────────────────────────────────────────
+// ── Kernel implementation
+// ──────────────────────────────────────────────────────
 AICORE void run_add_matmul_v2c(
-    __gm__ half    *A,          // [batch, TILE_SIZE]              input
-    __gm__ half    *B,          // [batch, TILE_SIZE]              input
-    __gm__ half    *C,          // [batch, TILE_SIZE]              output
-    __gm__ half    *D,          // [TILE_SIZE, TILE_SIZE]          weight (constant)
-    __gm__ half    *workspace,  // [num_cores*TILE_SIZE, TILE_SIZE] V2C buffer
-    int64_t         batch,
-    uint64_t        ffts_addr)
-{
-    const int32_t cid       = static_cast<int32_t>(get_block_idx());   // Cube core id
-    const int32_t vid       = static_cast<int32_t>(get_subblockid());  // Vec sub-block: 0 or 1
-    const int32_t num_cores = static_cast<int32_t>(block_num);         // launched Cube cores
+    __gm__ half *A,  // [batch, TILE_SIZE]              input
+    __gm__ half *B,  // [batch, TILE_SIZE]              input
+    __gm__ half *C,  // [batch, TILE_SIZE]              output
+    __gm__ half *D,  // [TILE_SIZE, TILE_SIZE]          weight (constant)
+    __gm__ half *workspace,  // [num_cores*TILE_SIZE, TILE_SIZE] V2C buffer
+    int64_t batch, uint64_t ffts_addr) {
+  const int32_t cid = static_cast<int32_t>(get_block_idx());  // Cube core id
+  const int32_t vid =
+      static_cast<int32_t>(get_subblockid());  // Vec sub-block: 0 or 1
+  const int32_t num_cores =
+      static_cast<int32_t>(block_num);  // launched Cube cores
 
-    set_ffts_base_addr(ffts_addr);
+  set_ffts_base_addr(ffts_addr);
 
-    const int32_t wave_rows  = num_cores * TILE_SIZE;
-    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+  const int32_t wave_rows = num_cores * TILE_SIZE;
+  const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
 
-    // ── Allocate on-chip buffers ───────────────────────────────────────────────
-    TileL1  d_l1, ab_l1;
-    TASSIGN(d_l1,  L1_D_OFFSET);
-    TASSIGN(ab_l1, L1_AB_OFFSET);
+  // ── Allocate on-chip buffers ───────────────────────────────────────────────
+  TileL1 d_l1, ab_l1;
+  TASSIGN(d_l1, L1_D_OFFSET);
+  TASSIGN(ab_l1, L1_AB_OFFSET);
 
-    TileL0A ab_l0;
-    TileL0B d_l0;
-    TileL0C c_l0;
-    TASSIGN(ab_l0, L0_OFFSET);
-    TASSIGN(d_l0,  L0_OFFSET);
-    TASSIGN(c_l0,  L0_OFFSET);
+  TileL0A ab_l0;
+  TileL0B d_l0;
+  TileL0C c_l0;
+  TASSIGN(ab_l0, L0_OFFSET);
+  TASSIGN(d_l0, L0_OFFSET);
+  TASSIGN(c_l0, L0_OFFSET);
 
-    TileVecUB a_ub, b_ub;
-    TASSIGN(a_ub, UB_A_OFFSET);
-    TASSIGN(b_ub, UB_B_OFFSET);
+  TileVecUB a_ub, b_ub;
+  TASSIGN(a_ub, UB_A_OFFSET);
+  TASSIGN(b_ub, UB_B_OFFSET);
 
-    // ── Cube core: GEMM ───────────────────────────────────────────────────────
+  // ── Cube core: GEMM ───────────────────────────────────────────────────────
 #if defined(__DAV_C220_CUBE__)
 
-    // Load the constant weight D once — reused for every round.
-    TileGlobal d_global(D);
-    TLOAD(d_l1, d_global);
+  // Load the constant weight D once — reused for every round.
+  TileGlobal d_global(D);
+  TLOAD(d_l1, d_global);
+  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(d_l0, d_l1);  // L1 → L0B (MTE1 pipe)
+  SetFlag<PIPE_MTE1, PIPE_M>(0);
+  WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+
+    // Wait for both Vec sub-blocks to write their halves of the workspace tile.
+    WaitCrossFlag(FLAG_V2C);
+
+    // Load workspace (A+B sum) from GM → ab_l1  (MTE2 pipe).
+    TileGlobal ws_in(workspace + cid * TILE_SIZE * TILE_SIZE);
+    TLOAD(ab_l1, ws_in);
+
+    // Signal Vec immediately after workspace TLOAD (via MTE2): the workspace
+    // slot is now captured in L1, Vec can overwrite it for the next round. This
+    // fires in the MTE2 pipe right after the preceding TLOAD — the GEMM and C
+    // store (MTE1, M, FIX pipes) run concurrently with Vec's next A+B load.
+    SetCrossFlag<PIPE_MTE2>(FLAG_C2V);
+
+    // Sync MTE2 → MTE1: wait for TLOAD to finish before TMOV reads L1.
     SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
     WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-    TMOV(d_l0, d_l1);                   // L1 → L0B (MTE1 pipe)
+
+    TMOV(ab_l0, ab_l1);  // L1 → L0A  (MTE1 pipe)
     SetFlag<PIPE_MTE1, PIPE_M>(0);
-    WaitFlag<PIPE_MTE1, PIPE_M>(0);
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);  // M pipe waits for ab_l0 to be ready
 
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+    // GEMM: c_l0 = (A+B) @ D  (initialises c_l0)
+    TMATMUL(c_l0, ab_l0, d_l0);
+    SetFlag<PIPE_M, PIPE_FIX>(0);
+    WaitFlag<PIPE_M, PIPE_FIX>(0);  // M→FIX: c_l0 ready for TSTORE
 
-        // Wait for both Vec sub-blocks to write their halves of the workspace tile.
-        WaitCrossFlag(FLAG_V2C);
-
-        // Load workspace (A+B sum) from GM → ab_l1  (MTE2 pipe).
-        TileGlobal ws_in(workspace + cid * TILE_SIZE * TILE_SIZE);
-        TLOAD(ab_l1, ws_in);
-
-        // Signal Vec immediately after workspace TLOAD (via MTE2): the workspace slot
-        // is now captured in L1, Vec can overwrite it for the next round.
-        // This fires in the MTE2 pipe right after the preceding TLOAD — the GEMM and
-        // C store (MTE1, M, FIX pipes) run concurrently with Vec's next A+B load.
-        SetCrossFlag<PIPE_MTE2>(FLAG_C2V);
-
-        // Sync MTE2 → MTE1: wait for TLOAD to finish before TMOV reads L1.
-        SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
-        WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-
-        TMOV(ab_l0, ab_l1);             // L1 → L0A  (MTE1 pipe)
-        SetFlag<PIPE_MTE1, PIPE_M>(0);
-        WaitFlag<PIPE_MTE1, PIPE_M>(0); // M pipe waits for ab_l0 to be ready
-
-        // GEMM: c_l0 = (A+B) @ D  (initialises c_l0)
-        TMATMUL(c_l0, ab_l0, d_l0);
-        SetFlag<PIPE_M, PIPE_FIX>(0);
-        WaitFlag<PIPE_M, PIPE_FIX>(0);  // M→FIX: c_l0 ready for TSTORE
-
-        // Store result (fp32 → fp16) to global memory C.
-        TileGlobal c_global(C + row_c * TILE_SIZE);
-        TSTORE(c_global, c_l0);
-        // Drain FIX pipe before the loop back-edge (or kernel exit on the last
-        // round): the next TMATMUL writes c_l0, so FIX must finish reading it.
-        // Back-to-back benchmark invocations would otherwise trigger an L0C
-        // read/write conflict (same pattern that raw_flag matmul_add_c2v avoids
-        // with its pipe_barrier before SetCrossFlag).
-        pipe_barrier(PIPE_ALL);
-    }
-    // pipe_barrier(PIPE_ALL) inside the loop already drained the last round.
+    // Store result (fp32 → fp16) to global memory C.
+    TileGlobal c_global(C + row_c * TILE_SIZE);
+    TSTORE(c_global, c_l0);
+    // Drain FIX pipe before the loop back-edge (or kernel exit on the last
+    // round): the next TMATMUL writes c_l0, so FIX must finish reading it.
+    // Back-to-back benchmark invocations would otherwise trigger an L0C
+    // read/write conflict (same pattern that raw_flag matmul_add_c2v avoids
+    // with its pipe_barrier before SetCrossFlag).
+    pipe_barrier(PIPE_ALL);
+  }
+  // pipe_barrier(PIPE_ALL) inside the loop already drained the last round.
 
 #endif  // __DAV_C220_CUBE__
 
-    // ── Vec sub-block: element-wise add + store to workspace ──────────────────
+  // ── Vec sub-block: element-wise add + store to workspace ──────────────────
 #if defined(__DAV_C220_VEC__)
 
-    set_mask_norm();
-    set_vector_mask(-1, -1);
+  set_mask_norm();
+  set_vector_mask(-1, -1);
 
-    // This sub-block's fixed workspace row offset (constant across rounds).
-    const int32_t ws_row = cid * TILE_SIZE + vid * HALF_TILE;
+  // This sub-block's fixed workspace row offset (constant across rounds).
+  const int32_t ws_row = cid * TILE_SIZE + vid * HALF_TILE;
 
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
 
-        // Load A and B slices — independent of the workspace handshake; prefetch
-        // them while Cube may still be draining the previous round's workspace.
-        HalfTileGlobal a_global(A + row_v * TILE_SIZE);
-        TLOAD(a_ub, a_global);
+    // Load A and B slices — independent of the workspace handshake; prefetch
+    // them while Cube may still be draining the previous round's workspace.
+    HalfTileGlobal a_global(A + row_v * TILE_SIZE);
+    TLOAD(a_ub, a_global);
 
-        HalfTileGlobal b_global(B + row_v * TILE_SIZE);
-        TLOAD(b_ub, b_global);
+    HalfTileGlobal b_global(B + row_v * TILE_SIZE);
+    TLOAD(b_ub, b_global);
 
-        pipe_barrier(PIPE_ALL);  // MTE2→V: both TLOADs done before TADD
+    pipe_barrier(PIPE_ALL);  // MTE2→V: both TLOADs done before TADD
 
-        // Compute element-wise sum: a_ub = A + B
-        TADD(a_ub, a_ub, b_ub);
-        pipe_barrier(PIPE_ALL);  // V→MTE3: TADD done before TSTORE
+    // Compute element-wise sum: a_ub = A + B
+    TADD(a_ub, a_ub, b_ub);
+    pipe_barrier(PIPE_ALL);  // V→MTE3: TADD done before TSTORE
 
-        // Wait for Cube to signal that it has loaded the previous workspace tile
-        // into L1 (slot is free to overwrite). Round 0: no previous tile, skip.
-        if (r > 0) {
-            WaitCrossFlag(FLAG_C2V);
-            pipe_barrier(PIPE_ALL);
-        }
-
-        // Write (A+B) sum to the workspace slot for this sub-block.
-        HalfTileGlobal ws_out(workspace + ws_row * TILE_SIZE);
-        TSTORE(ws_out, a_ub);
-        pipe_barrier(PIPE_ALL);  // MTE3: TSTORE complete before SetCrossFlag
-
-        // Signal Cube: workspace tile is fully written, safe to read.
-        SetCrossFlag<PIPE_MTE3>(FLAG_V2C);
+    // Wait for Cube to signal that it has loaded the previous workspace tile
+    // into L1 (slot is free to overwrite). Round 0: no previous tile, skip.
+    if (r > 0) {
+      WaitCrossFlag(FLAG_C2V);
+      pipe_barrier(PIPE_ALL);
     }
+
+    // Write (A+B) sum to the workspace slot for this sub-block.
+    HalfTileGlobal ws_out(workspace + ws_row * TILE_SIZE);
+    TSTORE(ws_out, a_ub);
+    pipe_barrier(PIPE_ALL);  // MTE3: TSTORE complete before SetCrossFlag
+
+    // Signal Cube: workspace tile is fully written, safe to read.
+    SetCrossFlag<PIPE_MTE3>(FLAG_V2C);
+  }
 
 #endif  // __DAV_C220_VEC__
 }
 
 #endif  // __CCE_AICORE__
 
-// ── Kernel entry point ─────────────────────────────────────────────────────────
+// ── Kernel entry point
+// ─────────────────────────────────────────────────────────
 extern "C" __global__ AICORE void add_matmul_v2c_kernel(
-    __gm__ uint8_t *A,
-    __gm__ uint8_t *B,
-    __gm__ uint8_t *C,
-    __gm__ uint8_t *D,
-    __gm__ uint8_t *workspace,
-    int64_t         batch,
-    uint64_t        ffts_addr)
-{
-    run_add_matmul_v2c(
-        reinterpret_cast<__gm__ half *>(A),
-        reinterpret_cast<__gm__ half *>(B),
-        reinterpret_cast<__gm__ half *>(C),
-        reinterpret_cast<__gm__ half *>(D),
-        reinterpret_cast<__gm__ half *>(workspace),
-        batch, ffts_addr);
+    __gm__ uint8_t *A, __gm__ uint8_t *B, __gm__ uint8_t *C, __gm__ uint8_t *D,
+    __gm__ uint8_t *workspace, int64_t batch, uint64_t ffts_addr) {
+  run_add_matmul_v2c(
+      reinterpret_cast<__gm__ half *>(A), reinterpret_cast<__gm__ half *>(B),
+      reinterpret_cast<__gm__ half *>(C), reinterpret_cast<__gm__ half *>(D),
+      reinterpret_cast<__gm__ half *>(workspace), batch, ffts_addr);
 }
 
-// ── Host-side launcher (called from Python via ctypes) ─────────────────────────
-extern "C" void call(uint32_t block_dim, void *stream,
-                     uint8_t *A, uint8_t *B, uint8_t *C,
-                     uint8_t *D, uint8_t *workspace, int64_t batch)
-{
-    uint32_t ffts_len  = 0;
-    uint64_t ffts_addr = 0;
-    rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
-    add_matmul_v2c_kernel<<<block_dim, nullptr, stream>>>(
-        A, B, C, D, workspace, batch, ffts_addr);
+// ── Host-side launcher (called from Python via ctypes)
+// ─────────────────────────
+extern "C" void call(uint32_t block_dim, void *stream, uint8_t *A, uint8_t *B,
+                     uint8_t *C, uint8_t *D, uint8_t *workspace,
+                     int64_t batch) {
+  uint32_t ffts_len = 0;
+  uint64_t ffts_addr = 0;
+  rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
+  add_matmul_v2c_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, workspace,
+                                                        batch, ffts_addr);
 }

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/benchmark.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/benchmark.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import ctypes
+import os
+import statistics
+import sys
+from pathlib import Path
+from typing import Callable
+
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+ADD_TILE_ELEMS = 24576  # 48 KiB UB tile / sizeof(fp16), matches add.cpp
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import (  # noqa: E402
+    compile_kernel,
+    configure_torch_npu,
+    cube_core_count,
+    stream_ptr,
+    tensor_ptr,
+    vector_core_count,
+)
+
+
+def load_add() -> ctypes.CDLL:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "add")))
+    lib.call_add.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    return lib
+
+
+def load_matmul() -> ctypes.CDLL:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul")))
+    lib.call_matmul.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    return lib
+
+
+def event_bench(
+    fn: Callable[[], None],
+    *,
+    warmup: int,
+    repeats: int,
+    flush_cache: bool,
+) -> list[float]:
+    cache = torch.empty((256 * 1024 * 1024,), dtype=torch.int8, device="npu") if flush_cache else None
+    for _ in range(warmup):
+        fn()
+    torch.npu.synchronize()
+
+    samples_us: list[float] = []
+    for _ in range(repeats):
+        if cache is not None:
+            cache.zero_()
+        start = torch.npu.Event(enable_timing=True)
+        end = torch.npu.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples_us.append(start.elapsed_time(end) * 1e3)
+    return samples_us
+
+
+def summarize(samples_us: list[float]) -> tuple[float, float, float]:
+    median = statistics.median(samples_us)
+    mean = statistics.mean(samples_us)
+    stdev = statistics.pstdev(samples_us) if len(samples_us) > 1 else 0.0
+    return median, mean, stdev
+
+
+def bench_add(args, device: str, block_dim: int) -> list[dict]:
+    lib = load_add()
+    rows = []
+    for n in args.add_sizes:
+        torch.manual_seed(0)
+        x = torch.randn(n, device=device, dtype=torch.float16)
+        z = torch.randn(n, device=device, dtype=torch.float16)
+        y = torch.empty_like(x)
+        # Do not spread tiny vectors across all physical cores: inactive blocks can
+        # still issue with invalid tiny tile sizes on this sample kernel.
+        active_blocks = min(block_dim, max(1, (n + ADD_TILE_ELEMS - 1) // ADD_TILE_ELEMS))
+        stream = stream_ptr()
+
+        def launch() -> None:
+            lib.call_add(active_blocks, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), n)
+
+        samples = event_bench(launch, warmup=args.warmup, repeats=args.repeats, flush_cache=args.flush_cache)
+        median, mean, stdev = summarize(samples)
+        bytes_moved = n * 3 * 2
+        rows.append(
+            {
+                "kernel": "add",
+                "shape": f"n={n}",
+                "block_dim": active_blocks,
+                "median_us": median,
+                "mean_us": mean,
+                "stdev_us": stdev,
+                "effective_gbs": bytes_moved / median * 1e-3,
+            }
+        )
+    return rows
+
+
+def bench_matmul(args, device: str, max_block_dim: int) -> list[dict]:
+    lib = load_matmul()
+    rows = []
+    for m in args.matmul_m:
+        if m % 128 != 0:
+            raise ValueError(f"matmul M must be a multiple of 128, got {m}")
+        torch.manual_seed(1)
+        a = torch.randn(m, 128, device=device, dtype=torch.float16)
+        b = torch.randn(128, 128, device=device, dtype=torch.float16)
+        c = torch.empty(m, 128, device=device, dtype=torch.float16)
+        block_dim = min(max_block_dim, max(1, m // 128))
+        stream = stream_ptr()
+
+        def launch() -> None:
+            lib.call_matmul(block_dim, stream, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), m)
+
+        samples = event_bench(launch, warmup=args.warmup, repeats=args.repeats, flush_cache=args.flush_cache)
+        median, mean, stdev = summarize(samples)
+        flops = 2 * m * 128 * 128
+        bytes_moved = (m * 128 + 128 * 128 + m * 128) * 2
+        rows.append(
+            {
+                "kernel": "simple_matmul",
+                "shape": f"m={m},k=128,n=128",
+                "block_dim": block_dim,
+                "median_us": median,
+                "mean_us": mean,
+                "stdev_us": stdev,
+                "effective_gbs": bytes_moved / median * 1e-3,
+                "effective_tflops": flops / median * 1e-6,
+            }
+        )
+    return rows
+
+
+def print_rows(rows: list[dict]) -> None:
+    header = (
+        f"{'kernel':<15} {'shape':<20} {'block':>5} {'median_us':>10} "
+        f"{'mean_us':>10} {'stdev_us':>10} {'GB/s':>10} {'TFLOP/s':>10}"
+    )
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print(
+            f"{row['kernel']:<15} {row['shape']:<20} {row['block_dim']:>5} "
+            f"{row['median_us']:>10.2f} {row['mean_us']:>10.2f} "
+            f"{row['stdev_us']:>10.2f} {row['effective_gbs']:>10.2f} "
+            f"{row.get('effective_tflops', 0.0):>10.4f}"
+        )
+
+
+def write_csv(rows: list[dict], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "kernel",
+        "shape",
+        "block_dim",
+        "median_us",
+        "mean_us",
+        "stdev_us",
+        "effective_gbs",
+        "effective_tflops",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in fieldnames})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark local A2A3 PTO demo kernels")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--kernel", choices=("add", "matmul", "all"), default="all")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--add-sizes", type=int, nargs="*", default=[4096, 65536, 1048576])
+    parser.add_argument("--matmul-m", type=int, nargs="*", default=[128, 1024, 4096])
+    parser.add_argument("--flush-cache", action="store_true")
+    parser.add_argument("--csv", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.warmup < 0 or args.repeats <= 0:
+        raise ValueError("--warmup must be >= 0 and --repeats must be > 0")
+
+    configure_torch_npu()
+    torch.npu.set_device(args.device)
+    cube_block_dim = cube_core_count(args.device)
+    vector_block_dim = vector_core_count(args.device)
+    rows: list[dict] = []
+    if args.kernel in ("add", "all"):
+        rows.extend(bench_add(args, args.device, vector_block_dim))
+    if args.kernel in ("matmul", "all"):
+        rows.extend(bench_matmul(args, args.device, cube_block_dim))
+    print_rows(rows)
+    if args.csv:
+        write_csv(rows, args.csv)
+        print(f"Wrote {args.csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/benchmark.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/benchmark.py
@@ -60,7 +60,11 @@ def event_bench(
     repeats: int,
     flush_cache: bool,
 ) -> list[float]:
-    cache = torch.empty((256 * 1024 * 1024,), dtype=torch.int8, device="npu") if flush_cache else None
+    cache = (
+        torch.empty((256 * 1024 * 1024,), dtype=torch.int8, device="npu")
+        if flush_cache
+        else None
+    )
     for _ in range(warmup):
         fn()
     torch.npu.synchronize()
@@ -96,13 +100,22 @@ def bench_add(args, device: str, block_dim: int) -> list[dict]:
         y = torch.empty_like(x)
         # Do not spread tiny vectors across all physical cores: inactive blocks can
         # still issue with invalid tiny tile sizes on this sample kernel.
-        active_blocks = min(block_dim, max(1, (n + ADD_TILE_ELEMS - 1) // ADD_TILE_ELEMS))
+        active_blocks = min(
+            block_dim, max(1, (n + ADD_TILE_ELEMS - 1) // ADD_TILE_ELEMS)
+        )
         stream = stream_ptr()
 
         def launch() -> None:
-            lib.call_add(active_blocks, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), n)
+            lib.call_add(
+                active_blocks, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), n
+            )
 
-        samples = event_bench(launch, warmup=args.warmup, repeats=args.repeats, flush_cache=args.flush_cache)
+        samples = event_bench(
+            launch,
+            warmup=args.warmup,
+            repeats=args.repeats,
+            flush_cache=args.flush_cache,
+        )
         median, mean, stdev = summarize(samples)
         bytes_moved = n * 3 * 2
         rows.append(
@@ -133,9 +146,16 @@ def bench_matmul(args, device: str, max_block_dim: int) -> list[dict]:
         stream = stream_ptr()
 
         def launch() -> None:
-            lib.call_matmul(block_dim, stream, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), m)
+            lib.call_matmul(
+                block_dim, stream, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), m
+            )
 
-        samples = event_bench(launch, warmup=args.warmup, repeats=args.repeats, flush_cache=args.flush_cache)
+        samples = event_bench(
+            launch,
+            warmup=args.warmup,
+            repeats=args.repeats,
+            flush_cache=args.flush_cache,
+        )
         median, mean, stdev = summarize(samples)
         flops = 2 * m * 128 * 128
         bytes_moved = (m * 128 + 128 * 128 + m * 128) * 2
@@ -190,12 +210,16 @@ def write_csv(rows: list[dict], path: Path) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark local A2A3 PTO demo kernels")
+    parser = argparse.ArgumentParser(
+        description="Benchmark local A2A3 PTO demo kernels"
+    )
     parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
     parser.add_argument("--kernel", choices=("add", "matmul", "all"), default="all")
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--repeats", type=int, default=20)
-    parser.add_argument("--add-sizes", type=int, nargs="*", default=[4096, 65536, 1048576])
+    parser.add_argument(
+        "--add-sizes", type=int, nargs="*", default=[4096, 65536, 1048576]
+    )
     parser.add_argument("--matmul-m", type=int, nargs="*", default=[128, 1024, 4096])
     parser.add_argument("--flush-cache", action="store_true")
     parser.add_argument("--csv", type=Path, default=None)

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/compile.sh
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/compile.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL="${1:-add}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+mkdir -p "${BUILD_DIR}"
+
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+PTO_LIB_PATH="${PTO_LIB_PATH:-${ASCEND_HOME_PATH}}"
+BISHENG="${ASCEND_HOME_PATH}/bin/bisheng"
+if [[ ! -x "${BISHENG}" ]]; then
+  BISHENG="$(command -v bisheng)"
+fi
+
+case "${KERNEL}" in
+  add)
+    SRC="${SCRIPT_DIR}/add.cpp"
+    OUT="${BUILD_DIR}/libadd.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220-vec)
+    ;;
+  matmul|simple_matmul)
+    SRC="${SCRIPT_DIR}/matmul.cpp"
+    OUT="${BUILD_DIR}/libmatmul.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220-cube)
+    ;;
+  matmul_add|mix_c2v)
+    SRC="${SCRIPT_DIR}/matmul_add.cpp"
+    OUT="${BUILD_DIR}/libmatmul_add_c2v.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220)
+    ;;
+  add_matmul|mix_v2c)
+    SRC="${SCRIPT_DIR}/add_matmul.cpp"
+    OUT="${BUILD_DIR}/libadd_matmul_v2c.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220)
+    ;;
+  *)
+    echo "usage: $0 {add|matmul|matmul_add|add_matmul}" >&2
+    exit 2
+    ;;
+esac
+
+"${BISHENG}" \
+  -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
+  "${ARCH_FLAGS[@]}" \
+  -I"${PTO_LIB_PATH}/include" \
+  -I"${ASCEND_HOME_PATH}/include" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/runtime" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/profiling" \
+  -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+  "${SRC}" -o "${OUT}"
+
+echo "${OUT}"

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul.cpp
@@ -1,0 +1,113 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+#define DIV_ROUNDUP(x, y) (((x) + (y) - 1) / (y))
+
+#if defined(__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+
+constexpr uint32_t M_TILE = 128;
+constexpr uint32_t N = 128;
+constexpr uint32_t K = 128;
+constexpr uint32_t TILE_ELEMS = M_TILE * K;
+constexpr unsigned L1_B = 0x0;
+constexpr unsigned L1_A = L1_B + TILE_ELEMS * sizeof(half);
+
+template <pipe_t SrcPipe, pipe_t DstPipe>
+AICORE inline void SetFlag(uint32_t id) {
+  set_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+}
+
+template <pipe_t SrcPipe, pipe_t DstPipe>
+AICORE inline void WaitFlag(uint32_t id) {
+  wait_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+}
+
+// simple_matmul: C[M,128] = A[M,128] @ B[128,128], M multiple of 128.
+AICORE void run_simple_matmul(__gm__ half *a, __gm__ half *b, __gm__ half *c,
+                              uint32_t m) {
+  const uint32_t total_batches = m / M_TILE;
+  const uint32_t core_id = get_block_idx();
+  const uint32_t num_cores = block_num;
+  const uint32_t batches_per_core = DIV_ROUNDUP(total_batches, num_cores);
+  const uint32_t batch_start = batches_per_core * core_id;
+  if (batch_start >= total_batches) return;
+
+  uint32_t batches_to_process = batches_per_core;
+  if (batch_start + batches_to_process > total_batches) {
+    batches_to_process = total_batches - batch_start;
+  }
+
+  using TensorShape = TileShape2D<half, M_TILE, K, Layout::ND>;
+  using TensorStrides = BaseShape2D<half, M_TILE, K, Layout::ND>;
+  using GlobalIn = GlobalTensor<half, TensorShape, TensorStrides, Layout::ND>;
+  using TensorShapeOut = TileShape2D<half, M_TILE, N, Layout::ND>;
+  using TensorStridesOut = BaseShape2D<half, M_TILE, N, Layout::ND>;
+  using GlobalOut =
+      GlobalTensor<half, TensorShapeOut, TensorStridesOut, Layout::ND>;
+  using TileL1 = Tile<TileType::Mat, half, M_TILE, K, BLayout::ColMajor, M_TILE,
+                      K, SLayout::RowMajor, 512>;
+  using TileL0A = TileLeft<half, M_TILE, K>;
+  using TileL0B = TileRight<half, K, N>;
+  using TileL0C = TileAcc<float, M_TILE, N>;
+
+  TileL1 b_l1;
+  TileL1 a_l1;
+  TASSIGN(b_l1, L1_B);
+  TASSIGN(a_l1, L1_A);
+
+  TileL0A a_l0;
+  TileL0B b_l0;
+  TileL0C c_l0;
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(c_l0, 0x0);
+
+  GlobalIn b_global(b);
+  TASSIGN(b_global, b);
+  TLOAD(b_l1, b_global);
+  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(b_l0, b_l1);
+  SetFlag<PIPE_MTE1, PIPE_M>(0);
+  WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+  for (uint32_t i = 0; i < batches_to_process; ++i) {
+    const uint32_t batch_idx = batch_start + i;
+    const uint32_t gm_offset = batch_idx * TILE_ELEMS;
+    GlobalIn a_global(a + gm_offset);
+    GlobalOut c_global(c + gm_offset);
+    TASSIGN(a_global, a + gm_offset);
+    TASSIGN(c_global, c + gm_offset);
+
+    TLOAD(a_l1, a_global);
+    SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    TMOV(a_l0, a_l1);
+    SetFlag<PIPE_MTE1, PIPE_M>(0);
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+    TMATMUL(c_l0, a_l0, b_l0);
+    pipe_barrier(PIPE_ALL);
+    SetFlag<PIPE_M, PIPE_FIX>(0);
+    WaitFlag<PIPE_M, PIPE_FIX>(0);
+    TSTORE(c_global, c_l0);
+    pipe_barrier(PIPE_ALL);
+  }
+}
+
+#endif
+
+extern "C" __global__ AICORE void simple_matmul_kernel(
+    __gm__ void *a, __gm__ void *b, __gm__ void *c, uint32_t m) {
+#if defined(__CHECK_FEATURE_AT_PRECOMPILE) || \
+    (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
+  run_simple_matmul((__gm__ half *)a, (__gm__ half *)b, (__gm__ half *)c, m);
+#endif
+}
+
+extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *a,
+                            uint8_t *b, uint8_t *c, uint32_t m) {
+  simple_matmul_kernel<<<block_dim, nullptr, stream>>>(a, b, c, m);
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul.cpp
@@ -99,8 +99,10 @@ AICORE void run_simple_matmul(__gm__ half *a, __gm__ half *b, __gm__ half *c,
 
 #endif
 
-extern "C" __global__ AICORE void simple_matmul_kernel(
-    __gm__ void *a, __gm__ void *b, __gm__ void *c, uint32_t m) {
+extern "C" __global__ AICORE void simple_matmul_kernel(__gm__ void *a,
+                                                       __gm__ void *b,
+                                                       __gm__ void *c,
+                                                       uint32_t m) {
 #if defined(__CHECK_FEATURE_AT_PRECOMPILE) || \
     (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))
   run_simple_matmul((__gm__ half *)a, (__gm__ half *)b, (__gm__ half *)c, m);

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul_add.cpp
@@ -13,9 +13,10 @@
 //     2. For each round r:
 //          a. Load A[row_c:row_c+T, :] → L1 → L0A
 //          b. GEMM: c_l0 = A @ B  (L0C ← L0A × L0B)
-//          c. If r > 0: wait for Vec signal (FLAG_V2C) confirming workspace freed
-//          d. TSTORE c_l0 → workspace[cid*T : (cid+1)*T, :]  (FIX pipe, f32→f16)
-//          e. SetCrossFlag FLAG_C2V  (signals both Vec sub-blocks: tile ready)
+//          c. If r > 0: wait for Vec signal (FLAG_V2C) confirming workspace
+//          freed d. TSTORE c_l0 → workspace[cid*T : (cid+1)*T, :]  (FIX pipe,
+//          f32→f16) e. SetCrossFlag FLAG_C2V  (signals both Vec sub-blocks:
+//          tile ready)
 //
 //   Vec sub-block (cid, vid ∈ {0,1}):
 //     Each sub-block owns half the tile rows: vid*T/2 .. (vid+1)*T/2
@@ -31,7 +32,8 @@
 // Cross-core sync uses FFTS (Fast Fine-grained Task Synchronization).
 // Flag mode = VEC_NUM = 2:
 //   • Cube sends FLAG_C2V once; hardware delivers it to both Vec sub-blocks.
-//   • Each Vec sub-block sends FLAG_V2C once; Cube unblocks after VEC_NUM signals.
+//   • Each Vec sub-block sends FLAG_V2C once; Cube unblocks after VEC_NUM
+//   signals.
 //
 // Memory budget:
 //   L1  (512 KB): b_l1 (32 KB at 0) + a_l1 (32 KB at 32 KB) = 64 KB used
@@ -41,21 +43,25 @@
 //   UB  (192 KB): c_ub (16 KB at 0) + d_ub (16 KB at 16 KB) = 32 KB used
 // =============================================================================
 
-#include <pto/pto-inst.hpp>
-#include "acl/acl.h"
 #include <runtime/rt_ffts.h>
+
+#include <pto/pto-inst.hpp>
+
+#include "acl/acl.h"
 
 using namespace pto;
 
-// ── Tile dimensions ────────────────────────────────────────────────────────────
-#define TILE_SIZE 128   // rows/cols per matrix tile
-#define HALF_TILE  64   // rows per Vec sub-block  (TILE_SIZE / VEC_NUM)
-#define VEC_NUM     2   // Vec sub-blocks per Cube core
+// ── Tile dimensions
+// ────────────────────────────────────────────────────────────
+#define TILE_SIZE 128  // rows/cols per matrix tile
+#define HALF_TILE 64   // rows per Vec sub-block  (TILE_SIZE / VEC_NUM)
+#define VEC_NUM 2      // Vec sub-blocks per Cube core
 
 #ifdef __CCE_AICORE__
 
-// ── On-chip buffer base addresses (bytes) ─────────────────────────────────────
-// L1: two back-to-back TILE_SIZE×TILE_SIZE half tiles
+// ── On-chip buffer base addresses (bytes)
+// ───────────────────────────────────── L1: two back-to-back
+// TILE_SIZE×TILE_SIZE half tiles
 constexpr uint32_t L1_B_OFFSET = 0u;
 constexpr uint32_t L1_A_OFFSET = TILE_SIZE * TILE_SIZE * sizeof(half);  // 32 KB
 
@@ -66,217 +72,212 @@ constexpr uint32_t L0_OFFSET = 0u;
 constexpr uint32_t UB_C_OFFSET = 0u;
 constexpr uint32_t UB_D_OFFSET = HALF_TILE * TILE_SIZE * sizeof(half);  // 16 KB
 
-// ── Cross-core FFTS flags ──────────────────────────────────────────────────────
+// ── Cross-core FFTS flags
+// ──────────────────────────────────────────────────────
 constexpr int32_t FLAG_C2V = 0;  // Cube → Vec: GEMM result written to workspace
 constexpr int32_t FLAG_V2C = 1;  // Vec → Cube: workspace slot has been read
 
-// ── Tile type aliases ──────────────────────────────────────────────────────────
-// L1 tile — NZ (ColMajor/RowMajor) layout required by the Cube engine
-using TileL1 = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE,
-                    BLayout::ColMajor, TILE_SIZE, TILE_SIZE,
-                    SLayout::RowMajor, 512, PadValue::Zero>;
+// ── Tile type aliases
+// ────────────────────────────────────────────────────────── L1 tile — NZ
+// (ColMajor/RowMajor) layout required by the Cube engine
+using TileL1 =
+    Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::ColMajor,
+         TILE_SIZE, TILE_SIZE, SLayout::RowMajor, 512, PadValue::Zero>;
 
 // L0 tiles — one per independent Cube scratchpad
-using TileL0A = TileLeft<half,  TILE_SIZE, TILE_SIZE>;
+using TileL0A = TileLeft<half, TILE_SIZE, TILE_SIZE>;
 using TileL0B = TileRight<half, TILE_SIZE, TILE_SIZE>;
-using TileL0C = TileAcc<float,  TILE_SIZE, TILE_SIZE>;  // fp32 accumulator
+using TileL0C = TileAcc<float, TILE_SIZE, TILE_SIZE>;  // fp32 accumulator
 
 // UB Vec tile — row-major, HALF_TILE rows × TILE_SIZE cols, fp16
-using TileVecUB = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE,
-                       BLayout::RowMajor, HALF_TILE, TILE_SIZE,
-                       SLayout::NoneBox, 512, PadValue::Null>;
+using TileVecUB =
+    Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::RowMajor,
+         HALF_TILE, TILE_SIZE, SLayout::NoneBox, 512, PadValue::Null>;
 
 // GlobalTensor aliases — contiguous 2D row-major in GM
 using TileGlobal =
-    GlobalTensor<half,
-                 TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+    GlobalTensor<half, TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
                  BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
                  Layout::ND>;
 
 using HalfTileGlobal =
-    GlobalTensor<half,
-                 TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+    GlobalTensor<half, TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
                  BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
                  Layout::ND>;
 
-// ── Cross-core sync helpers ────────────────────────────────────────────────────
-// SetCrossFlag: insert a signal into `Pipe`'s instruction stream.
+// ── Cross-core sync helpers
+// ──────────────────────────────────────────────────── SetCrossFlag: insert a
+// signal into `Pipe`'s instruction stream.
 //   mode = VEC_NUM means:
-//     • When Cube signals FLAG_C2V: one call unblocks all VEC_NUM Vec sub-blocks.
-//     • When Vec signals FLAG_V2C: Cube unblocks after receiving VEC_NUM signals
+//     • When Cube signals FLAG_C2V: one call unblocks all VEC_NUM Vec
+//     sub-blocks. • When Vec signals FLAG_V2C: Cube unblocks after receiving
+//     VEC_NUM signals
 //       (one per sub-block).
 template <pipe_t Pipe>
 AICORE inline void SetCrossFlag(int32_t flag) {
-    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+  ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
 }
 
-AICORE inline void WaitCrossFlag(int32_t flag) {
-    wait_flag_dev(flag);
-}
+AICORE inline void WaitCrossFlag(int32_t flag) { wait_flag_dev(flag); }
 
-// ── Intra-pipe sync helpers ────────────────────────────────────────────────────
+// ── Intra-pipe sync helpers
+// ────────────────────────────────────────────────────
 template <pipe_t Src, pipe_t Dst>
 AICORE inline void SetFlag(uint32_t id) {
-    set_flag(Src, Dst, static_cast<event_t>(id));
+  set_flag(Src, Dst, static_cast<event_t>(id));
 }
 
 template <pipe_t Src, pipe_t Dst>
 AICORE inline void WaitFlag(uint32_t id) {
-    wait_flag(Src, Dst, static_cast<event_t>(id));
+  wait_flag(Src, Dst, static_cast<event_t>(id));
 }
 
-// ── Kernel implementation ──────────────────────────────────────────────────────
+// ── Kernel implementation
+// ──────────────────────────────────────────────────────
 AICORE void run_matmul_add_c2v(
-    __gm__ half    *A,          // [batch, TILE_SIZE]              input matrix
-    __gm__ half    *B,          // [TILE_SIZE, TILE_SIZE]          weight (constant)
-    __gm__ half    *C,          // [batch, TILE_SIZE]              output
-    __gm__ half    *D,          // [batch, TILE_SIZE]              bias
-    __gm__ half    *workspace,  // [num_cores*TILE_SIZE, TILE_SIZE] C2V buffer
-    int64_t         batch,
-    uint64_t        ffts_addr)
-{
-    const int32_t cid       = static_cast<int32_t>(get_block_idx());   // Cube core id
-    const int32_t vid       = static_cast<int32_t>(get_subblockid());  // Vec sub-block: 0 or 1
-    const int32_t num_cores = static_cast<int32_t>(block_num);         // launched Cube cores
+    __gm__ half *A,  // [batch, TILE_SIZE]              input matrix
+    __gm__ half *B,  // [TILE_SIZE, TILE_SIZE]          weight (constant)
+    __gm__ half *C,  // [batch, TILE_SIZE]              output
+    __gm__ half *D,  // [batch, TILE_SIZE]              bias
+    __gm__ half *workspace,  // [num_cores*TILE_SIZE, TILE_SIZE] C2V buffer
+    int64_t batch, uint64_t ffts_addr) {
+  const int32_t cid = static_cast<int32_t>(get_block_idx());  // Cube core id
+  const int32_t vid =
+      static_cast<int32_t>(get_subblockid());  // Vec sub-block: 0 or 1
+  const int32_t num_cores =
+      static_cast<int32_t>(block_num);  // launched Cube cores
 
-    set_ffts_base_addr(ffts_addr);
+  set_ffts_base_addr(ffts_addr);
 
-    // One wave processes (num_cores × TILE_SIZE) rows across all cores.
-    const int32_t wave_rows  = num_cores * TILE_SIZE;
-    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+  // One wave processes (num_cores × TILE_SIZE) rows across all cores.
+  const int32_t wave_rows = num_cores * TILE_SIZE;
+  const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
 
-    // ── Allocate on-chip buffers ───────────────────────────────────────────────
-    TileL1  b_l1, a_l1;
-    TASSIGN(b_l1, L1_B_OFFSET);
-    TASSIGN(a_l1, L1_A_OFFSET);
+  // ── Allocate on-chip buffers ───────────────────────────────────────────────
+  TileL1 b_l1, a_l1;
+  TASSIGN(b_l1, L1_B_OFFSET);
+  TASSIGN(a_l1, L1_A_OFFSET);
 
-    TileL0A a_l0;
-    TileL0B b_l0;
-    TileL0C c_l0;
-    TASSIGN(a_l0, L0_OFFSET);
-    TASSIGN(b_l0, L0_OFFSET);
-    TASSIGN(c_l0, L0_OFFSET);
+  TileL0A a_l0;
+  TileL0B b_l0;
+  TileL0C c_l0;
+  TASSIGN(a_l0, L0_OFFSET);
+  TASSIGN(b_l0, L0_OFFSET);
+  TASSIGN(c_l0, L0_OFFSET);
 
-    TileVecUB c_ub, d_ub;
-    TASSIGN(c_ub, UB_C_OFFSET);
-    TASSIGN(d_ub, UB_D_OFFSET);
+  TileVecUB c_ub, d_ub;
+  TASSIGN(c_ub, UB_C_OFFSET);
+  TASSIGN(d_ub, UB_D_OFFSET);
 
-    // ── Cube core: GEMM ───────────────────────────────────────────────────────
+  // ── Cube core: GEMM ───────────────────────────────────────────────────────
 #if defined(__DAV_C220_CUBE__)
 
-    // Load the constant weight matrix B once — reused for every round.
-    TileGlobal b_global(B);
-    TLOAD(b_l1, b_global);
+  // Load the constant weight matrix B once — reused for every round.
+  TileGlobal b_global(B);
+  TLOAD(b_l1, b_global);
+  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(b_l0, b_l1);  // L1 → L0B (MTE1 pipe)
+  SetFlag<PIPE_MTE1, PIPE_M>(0);
+  WaitFlag<PIPE_MTE1, PIPE_M>(0);  // M pipe waits for b_l0 to be ready
+
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    // Row offset in A for this core + round
+    const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+
+    // Load A tile: GM → L1 → L0A
+    TileGlobal a_global(A + row_c * TILE_SIZE);
+    TLOAD(a_l1, a_global);
     SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
     WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-    TMOV(b_l0, b_l1);                   // L1 → L0B (MTE1 pipe)
+    TMOV(a_l0, a_l1);  // L1 → L0A (MTE1 pipe)
     SetFlag<PIPE_MTE1, PIPE_M>(0);
-    WaitFlag<PIPE_MTE1, PIPE_M>(0);     // M pipe waits for b_l0 to be ready
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);  // M pipe waits for a_l0 to be ready
 
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        // Row offset in A for this core + round
-        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+    // GEMM: c_l0 = A @ B  (initialises c_l0 — no prior accumulation)
+    TMATMUL(c_l0, a_l0, b_l0);
+    SetFlag<PIPE_M, PIPE_FIX>(0);
+    WaitFlag<PIPE_M, PIPE_FIX>(0);  // M→FIX: c_l0 ready for TSTORE
 
-        // Load A tile: GM → L1 → L0A
-        TileGlobal a_global(A + row_c * TILE_SIZE);
-        TLOAD(a_l1, a_global);
-        SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
-        WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-        TMOV(a_l0, a_l1);               // L1 → L0A (MTE1 pipe)
-        SetFlag<PIPE_MTE1, PIPE_M>(0);
-        WaitFlag<PIPE_MTE1, PIPE_M>(0); // M pipe waits for a_l0 to be ready
-
-        // GEMM: c_l0 = A @ B  (initialises c_l0 — no prior accumulation)
-        TMATMUL(c_l0, a_l0, b_l0);
-        SetFlag<PIPE_M, PIPE_FIX>(0);
-        WaitFlag<PIPE_M, PIPE_FIX>(0);  // M→FIX: c_l0 ready for TSTORE
-
-        // Wait for both Vec sub-blocks to finish reading the workspace slot
-        // from the *previous* round before overwriting it. Skip on round 0.
-        if (r > 0) {
-            WaitCrossFlag(FLAG_V2C);
-            pipe_barrier(PIPE_ALL);  // flush all pipes before issuing TSTORE
-        }
-
-        // Write GEMM result to workspace (fp32 → fp16 conversion via FIX pipe).
-        TileGlobal ws_out(workspace + cid * TILE_SIZE * TILE_SIZE);
-        TSTORE(ws_out, c_l0);
-        pipe_barrier(PIPE_ALL);  // FIX: TSTORE complete before SetCrossFlag fires
-        SetCrossFlag<PIPE_FIX>(FLAG_C2V);
+    // Wait for both Vec sub-blocks to finish reading the workspace slot
+    // from the *previous* round before overwriting it. Skip on round 0.
+    if (r > 0) {
+      WaitCrossFlag(FLAG_V2C);
+      pipe_barrier(PIPE_ALL);  // flush all pipes before issuing TSTORE
     }
+
+    // Write GEMM result to workspace (fp32 → fp16 conversion via FIX pipe).
+    TileGlobal ws_out(workspace + cid * TILE_SIZE * TILE_SIZE);
+    TSTORE(ws_out, c_l0);
+    pipe_barrier(PIPE_ALL);  // FIX: TSTORE complete before SetCrossFlag fires
+    SetCrossFlag<PIPE_FIX>(FLAG_C2V);
+  }
 
 #endif  // __DAV_C220_CUBE__
 
-    // ── Vec sub-block: add bias + store result ─────────────────────────────────
+  // ── Vec sub-block: add bias + store result ─────────────────────────────────
 #if defined(__DAV_C220_VEC__)
 
-    set_mask_norm();
-    set_vector_mask(-1, -1);
+  set_mask_norm();
+  set_vector_mask(-1, -1);
 
-    // This sub-block's workspace row offset (fixed across all rounds).
-    const int32_t ws_row = cid * TILE_SIZE + vid * HALF_TILE;
+  // This sub-block's workspace row offset (fixed across all rounds).
+  const int32_t ws_row = cid * TILE_SIZE + vid * HALF_TILE;
 
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        // Global output row this sub-block writes
-        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    // Global output row this sub-block writes
+    const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
 
-        // Wait for Cube: workspace slot contains a fresh GEMM result.
-        WaitCrossFlag(FLAG_C2V);
+    // Wait for Cube: workspace slot contains a fresh GEMM result.
+    WaitCrossFlag(FLAG_C2V);
 
-        // Load GEMM result and D from GM → UB (both loads can issue in parallel).
-        HalfTileGlobal ws_in(workspace + ws_row * TILE_SIZE);
-        TLOAD(c_ub, ws_in);
+    // Load GEMM result and D from GM → UB (both loads can issue in parallel).
+    HalfTileGlobal ws_in(workspace + ws_row * TILE_SIZE);
+    TLOAD(c_ub, ws_in);
 
-        HalfTileGlobal d_global(D + row_v * TILE_SIZE);
-        TLOAD(d_ub, d_global);
+    HalfTileGlobal d_global(D + row_v * TILE_SIZE);
+    TLOAD(d_ub, d_global);
 
-        pipe_barrier(PIPE_ALL);  // MTE2→V+MTE3: both TLOADs done before signal and TADD
+    pipe_barrier(
+        PIPE_ALL);  // MTE2→V+MTE3: both TLOADs done before signal and TADD
 
-        // Signal Cube: workspace slot is consumed — safe to overwrite next round.
-        SetCrossFlag<PIPE_MTE3>(FLAG_V2C);
+    // Signal Cube: workspace slot is consumed — safe to overwrite next round.
+    SetCrossFlag<PIPE_MTE3>(FLAG_V2C);
 
-        // C = GEMM_result + D  (Vec engine, element-wise)
-        TADD(c_ub, c_ub, d_ub);
-        pipe_barrier(PIPE_ALL);  // V→MTE3: TADD done before TSTORE
+    // C = GEMM_result + D  (Vec engine, element-wise)
+    TADD(c_ub, c_ub, d_ub);
+    pipe_barrier(PIPE_ALL);  // V→MTE3: TADD done before TSTORE
 
-        // Store result to global memory C.
-        HalfTileGlobal c_out(C + row_v * TILE_SIZE);
-        TSTORE(c_out, c_ub);
-        pipe_barrier(PIPE_ALL);  // MTE3: TSTORE complete before next round
-    }
+    // Store result to global memory C.
+    HalfTileGlobal c_out(C + row_v * TILE_SIZE);
+    TSTORE(c_out, c_ub);
+    pipe_barrier(PIPE_ALL);  // MTE3: TSTORE complete before next round
+  }
 
 #endif  // __DAV_C220_VEC__
 }
 
 #endif  // __CCE_AICORE__
 
-// ── Kernel entry point ─────────────────────────────────────────────────────────
+// ── Kernel entry point
+// ─────────────────────────────────────────────────────────
 extern "C" __global__ AICORE void matmul_add_c2v_kernel(
-    __gm__ uint8_t *A,
-    __gm__ uint8_t *B,
-    __gm__ uint8_t *C,
-    __gm__ uint8_t *D,
-    __gm__ uint8_t *workspace,
-    int64_t         batch,
-    uint64_t        ffts_addr)
-{
-    run_matmul_add_c2v(
-        reinterpret_cast<__gm__ half *>(A),
-        reinterpret_cast<__gm__ half *>(B),
-        reinterpret_cast<__gm__ half *>(C),
-        reinterpret_cast<__gm__ half *>(D),
-        reinterpret_cast<__gm__ half *>(workspace),
-        batch, ffts_addr);
+    __gm__ uint8_t *A, __gm__ uint8_t *B, __gm__ uint8_t *C, __gm__ uint8_t *D,
+    __gm__ uint8_t *workspace, int64_t batch, uint64_t ffts_addr) {
+  run_matmul_add_c2v(
+      reinterpret_cast<__gm__ half *>(A), reinterpret_cast<__gm__ half *>(B),
+      reinterpret_cast<__gm__ half *>(C), reinterpret_cast<__gm__ half *>(D),
+      reinterpret_cast<__gm__ half *>(workspace), batch, ffts_addr);
 }
 
-// ── Host-side launcher (called from Python via ctypes) ─────────────────────────
-extern "C" void call(uint32_t block_dim, void *stream,
-                     uint8_t *A, uint8_t *B, uint8_t *C,
-                     uint8_t *D, uint8_t *workspace, int64_t batch)
-{
-    uint32_t ffts_len  = 0;
-    uint64_t ffts_addr = 0;
-    rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
-    matmul_add_c2v_kernel<<<block_dim, nullptr, stream>>>(
-        A, B, C, D, workspace, batch, ffts_addr);
+// ── Host-side launcher (called from Python via ctypes)
+// ─────────────────────────
+extern "C" void call(uint32_t block_dim, void *stream, uint8_t *A, uint8_t *B,
+                     uint8_t *C, uint8_t *D, uint8_t *workspace,
+                     int64_t batch) {
+  uint32_t ffts_len = 0;
+  uint64_t ffts_addr = 0;
+  rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
+  matmul_add_c2v_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, workspace,
+                                                        batch, ffts_addr);
 }

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/matmul_add.cpp
@@ -1,0 +1,282 @@
+// =============================================================================
+// matmul_add_c2v.cpp — Persistent kernel: C = A @ B + D (Cube-to-Vec stream)
+//
+// Computes  C[batch, T] = A[batch, T] @ B[T, T] + D[batch, T]
+// where T = TILE_SIZE = 128.
+//
+// Algorithm (persistent kernel, block_dim == num_cube_cores):
+//   Each "round" all Cube cores process one wave of TILE_SIZE rows in parallel.
+//   After num_rounds waves the full batch is consumed.
+//
+//   Cube core (cid):
+//     1. Load B[0:T, 0:T] → L1 → L0B  (once, before the loop)
+//     2. For each round r:
+//          a. Load A[row_c:row_c+T, :] → L1 → L0A
+//          b. GEMM: c_l0 = A @ B  (L0C ← L0A × L0B)
+//          c. If r > 0: wait for Vec signal (FLAG_V2C) confirming workspace freed
+//          d. TSTORE c_l0 → workspace[cid*T : (cid+1)*T, :]  (FIX pipe, f32→f16)
+//          e. SetCrossFlag FLAG_C2V  (signals both Vec sub-blocks: tile ready)
+//
+//   Vec sub-block (cid, vid ∈ {0,1}):
+//     Each sub-block owns half the tile rows: vid*T/2 .. (vid+1)*T/2
+//     For each round r:
+//          a. WaitCrossFlag FLAG_C2V  (Cube has written workspace)
+//          b. TLOAD workspace slice → c_ub
+//          c. TLOAD D slice         → d_ub
+//          d. pipe_barrier(ALL)  — both loads complete
+//          e. SetCrossFlag FLAG_V2C  (signals Cube: workspace slot freed)
+//          f. TADD c_ub = c_ub + d_ub
+//          g. TSTORE c_ub → C output
+//
+// Cross-core sync uses FFTS (Fast Fine-grained Task Synchronization).
+// Flag mode = VEC_NUM = 2:
+//   • Cube sends FLAG_C2V once; hardware delivers it to both Vec sub-blocks.
+//   • Each Vec sub-block sends FLAG_V2C once; Cube unblocks after VEC_NUM signals.
+//
+// Memory budget:
+//   L1  (512 KB): b_l1 (32 KB at 0) + a_l1 (32 KB at 32 KB) = 64 KB used
+//   L0A ( 64 KB): a_l0 (32 KB at 0)
+//   L0B ( 64 KB): b_l0 (32 KB at 0)
+//   L0C (128 KB): c_l0 (64 KB at 0)
+//   UB  (192 KB): c_ub (16 KB at 0) + d_ub (16 KB at 16 KB) = 32 KB used
+// =============================================================================
+
+#include <pto/pto-inst.hpp>
+#include "acl/acl.h"
+#include <runtime/rt_ffts.h>
+
+using namespace pto;
+
+// ── Tile dimensions ────────────────────────────────────────────────────────────
+#define TILE_SIZE 128   // rows/cols per matrix tile
+#define HALF_TILE  64   // rows per Vec sub-block  (TILE_SIZE / VEC_NUM)
+#define VEC_NUM     2   // Vec sub-blocks per Cube core
+
+#ifdef __CCE_AICORE__
+
+// ── On-chip buffer base addresses (bytes) ─────────────────────────────────────
+// L1: two back-to-back TILE_SIZE×TILE_SIZE half tiles
+constexpr uint32_t L1_B_OFFSET = 0u;
+constexpr uint32_t L1_A_OFFSET = TILE_SIZE * TILE_SIZE * sizeof(half);  // 32 KB
+
+// L0A / L0B / L0C are independent scratchpads; each starts at byte 0
+constexpr uint32_t L0_OFFSET = 0u;
+
+// UB: two HALF_TILE×TILE_SIZE half tiles
+constexpr uint32_t UB_C_OFFSET = 0u;
+constexpr uint32_t UB_D_OFFSET = HALF_TILE * TILE_SIZE * sizeof(half);  // 16 KB
+
+// ── Cross-core FFTS flags ──────────────────────────────────────────────────────
+constexpr int32_t FLAG_C2V = 0;  // Cube → Vec: GEMM result written to workspace
+constexpr int32_t FLAG_V2C = 1;  // Vec → Cube: workspace slot has been read
+
+// ── Tile type aliases ──────────────────────────────────────────────────────────
+// L1 tile — NZ (ColMajor/RowMajor) layout required by the Cube engine
+using TileL1 = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE,
+                    BLayout::ColMajor, TILE_SIZE, TILE_SIZE,
+                    SLayout::RowMajor, 512, PadValue::Zero>;
+
+// L0 tiles — one per independent Cube scratchpad
+using TileL0A = TileLeft<half,  TILE_SIZE, TILE_SIZE>;
+using TileL0B = TileRight<half, TILE_SIZE, TILE_SIZE>;
+using TileL0C = TileAcc<float,  TILE_SIZE, TILE_SIZE>;  // fp32 accumulator
+
+// UB Vec tile — row-major, HALF_TILE rows × TILE_SIZE cols, fp16
+using TileVecUB = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE,
+                       BLayout::RowMajor, HALF_TILE, TILE_SIZE,
+                       SLayout::NoneBox, 512, PadValue::Null>;
+
+// GlobalTensor aliases — contiguous 2D row-major in GM
+using TileGlobal =
+    GlobalTensor<half,
+                 TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
+
+using HalfTileGlobal =
+    GlobalTensor<half,
+                 TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
+
+// ── Cross-core sync helpers ────────────────────────────────────────────────────
+// SetCrossFlag: insert a signal into `Pipe`'s instruction stream.
+//   mode = VEC_NUM means:
+//     • When Cube signals FLAG_C2V: one call unblocks all VEC_NUM Vec sub-blocks.
+//     • When Vec signals FLAG_V2C: Cube unblocks after receiving VEC_NUM signals
+//       (one per sub-block).
+template <pipe_t Pipe>
+AICORE inline void SetCrossFlag(int32_t flag) {
+    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+}
+
+AICORE inline void WaitCrossFlag(int32_t flag) {
+    wait_flag_dev(flag);
+}
+
+// ── Intra-pipe sync helpers ────────────────────────────────────────────────────
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void SetFlag(uint32_t id) {
+    set_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void WaitFlag(uint32_t id) {
+    wait_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+// ── Kernel implementation ──────────────────────────────────────────────────────
+AICORE void run_matmul_add_c2v(
+    __gm__ half    *A,          // [batch, TILE_SIZE]              input matrix
+    __gm__ half    *B,          // [TILE_SIZE, TILE_SIZE]          weight (constant)
+    __gm__ half    *C,          // [batch, TILE_SIZE]              output
+    __gm__ half    *D,          // [batch, TILE_SIZE]              bias
+    __gm__ half    *workspace,  // [num_cores*TILE_SIZE, TILE_SIZE] C2V buffer
+    int64_t         batch,
+    uint64_t        ffts_addr)
+{
+    const int32_t cid       = static_cast<int32_t>(get_block_idx());   // Cube core id
+    const int32_t vid       = static_cast<int32_t>(get_subblockid());  // Vec sub-block: 0 or 1
+    const int32_t num_cores = static_cast<int32_t>(block_num);         // launched Cube cores
+
+    set_ffts_base_addr(ffts_addr);
+
+    // One wave processes (num_cores × TILE_SIZE) rows across all cores.
+    const int32_t wave_rows  = num_cores * TILE_SIZE;
+    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+
+    // ── Allocate on-chip buffers ───────────────────────────────────────────────
+    TileL1  b_l1, a_l1;
+    TASSIGN(b_l1, L1_B_OFFSET);
+    TASSIGN(a_l1, L1_A_OFFSET);
+
+    TileL0A a_l0;
+    TileL0B b_l0;
+    TileL0C c_l0;
+    TASSIGN(a_l0, L0_OFFSET);
+    TASSIGN(b_l0, L0_OFFSET);
+    TASSIGN(c_l0, L0_OFFSET);
+
+    TileVecUB c_ub, d_ub;
+    TASSIGN(c_ub, UB_C_OFFSET);
+    TASSIGN(d_ub, UB_D_OFFSET);
+
+    // ── Cube core: GEMM ───────────────────────────────────────────────────────
+#if defined(__DAV_C220_CUBE__)
+
+    // Load the constant weight matrix B once — reused for every round.
+    TileGlobal b_global(B);
+    TLOAD(b_l1, b_global);
+    SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    TMOV(b_l0, b_l1);                   // L1 → L0B (MTE1 pipe)
+    SetFlag<PIPE_MTE1, PIPE_M>(0);
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);     // M pipe waits for b_l0 to be ready
+
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        // Row offset in A for this core + round
+        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+
+        // Load A tile: GM → L1 → L0A
+        TileGlobal a_global(A + row_c * TILE_SIZE);
+        TLOAD(a_l1, a_global);
+        SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+        WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+        TMOV(a_l0, a_l1);               // L1 → L0A (MTE1 pipe)
+        SetFlag<PIPE_MTE1, PIPE_M>(0);
+        WaitFlag<PIPE_MTE1, PIPE_M>(0); // M pipe waits for a_l0 to be ready
+
+        // GEMM: c_l0 = A @ B  (initialises c_l0 — no prior accumulation)
+        TMATMUL(c_l0, a_l0, b_l0);
+        SetFlag<PIPE_M, PIPE_FIX>(0);
+        WaitFlag<PIPE_M, PIPE_FIX>(0);  // M→FIX: c_l0 ready for TSTORE
+
+        // Wait for both Vec sub-blocks to finish reading the workspace slot
+        // from the *previous* round before overwriting it. Skip on round 0.
+        if (r > 0) {
+            WaitCrossFlag(FLAG_V2C);
+            pipe_barrier(PIPE_ALL);  // flush all pipes before issuing TSTORE
+        }
+
+        // Write GEMM result to workspace (fp32 → fp16 conversion via FIX pipe).
+        TileGlobal ws_out(workspace + cid * TILE_SIZE * TILE_SIZE);
+        TSTORE(ws_out, c_l0);
+        pipe_barrier(PIPE_ALL);  // FIX: TSTORE complete before SetCrossFlag fires
+        SetCrossFlag<PIPE_FIX>(FLAG_C2V);
+    }
+
+#endif  // __DAV_C220_CUBE__
+
+    // ── Vec sub-block: add bias + store result ─────────────────────────────────
+#if defined(__DAV_C220_VEC__)
+
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+
+    // This sub-block's workspace row offset (fixed across all rounds).
+    const int32_t ws_row = cid * TILE_SIZE + vid * HALF_TILE;
+
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        // Global output row this sub-block writes
+        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+
+        // Wait for Cube: workspace slot contains a fresh GEMM result.
+        WaitCrossFlag(FLAG_C2V);
+
+        // Load GEMM result and D from GM → UB (both loads can issue in parallel).
+        HalfTileGlobal ws_in(workspace + ws_row * TILE_SIZE);
+        TLOAD(c_ub, ws_in);
+
+        HalfTileGlobal d_global(D + row_v * TILE_SIZE);
+        TLOAD(d_ub, d_global);
+
+        pipe_barrier(PIPE_ALL);  // MTE2→V+MTE3: both TLOADs done before signal and TADD
+
+        // Signal Cube: workspace slot is consumed — safe to overwrite next round.
+        SetCrossFlag<PIPE_MTE3>(FLAG_V2C);
+
+        // C = GEMM_result + D  (Vec engine, element-wise)
+        TADD(c_ub, c_ub, d_ub);
+        pipe_barrier(PIPE_ALL);  // V→MTE3: TADD done before TSTORE
+
+        // Store result to global memory C.
+        HalfTileGlobal c_out(C + row_v * TILE_SIZE);
+        TSTORE(c_out, c_ub);
+        pipe_barrier(PIPE_ALL);  // MTE3: TSTORE complete before next round
+    }
+
+#endif  // __DAV_C220_VEC__
+}
+
+#endif  // __CCE_AICORE__
+
+// ── Kernel entry point ─────────────────────────────────────────────────────────
+extern "C" __global__ AICORE void matmul_add_c2v_kernel(
+    __gm__ uint8_t *A,
+    __gm__ uint8_t *B,
+    __gm__ uint8_t *C,
+    __gm__ uint8_t *D,
+    __gm__ uint8_t *workspace,
+    int64_t         batch,
+    uint64_t        ffts_addr)
+{
+    run_matmul_add_c2v(
+        reinterpret_cast<__gm__ half *>(A),
+        reinterpret_cast<__gm__ half *>(B),
+        reinterpret_cast<__gm__ half *>(C),
+        reinterpret_cast<__gm__ half *>(D),
+        reinterpret_cast<__gm__ half *>(workspace),
+        batch, ffts_addr);
+}
+
+// ── Host-side launcher (called from Python via ctypes) ─────────────────────────
+extern "C" void call(uint32_t block_dim, void *stream,
+                     uint8_t *A, uint8_t *B, uint8_t *C,
+                     uint8_t *D, uint8_t *workspace, int64_t batch)
+{
+    uint32_t ffts_len  = 0;
+    uint64_t ffts_addr = 0;
+    rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
+    matmul_add_c2v_kernel<<<block_dim, nullptr, stream>>>(
+        A, B, C, D, workspace, batch, ffts_addr);
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/pybind.cpp
@@ -1,0 +1,34 @@
+#include <torch/extension.h>
+#include <cstdint>
+#include <string>
+
+namespace py = pybind11;
+
+extern "C" void call_add(uint32_t block_dim, void *stream, uint8_t *y,
+                         uint8_t *x, uint8_t *z, uint32_t n);
+extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *a,
+                            uint8_t *b, uint8_t *c, uint32_t m);
+
+void launch_add(const at::Tensor &y, const at::Tensor &x,
+                const at::Tensor &z, uint32_t n, uint32_t block_dim, uintptr_t stream) {
+  call_add(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(y.data_ptr()),
+           static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()), n);
+}
+
+void launch_matmul(const at::Tensor &a, const at::Tensor &b,
+                   const at::Tensor &c, uint32_t m, uint32_t block_dim, uintptr_t stream) {
+  call_matmul(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(a.data_ptr()),
+              static_cast<uint8_t *>(b.data_ptr()), static_cast<uint8_t *>(c.data_ptr()), m);
+}
+
+#ifndef TORCH_EXTENSION_NAME
+#define TORCH_EXTENSION_NAME pto_dynamic_a2a3_demo
+#endif
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.doc() = "A2A3 PTO demo pybind launcher";
+  m.def("launch_add", &launch_add, py::arg("y"), py::arg("x"),
+        py::arg("z"), py::arg("n"), py::arg("block_dim"), py::arg("stream"));
+  m.def("launch_matmul", &launch_matmul, py::arg("a"), py::arg("b"),
+        py::arg("c"), py::arg("m"), py::arg("block_dim"), py::arg("stream"));
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/pybind.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+
 #include <cstdint>
 #include <string>
 
@@ -9,16 +10,21 @@ extern "C" void call_add(uint32_t block_dim, void *stream, uint8_t *y,
 extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *a,
                             uint8_t *b, uint8_t *c, uint32_t m);
 
-void launch_add(const at::Tensor &y, const at::Tensor &x,
-                const at::Tensor &z, uint32_t n, uint32_t block_dim, uintptr_t stream) {
-  call_add(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(y.data_ptr()),
-           static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()), n);
+void launch_add(const at::Tensor &y, const at::Tensor &x, const at::Tensor &z,
+                uint32_t n, uint32_t block_dim, uintptr_t stream) {
+  call_add(block_dim, reinterpret_cast<void *>(stream),
+           static_cast<uint8_t *>(y.data_ptr()),
+           static_cast<uint8_t *>(x.data_ptr()),
+           static_cast<uint8_t *>(z.data_ptr()), n);
 }
 
 void launch_matmul(const at::Tensor &a, const at::Tensor &b,
-                   const at::Tensor &c, uint32_t m, uint32_t block_dim, uintptr_t stream) {
-  call_matmul(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(a.data_ptr()),
-              static_cast<uint8_t *>(b.data_ptr()), static_cast<uint8_t *>(c.data_ptr()), m);
+                   const at::Tensor &c, uint32_t m, uint32_t block_dim,
+                   uintptr_t stream) {
+  call_matmul(block_dim, reinterpret_cast<void *>(stream),
+              static_cast<uint8_t *>(a.data_ptr()),
+              static_cast<uint8_t *>(b.data_ptr()),
+              static_cast<uint8_t *>(c.data_ptr()), m);
 }
 
 #ifndef TORCH_EXTENSION_NAME
@@ -27,8 +33,8 @@ void launch_matmul(const at::Tensor &a, const at::Tensor &b,
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.doc() = "A2A3 PTO demo pybind launcher";
-  m.def("launch_add", &launch_add, py::arg("y"), py::arg("x"),
-        py::arg("z"), py::arg("n"), py::arg("block_dim"), py::arg("stream"));
+  m.def("launch_add", &launch_add, py::arg("y"), py::arg("x"), py::arg("z"),
+        py::arg("n"), py::arg("block_dim"), py::arg("stream"));
   m.def("launch_matmul", &launch_matmul, py::arg("a"), py::arg("b"),
         py::arg("c"), py::arg("m"), py::arg("block_dim"), py::arg("stream"));
 }

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_kernel_ctypes.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import sys
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import (  # noqa: E402
+    assert_close,
+    compile_kernel,
+    configure_torch_npu,
+    cube_core_count,
+    run_repeated,
+    stream_ptr,
+    tensor_ptr,
+    vector_core_count,
+)
+
+
+def run_add(device: str, n: int) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "add")))
+    lib.call_add.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    lib.call_add.restype = None
+
+    x = torch.randn(n, device=device, dtype=torch.float16)
+    z = torch.randn(n, device=device, dtype=torch.float16)
+    y = torch.empty_like(x)
+    block_dim = vector_core_count(device)
+    stream = stream_ptr()
+    run_repeated(
+        lambda: lib.call_add(block_dim, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), n)
+    )
+    assert_close(y, x + z)
+    print(f"PASS add n={n} block_dim={block_dim}")
+
+
+def run_matmul(device: str, m: int) -> None:
+    if m % 128 != 0:
+        raise ValueError("m must be a multiple of 128")
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul")))
+    lib.call_matmul.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    lib.call_matmul.restype = None
+
+    torch.manual_seed(0)
+    a = torch.randn(m, 128, device=device, dtype=torch.float16)
+    b = torch.randn(128, 128, device=device, dtype=torch.float16)
+    c = torch.empty(m, 128, device=device, dtype=torch.float16)
+    block_dim = min(cube_core_count(device), max(1, m // 128))
+    stream = stream_ptr()
+    run_repeated(
+        lambda: lib.call_matmul(block_dim, stream, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), m)
+    )
+    assert_close(c, torch.matmul(a, b))
+    print(f"PASS simple_matmul m={m} block_dim={block_dim}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("add", "matmul", "all"), default="all")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--m", type=int, default=128)
+    args = parser.parse_args()
+
+    configure_torch_npu()
+    torch.npu.set_device(args.device)
+    if args.kernel in ("add", "all"):
+        run_add(args.device, args.n)
+    if args.kernel in ("matmul", "all"):
+        run_matmul(args.device, args.m)
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_kernel_ctypes.py
@@ -42,7 +42,9 @@ def run_add(device: str, n: int) -> None:
     block_dim = vector_core_count(device)
     stream = stream_ptr()
     run_repeated(
-        lambda: lib.call_add(block_dim, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), n)
+        lambda: lib.call_add(
+            block_dim, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), n
+        )
     )
     assert_close(y, x + z)
     print(f"PASS add n={n} block_dim={block_dim}")
@@ -69,7 +71,9 @@ def run_matmul(device: str, m: int) -> None:
     block_dim = min(cube_core_count(device), max(1, m // 128))
     stream = stream_ptr()
     run_repeated(
-        lambda: lib.call_matmul(block_dim, stream, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), m)
+        lambda: lib.call_matmul(
+            block_dim, stream, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), m
+        )
     )
     assert_close(c, torch.matmul(a, b))
     print(f"PASS simple_matmul m={m} block_dim={block_dim}")

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_kernel_pybind.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+from torch.utils.cpp_extension import load
+
+HERE = Path(__file__).resolve().parent
+BUILD = HERE / "build"
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import (  # noqa: E402
+    assert_close,
+    configure_torch_npu,
+    cube_core_count,
+    run_repeated,
+    stream_as_int,
+    vector_core_count,
+)
+
+
+def build_kernel(name: str) -> Path:
+    out = subprocess.check_output(["bash", str(HERE / "compile.sh"), name], text=True)
+    return Path(out.strip().splitlines()[-1])
+
+
+def build_module():
+    BUILD.mkdir(exist_ok=True)
+    ext_dir = BUILD / "torch_ext_dynamic"
+    ext_dir.mkdir(exist_ok=True)
+    add_lib = build_kernel("add")
+    matmul_lib = build_kernel("matmul")
+    print("Using pybind launch path: torch.utils.cpp_extension.load")
+    return load(
+        name="pto_dynamic_a2a3_demo",
+        sources=[str(HERE / "pybind.cpp")],
+        extra_ldflags=[str(add_lib), str(matmul_lib), f"-Wl,-rpath,{add_lib.parent}"],
+        build_directory=str(ext_dir),
+        verbose=False,
+    )
+
+
+def run_add(mod, device: str, n: int, stream: int) -> None:
+    x = torch.randn(n, device=device, dtype=torch.float16)
+    z = torch.randn(n, device=device, dtype=torch.float16)
+    y = torch.empty_like(x)
+    block_dim = vector_core_count(device)
+    run_repeated(lambda: mod.launch_add(y, x, z, n, block_dim, stream))
+    assert_close(y, x + z)
+    print(f"PASS pybind add n={n} block_dim={block_dim}")
+
+
+def run_matmul(mod, device: str, m: int, stream: int) -> None:
+    if m % 128 != 0:
+        raise ValueError("m must be a multiple of 128")
+    torch.manual_seed(0)
+    a = torch.randn(m, 128, device=device, dtype=torch.float16)
+    b = torch.randn(128, 128, device=device, dtype=torch.float16)
+    c = torch.empty(m, 128, device=device, dtype=torch.float16)
+    block_dim = min(cube_core_count(device), max(1, m // 128))
+    run_repeated(lambda: mod.launch_matmul(a, b, c, m, block_dim, stream))
+    assert_close(c, torch.matmul(a, b))
+    print(f"PASS pybind simple_matmul m={m} block_dim={block_dim}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("add", "matmul", "all"), default="all")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--m", type=int, default=128)
+    args = parser.parse_args()
+
+    configure_torch_npu()
+    torch.npu.set_device(args.device)
+    mod = build_module()
+    stream = stream_as_int()
+    if args.kernel in ("add", "all"):
+        run_add(mod, args.device, args.n, stream)
+    if args.kernel in ("matmul", "all"):
+        run_matmul(mod, args.device, args.m, stream)
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_mix_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_mix_ctypes.py
@@ -14,7 +14,15 @@ HERE = Path(__file__).resolve().parent
 TILE = 128
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, cube_core_count, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    compile_kernel,
+    configure_torch_npu,
+    cube_core_count,
+    run_repeated,
+    stream_ptr,
+    tensor_ptr,
+)  # noqa: E402
 
 
 def load(kind: str):
@@ -48,7 +56,14 @@ def run_c2v(device: str, rounds: int) -> None:
     ws = workspace(block_dim, device)
     run_repeated(
         lambda: load("matmul_add").call(
-            block_dim, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), tensor_ptr(ws), batch
+            block_dim,
+            stream_ptr(),
+            tensor_ptr(a),
+            tensor_ptr(b),
+            tensor_ptr(c),
+            tensor_ptr(d),
+            tensor_ptr(ws),
+            batch,
         )
     )
     assert_close(c, (a @ b + d).to(torch.float16))
@@ -66,7 +81,14 @@ def run_v2c(device: str, rounds: int) -> None:
     ws = workspace(block_dim, device)
     run_repeated(
         lambda: load("add_matmul").call(
-            block_dim, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), tensor_ptr(ws), batch
+            block_dim,
+            stream_ptr(),
+            tensor_ptr(a),
+            tensor_ptr(b),
+            tensor_ptr(c),
+            tensor_ptr(d),
+            tensor_ptr(ws),
+            batch,
         )
     )
     assert_close(c, ((a + b) @ d).to(torch.float16))
@@ -75,7 +97,9 @@ def run_v2c(device: str, rounds: int) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--kernel", choices=("matmul_add", "add_matmul", "all"), default="all")
+    parser.add_argument(
+        "--kernel", choices=("matmul_add", "add_matmul", "all"), default="all"
+    )
     parser.add_argument("--rounds", type=int, default=1)
     parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
     args = parser.parse_args()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_mix_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_mix_ctypes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import sys
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+TILE = 128
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, cube_core_count, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+
+
+def load(kind: str):
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", kind)))
+    lib.call.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_int64,
+    ]
+    lib.call.restype = None
+    return lib
+
+
+def workspace(block_dim: int, device: str) -> torch.Tensor:
+    return torch.empty(block_dim * TILE, TILE, device=device, dtype=torch.float16)
+
+
+def run_c2v(device: str, rounds: int) -> None:
+    block_dim = cube_core_count(device)
+    batch = rounds * block_dim * TILE
+    torch.manual_seed(0)
+    a = torch.randn(batch, TILE, device=device, dtype=torch.float16)
+    b = torch.randn(TILE, TILE, device=device, dtype=torch.float16)
+    d = torch.randn(batch, TILE, device=device, dtype=torch.float16)
+    c = torch.empty_like(a)
+    ws = workspace(block_dim, device)
+    run_repeated(
+        lambda: load("matmul_add").call(
+            block_dim, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), tensor_ptr(ws), batch
+        )
+    )
+    assert_close(c, (a @ b + d).to(torch.float16))
+    print(f"PASS A2A3 matmul_add_c2v rounds={rounds} batch={batch}")
+
+
+def run_v2c(device: str, rounds: int) -> None:
+    block_dim = cube_core_count(device)
+    batch = rounds * block_dim * TILE
+    torch.manual_seed(1)
+    a = torch.randn(batch, TILE, device=device, dtype=torch.float16)
+    b = torch.randn(batch, TILE, device=device, dtype=torch.float16)
+    d = torch.randn(TILE, TILE, device=device, dtype=torch.float16)
+    c = torch.empty_like(a)
+    ws = workspace(block_dim, device)
+    run_repeated(
+        lambda: load("add_matmul").call(
+            block_dim, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), tensor_ptr(ws), batch
+        )
+    )
+    assert_close(c, ((a + b) @ d).to(torch.float16))
+    print(f"PASS A2A3 add_matmul_v2c rounds={rounds} batch={batch}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("matmul_add", "add_matmul", "all"), default="all")
+    parser.add_argument("--rounds", type=int, default=1)
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    args = parser.parse_args()
+    configure_torch_npu()
+    torch.npu.set_device(args.device)
+    if args.kernel in ("matmul_add", "all"):
+        run_c2v(args.device, args.rounds)
+    if args.kernel in ("add_matmul", "all"):
+        run_v2c(args.device, args.rounds)
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_sim.sh
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/run_sim.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-msprof}"
+shift || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUN_WITH_TIMEOUT="${REFERENCE_DIR}/run_with_timeout.sh"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+SOC_VERSION="${MSPROF_SOC_VERSION:-Ascend910B2}"
+source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+cd "${SCRIPT_DIR}"
+
+case "${MODE}" in
+  msprof)
+    export PTO_SIMULATOR=1
+    SIM_LIB="${ASCEND_HOME_PATH}/tools/simulator/${SOC_VERSION}/lib"
+    export LD_LIBRARY_PATH="${SIM_LIB}:${LD_LIBRARY_PATH:-}"
+    MSPROF_TIMEOUT="${MSPROF_TIMEOUT:-120}" msprof op simulator \
+      --soc-version="${SOC_VERSION}" \
+      --timeout="${MSPROF_TIMEOUT}" \
+      --output="${SCRIPT_DIR}/outputs/msprof_dynamic" \
+      python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  direct)
+    "${RUN_WITH_TIMEOUT}" python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  *)
+    echo "usage: $0 {msprof|direct} [run_kernel_ctypes.py args]" >&2
+    exit 2
+    ;;
+esac

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/README.md
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/README.md
@@ -34,26 +34,26 @@ Optional cannsim path:
 
 Use tiny shapes first. CA-model startup dominates wall time.
 
-Pybind CA-model smoke:
+Pybind CA-model smoke (allow ~90 s wall time):
 
 ```bash
-msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=120 \
   --output=outputs/msprof_pybind \
   python3 run_kernel_pybind.py --kernel all --n 128 --block-dim 8
 ```
 
 ## A5 Mix Notes
 
-Run one mix direction at a time under CA model:
+Run one mix direction at a time under CA model. Mix kernels need **120–180 s** simulator timeout (observed ~177 s for C2V on 910B hosts):
 
 ```bash
-msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=180 \
   --output=outputs/msprof_mix_c2v \
   python3 run_mix_ctypes.py --kernel matmul_add --rounds 1 --block-dim 8
 ```
 
 ```bash
-msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=180 \
   --output=outputs/msprof_mix_v2c \
   python3 run_mix_ctypes.py --kernel add_matmul --rounds 1 --block-dim 8
 ```

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/README.md
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/README.md
@@ -1,0 +1,61 @@
+# Dynamic Multi-Core A5
+
+This directory mirrors `dynamic_multi_core/a2a3` but targets A5/Ascend950. On Ascend910B hosts, A5 is verified through CPU CA-model launch modes only.
+
+**Do not use `./run_sim.sh direct` or bare `run_kernel_ctypes.py` on a 910B NPU.** A5 `dav-c310` kernels will fault with `507035` on A2A3 hardware. Use `msprof`, `cannsim`, or test on real Ascend950 hardware.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `add.cpp` | Vector kernel: `y = x + z`, dynamic length, A5 `dav-c310-vec`. |
+| `matmul.cpp` | Tiny dynamic cube matmul smoke, shape `(16,16)x(16,16)`. |
+| `matmul_add.cpp`, `add_matmul.cpp` | Self-contained A5 mix kernels for direct C2V and V2C handoff. |
+| `compile.sh` | Raw A5 `bisheng` command for `add`. |
+| `run_kernel_ctypes.py` | ctypes runner with simulator-safe CPU-created inputs. |
+| `run_mix_ctypes.py` | Reduced `rounds=1` CA-model smoke for A5 mix directions. |
+| `run_sim.sh` | `msprof`, `cannsim`, or `direct` launch wrapper. |
+| `pybind.cpp`, `run_kernel_pybind.py` | Tensor-style pybind launcher for add and tiny matmul under CA model. |
+
+## A5 CA-Model Smoke
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+./run_sim.sh msprof --n 128 --block-dim 8
+```
+
+Optional cannsim path:
+
+```bash
+./run_sim.sh cannsim --output-json outputs/add_cannsim.json
+```
+
+`cannsim` may report a user-process segmentation fault during teardown after the kernel has written valid PASS JSON. `run_sim.sh` accepts that case only when the requested JSON exists and contains `"result": "PASS"`.
+
+Use tiny shapes first. CA-model startup dominates wall time.
+
+Pybind CA-model smoke:
+
+```bash
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_pybind \
+  python3 run_kernel_pybind.py --kernel all --n 128 --block-dim 8
+```
+
+## A5 Mix Notes
+
+Run one mix direction at a time under CA model:
+
+```bash
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_mix_c2v \
+  python3 run_mix_ctypes.py --kernel matmul_add --rounds 1 --block-dim 8
+```
+
+```bash
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_mix_v2c \
+  python3 run_mix_ctypes.py --kernel add_matmul --rounds 1 --block-dim 8
+```
+
+CA-model mix kernels are much slower than vector kernels. Keep `rounds=1` unless you explicitly need a larger simulation.

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add.cpp
@@ -1,0 +1,66 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr uint32_t UB_BYTES_PER_TILE = 32 * 1024;
+constexpr uint32_t ELEMS_PER_TILE = UB_BYTES_PER_TILE / sizeof(half);
+constexpr unsigned X_UB = 0x00000;
+constexpr unsigned Z_UB = 0x08000;
+constexpr unsigned Y_UB = 0x10000;
+
+template <typename T>
+AICORE void run_add(__gm__ T *y, __gm__ T *x, __gm__ T *z, uint32_t n) {
+#if defined(__DAV_VEC__)
+  const uint32_t num_cores = block_num;
+  const uint32_t core = block_idx;
+  const uint32_t per_core = (n + num_cores - 1) / num_cores;
+  const uint32_t base = core * per_core;
+  if (base >= n) return;
+
+  uint32_t remaining_core = per_core;
+  if (base + remaining_core > n) remaining_core = n - base;
+
+  using Shape = pto::Shape<1, 1, 1, 1, ELEMS_PER_TILE>;
+  using Stride = pto::Stride<1, 1, 1, 1, 1>;
+  using Global = pto::GlobalTensor<T, Shape, Stride>;
+  using VecTile =
+      Tile<TileType::Vec, T, 1, ELEMS_PER_TILE, BLayout::RowMajor, -1, -1>;
+
+  Global x_g(x + base);
+  Global z_g(z + base);
+  Global y_g(y + base);
+
+  for (uint32_t done = 0; done < remaining_core; done += ELEMS_PER_TILE) {
+    const uint32_t cols =
+        (remaining_core - done > ELEMS_PER_TILE) ? ELEMS_PER_TILE
+                                                 : (remaining_core - done);
+    VecTile x_t(1, cols), z_t(1, cols), y_t(1, cols);
+    TASSIGN(x_t, X_UB);
+    TASSIGN(z_t, Z_UB);
+    TASSIGN(y_t, Y_UB);
+    TASSIGN(x_g, x + base + done);
+    TASSIGN(z_g, z + base + done);
+    TASSIGN(y_g, y + base + done);
+
+    TLOAD(x_t, x_g);
+    TLOAD(z_t, z_g);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(y_t, x_t, z_t);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(y_g, y_t);
+    pipe_barrier(PIPE_ALL);
+  }
+#endif
+}
+
+extern "C" __global__ AICORE void add_kernel(__gm__ void *y, __gm__ void *x,
+                                             __gm__ void *z, uint32_t n) {
+  run_add<half>((__gm__ half *)y, (__gm__ half *)x, (__gm__ half *)z, n);
+}
+
+extern "C" void call_add(uint32_t block_dim, void *stream, uint8_t *y,
+                         uint8_t *x, uint8_t *z, uint32_t n) {
+  add_kernel<<<block_dim, nullptr, stream>>>(y, x, z, n);
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add.cpp
@@ -31,9 +31,9 @@ AICORE void run_add(__gm__ T *y, __gm__ T *x, __gm__ T *z, uint32_t n) {
   Global y_g(y + base);
 
   for (uint32_t done = 0; done < remaining_core; done += ELEMS_PER_TILE) {
-    const uint32_t cols =
-        (remaining_core - done > ELEMS_PER_TILE) ? ELEMS_PER_TILE
-                                                 : (remaining_core - done);
+    const uint32_t cols = (remaining_core - done > ELEMS_PER_TILE)
+                              ? ELEMS_PER_TILE
+                              : (remaining_core - done);
     VecTile x_t(1, cols), z_t(1, cols), y_t(1, cols);
     TASSIGN(x_t, X_UB);
     TASSIGN(z_t, Z_UB);

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add_matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add_matmul.cpp
@@ -1,0 +1,113 @@
+#include "cv_sync_common.hpp"
+
+#ifdef __CCE_AICORE__
+
+AICORE void run_add_matmul_v2c(__gm__ half *A, __gm__ half *B, __gm__ half *C, __gm__ half *D, int64_t batch)
+{
+    const int32_t cid = static_cast<int32_t>(get_block_idx());
+    const int32_t vid = static_cast<int32_t>(get_subblockid());
+    const int32_t num_cores = static_cast<int32_t>(block_num);
+    const int32_t wave_rows = num_cores * TILE_SIZE;
+    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+    constexpr uint16_t READY_FLAG = 10;
+    constexpr uint16_t FREE_FLAG = 11;
+
+    TileL1 d_l1, ab_l1;
+    TileL1Insert ab_insert;
+    TASSIGN(d_l1, L1_0_OFFSET);
+    TASSIGN(ab_l1, L1_1_OFFSET);
+    TASSIGN(ab_insert, L1_1_OFFSET);
+
+    TileL0A ab_l0;
+    TileL0B d_l0;
+    TileL0C c_l0;
+    TASSIGN(ab_l0, L0_OFFSET);
+    TASSIGN(d_l0, L0_OFFSET);
+    TASSIGN(c_l0, L0_OFFSET);
+
+    TileVec a_ub, b_ub;
+    TileVecNZ ab_nz;
+    TASSIGN(a_ub, UB_0_OFFSET);
+    TASSIGN(b_ub, UB_1_OFFSET);
+    TASSIGN(ab_nz, UB_2_OFFSET);
+
+#if defined(__DAV_CUBE__)
+    TileGlobal d_global(D);
+    TLOAD(d_l1, d_global);
+    SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    TMOV(d_l0, d_l1);
+    SetFlag<PIPE_MTE1, PIPE_M>(0);
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+
+        WaitBothVec<PIPE_MTE1>(READY_FLAG);
+        pipe_barrier(PIPE_ALL);
+        TMOV(ab_l0, ab_l1);
+        SetFlag<PIPE_MTE1, PIPE_M>(0);
+        WaitFlag<PIPE_MTE1, PIPE_M>(0);
+        pipe_barrier(PIPE_ALL);
+        SignalBothVec<PIPE_MTE1>(FREE_FLAG);
+
+        TMATMUL(c_l0, ab_l0, d_l0);
+        SetFlag<PIPE_M, PIPE_FIX>(0);
+        WaitFlag<PIPE_M, PIPE_FIX>(0);
+
+        TileGlobal c_global(C + row_c * TILE_SIZE);
+        TSTORE(c_global, c_l0);
+        pipe_barrier(PIPE_ALL);
+    }
+#endif
+
+#if defined(__DAV_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+
+        HalfTileGlobal a_global(A + row_v * TILE_SIZE);
+        HalfTileGlobal b_global(B + row_v * TILE_SIZE);
+        TLOAD(a_ub, a_global);
+        TLOAD(b_ub, b_global);
+        SetFlag<PIPE_MTE2, PIPE_V>(0);
+        WaitFlag<PIPE_MTE2, PIPE_V>(0);
+
+        TADD(a_ub, a_ub, b_ub);
+        SetFlag<PIPE_V, PIPE_MTE3>(0);
+        WaitFlag<PIPE_V, PIPE_MTE3>(0);
+        TMOV(ab_nz, a_ub);
+        SetFlag<PIPE_V, PIPE_MTE3>(0);
+        WaitFlag<PIPE_V, PIPE_MTE3>(0);
+
+        if (r > 0) {
+            wait_intra_block(PIPE_MTE3, FREE_FLAG);
+            pipe_barrier(PIPE_ALL);
+        }
+        TINSERT(ab_insert, ab_nz, static_cast<uint16_t>(vid * HALF_TILE), static_cast<uint16_t>(0));
+        pipe_barrier(PIPE_ALL);
+        set_intra_block(PIPE_MTE3, READY_FLAG);
+    }
+    if (num_rounds > 0) {
+        wait_intra_block(PIPE_MTE3, FREE_FLAG);
+        pipe_barrier(PIPE_ALL);
+    }
+#endif
+}
+
+#endif
+
+extern "C" __global__ AICORE void add_matmul_v2c_kernel(__gm__ uint8_t *A, __gm__ uint8_t *B, __gm__ uint8_t *C,
+                                                         __gm__ uint8_t *D, int64_t batch)
+{
+    run_add_matmul_v2c(reinterpret_cast<__gm__ half *>(A), reinterpret_cast<__gm__ half *>(B),
+                       reinterpret_cast<__gm__ half *>(C), reinterpret_cast<__gm__ half *>(D), batch);
+}
+
+void LaunchAddMatmulV2C(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
+                        void *stream)
+{
+    add_matmul_v2c_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, batch);
+}
+

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add_matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/add_matmul.cpp
@@ -2,112 +2,115 @@
 
 #ifdef __CCE_AICORE__
 
-AICORE void run_add_matmul_v2c(__gm__ half *A, __gm__ half *B, __gm__ half *C, __gm__ half *D, int64_t batch)
-{
-    const int32_t cid = static_cast<int32_t>(get_block_idx());
-    const int32_t vid = static_cast<int32_t>(get_subblockid());
-    const int32_t num_cores = static_cast<int32_t>(block_num);
-    const int32_t wave_rows = num_cores * TILE_SIZE;
-    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
-    constexpr uint16_t READY_FLAG = 10;
-    constexpr uint16_t FREE_FLAG = 11;
+AICORE void run_add_matmul_v2c(__gm__ half *A, __gm__ half *B, __gm__ half *C,
+                               __gm__ half *D, int64_t batch) {
+  const int32_t cid = static_cast<int32_t>(get_block_idx());
+  const int32_t vid = static_cast<int32_t>(get_subblockid());
+  const int32_t num_cores = static_cast<int32_t>(block_num);
+  const int32_t wave_rows = num_cores * TILE_SIZE;
+  const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+  constexpr uint16_t READY_FLAG = 10;
+  constexpr uint16_t FREE_FLAG = 11;
 
-    TileL1 d_l1, ab_l1;
-    TileL1Insert ab_insert;
-    TASSIGN(d_l1, L1_0_OFFSET);
-    TASSIGN(ab_l1, L1_1_OFFSET);
-    TASSIGN(ab_insert, L1_1_OFFSET);
+  TileL1 d_l1, ab_l1;
+  TileL1Insert ab_insert;
+  TASSIGN(d_l1, L1_0_OFFSET);
+  TASSIGN(ab_l1, L1_1_OFFSET);
+  TASSIGN(ab_insert, L1_1_OFFSET);
 
-    TileL0A ab_l0;
-    TileL0B d_l0;
-    TileL0C c_l0;
-    TASSIGN(ab_l0, L0_OFFSET);
-    TASSIGN(d_l0, L0_OFFSET);
-    TASSIGN(c_l0, L0_OFFSET);
+  TileL0A ab_l0;
+  TileL0B d_l0;
+  TileL0C c_l0;
+  TASSIGN(ab_l0, L0_OFFSET);
+  TASSIGN(d_l0, L0_OFFSET);
+  TASSIGN(c_l0, L0_OFFSET);
 
-    TileVec a_ub, b_ub;
-    TileVecNZ ab_nz;
-    TASSIGN(a_ub, UB_0_OFFSET);
-    TASSIGN(b_ub, UB_1_OFFSET);
-    TASSIGN(ab_nz, UB_2_OFFSET);
+  TileVec a_ub, b_ub;
+  TileVecNZ ab_nz;
+  TASSIGN(a_ub, UB_0_OFFSET);
+  TASSIGN(b_ub, UB_1_OFFSET);
+  TASSIGN(ab_nz, UB_2_OFFSET);
 
 #if defined(__DAV_CUBE__)
-    TileGlobal d_global(D);
-    TLOAD(d_l1, d_global);
-    SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
-    WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-    TMOV(d_l0, d_l1);
+  TileGlobal d_global(D);
+  TLOAD(d_l1, d_global);
+  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(d_l0, d_l1);
+  SetFlag<PIPE_MTE1, PIPE_M>(0);
+  WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+
+    WaitBothVec<PIPE_MTE1>(READY_FLAG);
+    pipe_barrier(PIPE_ALL);
+    TMOV(ab_l0, ab_l1);
     SetFlag<PIPE_MTE1, PIPE_M>(0);
     WaitFlag<PIPE_MTE1, PIPE_M>(0);
+    pipe_barrier(PIPE_ALL);
+    SignalBothVec<PIPE_MTE1>(FREE_FLAG);
 
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+    TMATMUL(c_l0, ab_l0, d_l0);
+    SetFlag<PIPE_M, PIPE_FIX>(0);
+    WaitFlag<PIPE_M, PIPE_FIX>(0);
 
-        WaitBothVec<PIPE_MTE1>(READY_FLAG);
-        pipe_barrier(PIPE_ALL);
-        TMOV(ab_l0, ab_l1);
-        SetFlag<PIPE_MTE1, PIPE_M>(0);
-        WaitFlag<PIPE_MTE1, PIPE_M>(0);
-        pipe_barrier(PIPE_ALL);
-        SignalBothVec<PIPE_MTE1>(FREE_FLAG);
-
-        TMATMUL(c_l0, ab_l0, d_l0);
-        SetFlag<PIPE_M, PIPE_FIX>(0);
-        WaitFlag<PIPE_M, PIPE_FIX>(0);
-
-        TileGlobal c_global(C + row_c * TILE_SIZE);
-        TSTORE(c_global, c_l0);
-        pipe_barrier(PIPE_ALL);
-    }
+    TileGlobal c_global(C + row_c * TILE_SIZE);
+    TSTORE(c_global, c_l0);
+    pipe_barrier(PIPE_ALL);
+  }
 #endif
 
 #if defined(__DAV_VEC__)
-    set_mask_norm();
-    set_vector_mask(-1, -1);
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
 
-        HalfTileGlobal a_global(A + row_v * TILE_SIZE);
-        HalfTileGlobal b_global(B + row_v * TILE_SIZE);
-        TLOAD(a_ub, a_global);
-        TLOAD(b_ub, b_global);
-        SetFlag<PIPE_MTE2, PIPE_V>(0);
-        WaitFlag<PIPE_MTE2, PIPE_V>(0);
+    HalfTileGlobal a_global(A + row_v * TILE_SIZE);
+    HalfTileGlobal b_global(B + row_v * TILE_SIZE);
+    TLOAD(a_ub, a_global);
+    TLOAD(b_ub, b_global);
+    SetFlag<PIPE_MTE2, PIPE_V>(0);
+    WaitFlag<PIPE_MTE2, PIPE_V>(0);
 
-        TADD(a_ub, a_ub, b_ub);
-        SetFlag<PIPE_V, PIPE_MTE3>(0);
-        WaitFlag<PIPE_V, PIPE_MTE3>(0);
-        TMOV(ab_nz, a_ub);
-        SetFlag<PIPE_V, PIPE_MTE3>(0);
-        WaitFlag<PIPE_V, PIPE_MTE3>(0);
+    TADD(a_ub, a_ub, b_ub);
+    SetFlag<PIPE_V, PIPE_MTE3>(0);
+    WaitFlag<PIPE_V, PIPE_MTE3>(0);
+    TMOV(ab_nz, a_ub);
+    SetFlag<PIPE_V, PIPE_MTE3>(0);
+    WaitFlag<PIPE_V, PIPE_MTE3>(0);
 
-        if (r > 0) {
-            wait_intra_block(PIPE_MTE3, FREE_FLAG);
-            pipe_barrier(PIPE_ALL);
-        }
-        TINSERT(ab_insert, ab_nz, static_cast<uint16_t>(vid * HALF_TILE), static_cast<uint16_t>(0));
-        pipe_barrier(PIPE_ALL);
-        set_intra_block(PIPE_MTE3, READY_FLAG);
+    if (r > 0) {
+      wait_intra_block(PIPE_MTE3, FREE_FLAG);
+      pipe_barrier(PIPE_ALL);
     }
-    if (num_rounds > 0) {
-        wait_intra_block(PIPE_MTE3, FREE_FLAG);
-        pipe_barrier(PIPE_ALL);
-    }
+    TINSERT(ab_insert, ab_nz, static_cast<uint16_t>(vid * HALF_TILE),
+            static_cast<uint16_t>(0));
+    pipe_barrier(PIPE_ALL);
+    set_intra_block(PIPE_MTE3, READY_FLAG);
+  }
+  if (num_rounds > 0) {
+    wait_intra_block(PIPE_MTE3, FREE_FLAG);
+    pipe_barrier(PIPE_ALL);
+  }
 #endif
 }
 
 #endif
 
-extern "C" __global__ AICORE void add_matmul_v2c_kernel(__gm__ uint8_t *A, __gm__ uint8_t *B, __gm__ uint8_t *C,
-                                                         __gm__ uint8_t *D, int64_t batch)
-{
-    run_add_matmul_v2c(reinterpret_cast<__gm__ half *>(A), reinterpret_cast<__gm__ half *>(B),
-                       reinterpret_cast<__gm__ half *>(C), reinterpret_cast<__gm__ half *>(D), batch);
+extern "C" __global__ AICORE void add_matmul_v2c_kernel(__gm__ uint8_t *A,
+                                                        __gm__ uint8_t *B,
+                                                        __gm__ uint8_t *C,
+                                                        __gm__ uint8_t *D,
+                                                        int64_t batch) {
+  run_add_matmul_v2c(reinterpret_cast<__gm__ half *>(A),
+                     reinterpret_cast<__gm__ half *>(B),
+                     reinterpret_cast<__gm__ half *>(C),
+                     reinterpret_cast<__gm__ half *>(D), batch);
 }
 
-void LaunchAddMatmulV2C(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
-                        void *stream)
-{
-    add_matmul_v2c_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, batch);
+void LaunchAddMatmulV2C(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C,
+                        uint8_t *D, int64_t batch, void *stream) {
+  add_matmul_v2c_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, batch);
 }
-

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/compile.sh
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/compile.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL="${1:-add}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+mkdir -p "${BUILD_DIR}"
+
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+PTO_LIB_PATH="${PTO_LIB_PATH:-${ASCEND_HOME_PATH}}"
+BISHENG="${ASCEND_HOME_PATH}/bin/bisheng"
+if [[ ! -x "${BISHENG}" ]]; then
+  BISHENG="$(command -v bisheng)"
+fi
+
+case "${KERNEL}" in
+  add)
+    SRC="${SCRIPT_DIR}/add.cpp"
+    OUT="${BUILD_DIR}/libadd_a5.so"
+    ARCH="dav-c310-vec"
+    ;;
+  matmul)
+    SRC="${SCRIPT_DIR}/matmul.cpp"
+    OUT="${BUILD_DIR}/libmatmul_a5.so"
+    ARCH="dav-c310-cube"
+    ;;
+  mix)
+    OUT="${BUILD_DIR}/libmix_a5.so"
+    ARCH="dav-c310"
+    ;;
+  *)
+    echo "usage: $0 {add|matmul|mix}" >&2
+    exit 2
+    ;;
+esac
+
+COMMON_FLAGS=(
+  -I"${PTO_LIB_PATH}/include" \
+  -I"${ASCEND_HOME_PATH}/include" \
+  -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+  -I"${SCRIPT_DIR}" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/profiling" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/runtime/runtime" \
+  -std=gnu++17 -O2 -Wno-macro-redefined -Wno-ignored-attributes \
+  -fPIC -xcce -Xhost-start -Xhost-end \
+  -mllvm -cce-aicore-stack-size=0x8000 \
+  -mllvm -cce-aicore-function-stack-size=0x8000 \
+  -mllvm -cce-aicore-record-overflow=true \
+  -mllvm -cce-aicore-addr-transform \
+  -mllvm -cce-aicore-dcci-insert-for-scalar=false \
+  --cce-aicore-arch="${ARCH}" -DREGISTER_BASE
+)
+
+if [[ "${KERNEL}" == "add" || "${KERNEL}" == "matmul" ]]; then
+  "${BISHENG}" "${COMMON_FLAGS[@]}" -c "${SRC}" -o "${BUILD_DIR}/${KERNEL}.o"
+  "${BISHENG}" -fPIC -shared --cce-fatobj-link \
+    -Wl,-soname,"$(basename "${OUT}")" \
+    "${BUILD_DIR}/${KERNEL}.o" -o "${OUT}"
+else
+  kernel_objs=()
+  for src in matmul_add.cpp add_matmul.cpp; do
+    obj="${BUILD_DIR}/${src%.cpp}.o"
+    "${BISHENG}" "${COMMON_FLAGS[@]}" -c "${SCRIPT_DIR}/${src}" -o "${obj}"
+    kernel_objs+=("${obj}")
+  done
+  kernel_so="${BUILD_DIR}/libmix_a5_kernels.so"
+  "${BISHENG}" -fPIC -shared --cce-fatobj-link \
+    -Wl,-soname,"$(basename "${kernel_so}")" \
+    "${kernel_objs[@]}" -o "${kernel_so}"
+  "${BISHENG}" \
+    -I"${ASCEND_HOME_PATH}/include" \
+    -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+    -I"${SCRIPT_DIR}" \
+    -std=gnu++17 -O2 -Wno-macro-redefined -Wno-ignored-attributes \
+    -xc++ -include stdint.h -include stddef.h -fPIC \
+    -c "${SCRIPT_DIR}/launch_api.cpp" -o "${BUILD_DIR}/launch_api.o"
+  "${BISHENG}" "${BUILD_DIR}/launch_api.o" -shared -o "${OUT}" \
+    -L"${BUILD_DIR}" -lmix_a5_kernels -lstdc++ -Wl,-rpath,"${BUILD_DIR}"
+fi
+
+echo "${OUT}"

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/cv_sync_common.hpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/cv_sync_common.hpp
@@ -25,52 +25,58 @@ constexpr uint32_t C2V_FLOAT_UB_BASE = 0x20000u;
 
 #ifdef __CCE_AICORE__
 
-using TileL1 = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::ColMajor, TILE_SIZE, TILE_SIZE,
-                    SLayout::RowMajor, 512, PadValue::Zero>;
-using TileL1Insert = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::RowMajor, TILE_SIZE, TILE_SIZE,
-                          SLayout::RowMajor, 512, PadValue::Zero>;
+using TileL1 =
+    Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::ColMajor,
+         TILE_SIZE, TILE_SIZE, SLayout::RowMajor, 512, PadValue::Zero>;
+using TileL1Insert =
+    Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::RowMajor,
+         TILE_SIZE, TILE_SIZE, SLayout::RowMajor, 512, PadValue::Zero>;
 using TileL0A = TileLeft<half, TILE_SIZE, TILE_SIZE>;
 using TileL0B = TileRight<half, TILE_SIZE, TILE_SIZE>;
 using TileL0C = TileAcc<float, TILE_SIZE, TILE_SIZE>;
-using TileVec = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::RowMajor, HALF_TILE, TILE_SIZE,
-                     SLayout::NoneBox, 512, PadValue::Null>;
-using TileVecNZ = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::ColMajor, HALF_TILE, TILE_SIZE,
-                       SLayout::RowMajor, 512, PadValue::Null>;
-using TileVecFloat = Tile<TileType::Vec, float, HALF_TILE, TILE_SIZE, BLayout::RowMajor, HALF_TILE, TILE_SIZE,
-                          SLayout::NoneBox, 512, PadValue::Null>;
+using TileVec =
+    Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::RowMajor,
+         HALF_TILE, TILE_SIZE, SLayout::NoneBox, 512, PadValue::Null>;
+using TileVecNZ =
+    Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::ColMajor,
+         HALF_TILE, TILE_SIZE, SLayout::RowMajor, 512, PadValue::Null>;
+using TileVecFloat =
+    Tile<TileType::Vec, float, HALF_TILE, TILE_SIZE, BLayout::RowMajor,
+         HALF_TILE, TILE_SIZE, SLayout::NoneBox, 512, PadValue::Null>;
 
-using TileGlobal = GlobalTensor<half, TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
-                                BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>, Layout::ND>;
-using HalfTileGlobal = GlobalTensor<half, TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
-                                    BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>, Layout::ND>;
-using HalfTileGlobalFloat = GlobalTensor<float, TileShape2D<float, HALF_TILE, TILE_SIZE, Layout::ND>,
-                                         BaseShape2D<float, HALF_TILE, TILE_SIZE, Layout::ND>, Layout::ND>;
+using TileGlobal =
+    GlobalTensor<half, TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
+using HalfTileGlobal =
+    GlobalTensor<half, TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
+using HalfTileGlobalFloat =
+    GlobalTensor<float, TileShape2D<float, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 BaseShape2D<float, HALF_TILE, TILE_SIZE, Layout::ND>,
+                 Layout::ND>;
 
 template <pipe_t Src, pipe_t Dst>
-AICORE inline void SetFlag(uint32_t id)
-{
-    set_flag(Src, Dst, static_cast<event_t>(id));
+AICORE inline void SetFlag(uint32_t id) {
+  set_flag(Src, Dst, static_cast<event_t>(id));
 }
 
 template <pipe_t Src, pipe_t Dst>
-AICORE inline void WaitFlag(uint32_t id)
-{
-    wait_flag(Src, Dst, static_cast<event_t>(id));
+AICORE inline void WaitFlag(uint32_t id) {
+  wait_flag(Src, Dst, static_cast<event_t>(id));
 }
 
 template <pipe_t Pipe>
-AICORE inline void SignalBothVec(uint16_t flag)
-{
-    set_intra_block(Pipe, flag);
-    set_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+AICORE inline void SignalBothVec(uint16_t flag) {
+  set_intra_block(Pipe, flag);
+  set_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
 }
 
 template <pipe_t Pipe>
-AICORE inline void WaitBothVec(uint16_t flag)
-{
-    wait_intra_block(Pipe, flag);
-    wait_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+AICORE inline void WaitBothVec(uint16_t flag) {
+  wait_intra_block(Pipe, flag);
+  wait_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
 }
 
 #endif
-

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/cv_sync_common.hpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/cv_sync_common.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr int32_t TILE_SIZE = 128;
+constexpr int32_t HALF_TILE = 64;
+constexpr int32_t VEC_NUM = 2;
+
+constexpr uint16_t FLAG_READY = 0;
+constexpr uint16_t FLAG_FREE = 1;
+constexpr uint16_t FLAG_V2C_READY = 2;
+constexpr uint16_t FLAG_V2C_FREE = 3;
+constexpr uint16_t VEC_FLAG_OFFSET = 16;
+
+constexpr uint32_t L1_0_OFFSET = 0u;
+constexpr uint32_t L1_1_OFFSET = TILE_SIZE * TILE_SIZE * sizeof(half);
+constexpr uint32_t L1_2_OFFSET = 2 * TILE_SIZE * TILE_SIZE * sizeof(half);
+constexpr uint32_t L0_OFFSET = 0u;
+constexpr uint32_t UB_0_OFFSET = 0u;
+constexpr uint32_t UB_1_OFFSET = HALF_TILE * TILE_SIZE * sizeof(half);
+constexpr uint32_t UB_2_OFFSET = 2 * HALF_TILE * TILE_SIZE * sizeof(half);
+constexpr uint32_t C2V_FLOAT_UB_BASE = 0x20000u;
+
+#ifdef __CCE_AICORE__
+
+using TileL1 = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::ColMajor, TILE_SIZE, TILE_SIZE,
+                    SLayout::RowMajor, 512, PadValue::Zero>;
+using TileL1Insert = Tile<TileType::Mat, half, TILE_SIZE, TILE_SIZE, BLayout::RowMajor, TILE_SIZE, TILE_SIZE,
+                          SLayout::RowMajor, 512, PadValue::Zero>;
+using TileL0A = TileLeft<half, TILE_SIZE, TILE_SIZE>;
+using TileL0B = TileRight<half, TILE_SIZE, TILE_SIZE>;
+using TileL0C = TileAcc<float, TILE_SIZE, TILE_SIZE>;
+using TileVec = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::RowMajor, HALF_TILE, TILE_SIZE,
+                     SLayout::NoneBox, 512, PadValue::Null>;
+using TileVecNZ = Tile<TileType::Vec, half, HALF_TILE, TILE_SIZE, BLayout::ColMajor, HALF_TILE, TILE_SIZE,
+                       SLayout::RowMajor, 512, PadValue::Null>;
+using TileVecFloat = Tile<TileType::Vec, float, HALF_TILE, TILE_SIZE, BLayout::RowMajor, HALF_TILE, TILE_SIZE,
+                          SLayout::NoneBox, 512, PadValue::Null>;
+
+using TileGlobal = GlobalTensor<half, TileShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>,
+                                BaseShape2D<half, TILE_SIZE, TILE_SIZE, Layout::ND>, Layout::ND>;
+using HalfTileGlobal = GlobalTensor<half, TileShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>,
+                                    BaseShape2D<half, HALF_TILE, TILE_SIZE, Layout::ND>, Layout::ND>;
+using HalfTileGlobalFloat = GlobalTensor<float, TileShape2D<float, HALF_TILE, TILE_SIZE, Layout::ND>,
+                                         BaseShape2D<float, HALF_TILE, TILE_SIZE, Layout::ND>, Layout::ND>;
+
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void SetFlag(uint32_t id)
+{
+    set_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void WaitFlag(uint32_t id)
+{
+    wait_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+template <pipe_t Pipe>
+AICORE inline void SignalBothVec(uint16_t flag)
+{
+    set_intra_block(Pipe, flag);
+    set_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+}
+
+template <pipe_t Pipe>
+AICORE inline void WaitBothVec(uint16_t flag)
+{
+    wait_intra_block(Pipe, flag);
+    wait_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+}
+
+#endif
+

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/launch_api.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/launch_api.cpp
@@ -1,0 +1,19 @@
+#include <cstdint>
+
+void LaunchMatmulAddC2V(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
+                        void *stream);
+void LaunchAddMatmulV2C(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
+                        void *stream);
+
+extern "C" void cv_matmul_add_c2v(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
+                                   void *stream)
+{
+    LaunchMatmulAddC2V(block_dim, A, B, C, D, batch, stream);
+}
+
+extern "C" void cv_add_matmul_v2c(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
+                                   void *stream)
+{
+    LaunchAddMatmulV2C(block_dim, A, B, C, D, batch, stream);
+}
+

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/launch_api.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/launch_api.cpp
@@ -1,19 +1,18 @@
 #include <cstdint>
 
-void LaunchMatmulAddC2V(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
-                        void *stream);
-void LaunchAddMatmulV2C(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
-                        void *stream);
+void LaunchMatmulAddC2V(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C,
+                        uint8_t *D, int64_t batch, void *stream);
+void LaunchAddMatmulV2C(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C,
+                        uint8_t *D, int64_t batch, void *stream);
 
-extern "C" void cv_matmul_add_c2v(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
-                                   void *stream)
-{
-    LaunchMatmulAddC2V(block_dim, A, B, C, D, batch, stream);
+extern "C" void cv_matmul_add_c2v(uint32_t block_dim, uint8_t *A, uint8_t *B,
+                                  uint8_t *C, uint8_t *D, int64_t batch,
+                                  void *stream) {
+  LaunchMatmulAddC2V(block_dim, A, B, C, D, batch, stream);
 }
 
-extern "C" void cv_add_matmul_v2c(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
-                                   void *stream)
-{
-    LaunchAddMatmulV2C(block_dim, A, B, C, D, batch, stream);
+extern "C" void cv_add_matmul_v2c(uint32_t block_dim, uint8_t *A, uint8_t *B,
+                                  uint8_t *C, uint8_t *D, int64_t batch,
+                                  void *stream) {
+  LaunchAddMatmulV2C(block_dim, A, B, C, D, batch, stream);
 }
-

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul.cpp
@@ -1,5 +1,5 @@
-#include <pto/pto-inst.hpp>
 #include <pto/common/pto_tile.hpp>
+#include <pto/pto-inst.hpp>
 
 using namespace pto;
 
@@ -15,7 +15,7 @@ __global__ AICORE void dynamic_matmul_kernel(__gm__ float *out, __gm__ half *a,
   using GlobalB = GlobalTensor<half, pto::Shape<1, 1, 1, K, N>,
                                pto::Stride<K * N, K * N, K * N, N, 1>>;
   using GlobalC = GlobalTensor<float, pto::Shape<1, 1, 1, M, N>,
-                                pto::Stride<M * N, M * N, M * N, N, 1>>;
+                               pto::Stride<M * N, M * N, M * N, N, 1>>;
 
   GlobalA a_g(a);
   GlobalB b_g(b);
@@ -58,6 +58,6 @@ __global__ AICORE void dynamic_matmul_kernel(__gm__ float *out, __gm__ half *a,
 extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *out,
                             uint8_t *a, uint8_t *b) {
   (void)block_dim;
-  dynamic_matmul_kernel<<<1, nullptr, stream>>>((__gm__ float *)out,
-                                                (__gm__ half *)a, (__gm__ half *)b);
+  dynamic_matmul_kernel<<<1, nullptr, stream>>>(
+      (__gm__ float *)out, (__gm__ half *)a, (__gm__ half *)b);
 }

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul.cpp
@@ -1,0 +1,63 @@
+#include <pto/pto-inst.hpp>
+#include <pto/common/pto_tile.hpp>
+
+using namespace pto;
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+__global__ AICORE void dynamic_matmul_kernel(__gm__ float *out, __gm__ half *a,
+                                             __gm__ half *b) {
+#if defined(__DAV_CUBE__)
+  using GlobalA = GlobalTensor<half, pto::Shape<1, 1, 1, M, K>,
+                               pto::Stride<M * K, M * K, M * K, K, 1>>;
+  using GlobalB = GlobalTensor<half, pto::Shape<1, 1, 1, K, N>,
+                               pto::Stride<K * N, K * N, K * N, N, 1>>;
+  using GlobalC = GlobalTensor<float, pto::Shape<1, 1, 1, M, N>,
+                                pto::Stride<M * N, M * N, M * N, N, 1>>;
+
+  GlobalA a_g(a);
+  GlobalB b_g(b);
+  GlobalC c_g(out);
+
+  using MatA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, M, K,
+                    SLayout::RowMajor, 512>;
+  using MatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N,
+                    SLayout::RowMajor, 512>;
+  using Left = TileLeft<half, M, K, M, K>;
+  using Right = TileRight<half, K, N, K, N>;
+  using Acc = TileAcc<float, M, N, M, N>;
+
+  MatA a_l1;
+  MatB b_l1;
+  Left a_l0;
+  Right b_l0;
+  Acc c_l0;
+  TASSIGN(a_l1, 0x0);
+  TASSIGN(b_l1, 0x10000);
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(c_l0, 0x0);
+
+  TLOAD(a_l1, a_g);
+  TLOAD(b_l1, b_g);
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  TMOV(a_l0, a_l1);
+  TMOV(b_l0, b_l1);
+  set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+  wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+  TMATMUL(c_l0, a_l0, b_l0);
+  set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  TSTORE(c_g, c_l0);
+#endif
+}
+
+extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *out,
+                            uint8_t *a, uint8_t *b) {
+  (void)block_dim;
+  dynamic_matmul_kernel<<<1, nullptr, stream>>>((__gm__ float *)out,
+                                                (__gm__ half *)a, (__gm__ half *)b);
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul_add.cpp
@@ -2,103 +2,105 @@
 
 #ifdef __CCE_AICORE__
 
-AICORE void run_matmul_add_c2v(__gm__ half *A, __gm__ half *B, __gm__ float *C, __gm__ float *D, int64_t batch)
-{
-    const int32_t cid = static_cast<int32_t>(get_block_idx());
-    const int32_t vid = static_cast<int32_t>(get_subblockid());
-    const int32_t num_cores = static_cast<int32_t>(block_num);
-    const int32_t wave_rows = num_cores * TILE_SIZE;
-    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+AICORE void run_matmul_add_c2v(__gm__ half *A, __gm__ half *B, __gm__ float *C,
+                               __gm__ float *D, int64_t batch) {
+  const int32_t cid = static_cast<int32_t>(get_block_idx());
+  const int32_t vid = static_cast<int32_t>(get_subblockid());
+  const int32_t num_cores = static_cast<int32_t>(block_num);
+  const int32_t wave_rows = num_cores * TILE_SIZE;
+  const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
 
-    TileL1 b_l1, a_l1;
-    TASSIGN(b_l1, L1_0_OFFSET);
-    TASSIGN(a_l1, L1_1_OFFSET);
+  TileL1 b_l1, a_l1;
+  TASSIGN(b_l1, L1_0_OFFSET);
+  TASSIGN(a_l1, L1_1_OFFSET);
 
-    TileL0A a_l0;
-    TileL0B b_l0;
-    TileL0C c_l0;
-    TASSIGN(a_l0, L0_OFFSET);
-    TASSIGN(b_l0, L0_OFFSET);
-    TASSIGN(c_l0, L0_OFFSET);
+  TileL0A a_l0;
+  TileL0B b_l0;
+  TileL0C c_l0;
+  TASSIGN(a_l0, L0_OFFSET);
+  TASSIGN(b_l0, L0_OFFSET);
+  TASSIGN(c_l0, L0_OFFSET);
 
-    TileVecFloat c_ub, d_ub;
-    TASSIGN(c_ub, C2V_FLOAT_UB_BASE);
-    TASSIGN(d_ub, UB_0_OFFSET);
+  TileVecFloat c_ub, d_ub;
+  TASSIGN(c_ub, C2V_FLOAT_UB_BASE);
+  TASSIGN(d_ub, UB_0_OFFSET);
 
 #if defined(__DAV_CUBE__)
-    TileGlobal b_global(B);
-    TLOAD(b_l1, b_global);
+  TileGlobal b_global(B);
+  TLOAD(b_l1, b_global);
+  SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(b_l0, b_l1);
+  SetFlag<PIPE_MTE1, PIPE_M>(0);
+  WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+    TileGlobal a_global(A + row_c * TILE_SIZE);
+    TLOAD(a_l1, a_global);
     SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
     WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
-    TMOV(b_l0, b_l1);
+
+    TMOV(a_l0, a_l1);
     SetFlag<PIPE_MTE1, PIPE_M>(0);
     WaitFlag<PIPE_MTE1, PIPE_M>(0);
 
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
-        TileGlobal a_global(A + row_c * TILE_SIZE);
-        TLOAD(a_l1, a_global);
-        SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
-        WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    TMATMUL(c_l0, a_l0, b_l0);
+    SetFlag<PIPE_M, PIPE_FIX>(0);
+    WaitFlag<PIPE_M, PIPE_FIX>(0);
 
-        TMOV(a_l0, a_l1);
-        SetFlag<PIPE_MTE1, PIPE_M>(0);
-        WaitFlag<PIPE_MTE1, PIPE_M>(0);
-
-        TMATMUL(c_l0, a_l0, b_l0);
-        SetFlag<PIPE_M, PIPE_FIX>(0);
-        WaitFlag<PIPE_M, PIPE_FIX>(0);
-
-        if (r > 0) {
-            WaitBothVec<PIPE_FIX>(FLAG_FREE);
-        }
-        TMOV<TileVecFloat, TileL0C, AccToVecMode::DualModeSplitM>(c_ub, c_l0);
-        pipe_barrier(PIPE_ALL);
-        SignalBothVec<PIPE_FIX>(FLAG_READY);
+    if (r > 0) {
+      WaitBothVec<PIPE_FIX>(FLAG_FREE);
     }
-    if (num_rounds > 0) {
-        WaitBothVec<PIPE_FIX>(FLAG_FREE);
-        pipe_barrier(PIPE_ALL);
-    }
+    TMOV<TileVecFloat, TileL0C, AccToVecMode::DualModeSplitM>(c_ub, c_l0);
+    pipe_barrier(PIPE_ALL);
+    SignalBothVec<PIPE_FIX>(FLAG_READY);
+  }
+  if (num_rounds > 0) {
+    WaitBothVec<PIPE_FIX>(FLAG_FREE);
+    pipe_barrier(PIPE_ALL);
+  }
 #endif
 
 #if defined(__DAV_VEC__)
-    set_mask_norm();
-    set_vector_mask(-1, -1);
-    for (int32_t r = 0; r < num_rounds; ++r) {
-        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  for (int32_t r = 0; r < num_rounds; ++r) {
+    const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
 
-        wait_intra_block(PIPE_V, FLAG_READY);
+    wait_intra_block(PIPE_V, FLAG_READY);
 
-        HalfTileGlobalFloat d_global(D + row_v * TILE_SIZE);
-        TLOAD(d_ub, d_global);
-        SetFlag<PIPE_MTE2, PIPE_V>(0);
-        WaitFlag<PIPE_MTE2, PIPE_V>(0);
+    HalfTileGlobalFloat d_global(D + row_v * TILE_SIZE);
+    TLOAD(d_ub, d_global);
+    SetFlag<PIPE_MTE2, PIPE_V>(0);
+    WaitFlag<PIPE_MTE2, PIPE_V>(0);
 
-        TADD(c_ub, c_ub, d_ub);
-        SetFlag<PIPE_V, PIPE_MTE3>(0);
-        WaitFlag<PIPE_V, PIPE_MTE3>(0);
+    TADD(c_ub, c_ub, d_ub);
+    SetFlag<PIPE_V, PIPE_MTE3>(0);
+    WaitFlag<PIPE_V, PIPE_MTE3>(0);
 
-        HalfTileGlobalFloat c_global(C + row_v * TILE_SIZE);
-        TSTORE(c_global, c_ub);
-        pipe_barrier(PIPE_ALL);
-        set_intra_block(PIPE_V, FLAG_FREE);
-    }
+    HalfTileGlobalFloat c_global(C + row_v * TILE_SIZE);
+    TSTORE(c_global, c_ub);
+    pipe_barrier(PIPE_ALL);
+    set_intra_block(PIPE_V, FLAG_FREE);
+  }
 #endif
 }
 
 #endif
 
-extern "C" __global__ AICORE void matmul_add_c2v_kernel(__gm__ uint8_t *A, __gm__ uint8_t *B, __gm__ uint8_t *C,
-                                                         __gm__ uint8_t *D, int64_t batch)
-{
-    run_matmul_add_c2v(reinterpret_cast<__gm__ half *>(A), reinterpret_cast<__gm__ half *>(B),
-                       reinterpret_cast<__gm__ float *>(C), reinterpret_cast<__gm__ float *>(D), batch);
+extern "C" __global__ AICORE void matmul_add_c2v_kernel(__gm__ uint8_t *A,
+                                                        __gm__ uint8_t *B,
+                                                        __gm__ uint8_t *C,
+                                                        __gm__ uint8_t *D,
+                                                        int64_t batch) {
+  run_matmul_add_c2v(reinterpret_cast<__gm__ half *>(A),
+                     reinterpret_cast<__gm__ half *>(B),
+                     reinterpret_cast<__gm__ float *>(C),
+                     reinterpret_cast<__gm__ float *>(D), batch);
 }
 
-void LaunchMatmulAddC2V(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
-                        void *stream)
-{
-    matmul_add_c2v_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, batch);
+void LaunchMatmulAddC2V(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C,
+                        uint8_t *D, int64_t batch, void *stream) {
+  matmul_add_c2v_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, batch);
 }
-

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/matmul_add.cpp
@@ -1,0 +1,104 @@
+#include "cv_sync_common.hpp"
+
+#ifdef __CCE_AICORE__
+
+AICORE void run_matmul_add_c2v(__gm__ half *A, __gm__ half *B, __gm__ float *C, __gm__ float *D, int64_t batch)
+{
+    const int32_t cid = static_cast<int32_t>(get_block_idx());
+    const int32_t vid = static_cast<int32_t>(get_subblockid());
+    const int32_t num_cores = static_cast<int32_t>(block_num);
+    const int32_t wave_rows = num_cores * TILE_SIZE;
+    const int32_t num_rounds = static_cast<int32_t>(batch) / wave_rows;
+
+    TileL1 b_l1, a_l1;
+    TASSIGN(b_l1, L1_0_OFFSET);
+    TASSIGN(a_l1, L1_1_OFFSET);
+
+    TileL0A a_l0;
+    TileL0B b_l0;
+    TileL0C c_l0;
+    TASSIGN(a_l0, L0_OFFSET);
+    TASSIGN(b_l0, L0_OFFSET);
+    TASSIGN(c_l0, L0_OFFSET);
+
+    TileVecFloat c_ub, d_ub;
+    TASSIGN(c_ub, C2V_FLOAT_UB_BASE);
+    TASSIGN(d_ub, UB_0_OFFSET);
+
+#if defined(__DAV_CUBE__)
+    TileGlobal b_global(B);
+    TLOAD(b_l1, b_global);
+    SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+    TMOV(b_l0, b_l1);
+    SetFlag<PIPE_MTE1, PIPE_M>(0);
+    WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        const int32_t row_c = r * wave_rows + cid * TILE_SIZE;
+        TileGlobal a_global(A + row_c * TILE_SIZE);
+        TLOAD(a_l1, a_global);
+        SetFlag<PIPE_MTE2, PIPE_MTE1>(0);
+        WaitFlag<PIPE_MTE2, PIPE_MTE1>(0);
+
+        TMOV(a_l0, a_l1);
+        SetFlag<PIPE_MTE1, PIPE_M>(0);
+        WaitFlag<PIPE_MTE1, PIPE_M>(0);
+
+        TMATMUL(c_l0, a_l0, b_l0);
+        SetFlag<PIPE_M, PIPE_FIX>(0);
+        WaitFlag<PIPE_M, PIPE_FIX>(0);
+
+        if (r > 0) {
+            WaitBothVec<PIPE_FIX>(FLAG_FREE);
+        }
+        TMOV<TileVecFloat, TileL0C, AccToVecMode::DualModeSplitM>(c_ub, c_l0);
+        pipe_barrier(PIPE_ALL);
+        SignalBothVec<PIPE_FIX>(FLAG_READY);
+    }
+    if (num_rounds > 0) {
+        WaitBothVec<PIPE_FIX>(FLAG_FREE);
+        pipe_barrier(PIPE_ALL);
+    }
+#endif
+
+#if defined(__DAV_VEC__)
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    for (int32_t r = 0; r < num_rounds; ++r) {
+        const int32_t row_v = r * wave_rows + cid * TILE_SIZE + vid * HALF_TILE;
+
+        wait_intra_block(PIPE_V, FLAG_READY);
+
+        HalfTileGlobalFloat d_global(D + row_v * TILE_SIZE);
+        TLOAD(d_ub, d_global);
+        SetFlag<PIPE_MTE2, PIPE_V>(0);
+        WaitFlag<PIPE_MTE2, PIPE_V>(0);
+
+        TADD(c_ub, c_ub, d_ub);
+        SetFlag<PIPE_V, PIPE_MTE3>(0);
+        WaitFlag<PIPE_V, PIPE_MTE3>(0);
+
+        HalfTileGlobalFloat c_global(C + row_v * TILE_SIZE);
+        TSTORE(c_global, c_ub);
+        pipe_barrier(PIPE_ALL);
+        set_intra_block(PIPE_V, FLAG_FREE);
+    }
+#endif
+}
+
+#endif
+
+extern "C" __global__ AICORE void matmul_add_c2v_kernel(__gm__ uint8_t *A, __gm__ uint8_t *B, __gm__ uint8_t *C,
+                                                         __gm__ uint8_t *D, int64_t batch)
+{
+    run_matmul_add_c2v(reinterpret_cast<__gm__ half *>(A), reinterpret_cast<__gm__ half *>(B),
+                       reinterpret_cast<__gm__ float *>(C), reinterpret_cast<__gm__ float *>(D), batch);
+}
+
+void LaunchMatmulAddC2V(uint32_t block_dim, uint8_t *A, uint8_t *B, uint8_t *C, uint8_t *D, int64_t batch,
+                        void *stream)
+{
+    matmul_add_c2v_kernel<<<block_dim, nullptr, stream>>>(A, B, C, D, batch);
+}
+

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/pybind.cpp
@@ -1,0 +1,32 @@
+#include <torch/extension.h>
+#include <cstdint>
+
+namespace py = pybind11;
+
+extern "C" void call_add(uint32_t block_dim, void *stream, uint8_t *y,
+                         uint8_t *x, uint8_t *z, uint32_t n);
+extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *out,
+                            uint8_t *a, uint8_t *b);
+
+void launch_add(const at::Tensor &y, const at::Tensor &x, const at::Tensor &z,
+                uint32_t n, uint32_t block_dim, uintptr_t stream) {
+  call_add(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(y.data_ptr()),
+           static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()), n);
+}
+
+void launch_matmul(const at::Tensor &out, const at::Tensor &a, const at::Tensor &b,
+                   uint32_t block_dim, uintptr_t stream) {
+  call_matmul(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
+              static_cast<uint8_t *>(a.data_ptr()), static_cast<uint8_t *>(b.data_ptr()));
+}
+
+#ifndef TORCH_EXTENSION_NAME
+#define TORCH_EXTENSION_NAME pto_dynamic_a5_demo
+#endif
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("launch_add", &launch_add, py::arg("y"), py::arg("x"), py::arg("z"),
+        py::arg("n"), py::arg("block_dim"), py::arg("stream"));
+  m.def("launch_matmul", &launch_matmul, py::arg("out"), py::arg("a"), py::arg("b"),
+        py::arg("block_dim"), py::arg("stream"));
+}

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/pybind.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+
 #include <cstdint>
 
 namespace py = pybind11;
@@ -10,14 +11,18 @@ extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *out,
 
 void launch_add(const at::Tensor &y, const at::Tensor &x, const at::Tensor &z,
                 uint32_t n, uint32_t block_dim, uintptr_t stream) {
-  call_add(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(y.data_ptr()),
-           static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()), n);
+  call_add(block_dim, reinterpret_cast<void *>(stream),
+           static_cast<uint8_t *>(y.data_ptr()),
+           static_cast<uint8_t *>(x.data_ptr()),
+           static_cast<uint8_t *>(z.data_ptr()), n);
 }
 
-void launch_matmul(const at::Tensor &out, const at::Tensor &a, const at::Tensor &b,
-                   uint32_t block_dim, uintptr_t stream) {
-  call_matmul(block_dim, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
-              static_cast<uint8_t *>(a.data_ptr()), static_cast<uint8_t *>(b.data_ptr()));
+void launch_matmul(const at::Tensor &out, const at::Tensor &a,
+                   const at::Tensor &b, uint32_t block_dim, uintptr_t stream) {
+  call_matmul(block_dim, reinterpret_cast<void *>(stream),
+              static_cast<uint8_t *>(out.data_ptr()),
+              static_cast<uint8_t *>(a.data_ptr()),
+              static_cast<uint8_t *>(b.data_ptr()));
 }
 
 #ifndef TORCH_EXTENSION_NAME
@@ -27,6 +32,6 @@ void launch_matmul(const at::Tensor &out, const at::Tensor &a, const at::Tensor 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("launch_add", &launch_add, py::arg("y"), py::arg("x"), py::arg("z"),
         py::arg("n"), py::arg("block_dim"), py::arg("stream"));
-  m.def("launch_matmul", &launch_matmul, py::arg("out"), py::arg("a"), py::arg("b"),
-        py::arg("block_dim"), py::arg("stream"));
+  m.def("launch_matmul", &launch_matmul, py::arg("out"), py::arg("a"),
+        py::arg("b"), py::arg("block_dim"), py::arg("stream"));
 }

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_ctypes.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+
+
+def npu_from_cpu(arr: np.ndarray, device: str) -> torch.Tensor:
+    return torch.from_numpy(arr).to(device)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("add", "matmul", "all"), default="add")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--n", type=int, default=128)
+    parser.add_argument("--block-dim", type=int, default=8)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+
+    configure_torch_npu(simulator_safe=True)
+    torch.npu.set_device(args.device)
+
+    payloads = []
+    if args.kernel in ("add", "all"):
+        lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "add")))
+        lib.call_add.argtypes = [
+            ctypes.c_uint32,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+        ]
+        rng = np.random.default_rng(0)
+        x_cpu = rng.standard_normal(args.n).astype(np.float16)
+        z_cpu = rng.standard_normal(args.n).astype(np.float16)
+        x = npu_from_cpu(x_cpu, args.device)
+        z = npu_from_cpu(z_cpu, args.device)
+        y = npu_from_cpu(np.zeros(args.n, dtype=np.float16), args.device)
+        stream = stream_ptr()
+        run_repeated(
+            lambda: lib.call_add(args.block_dim, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), args.n)
+        )
+        assert_close(y.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
+        payloads.append({"kernel": "add", "n": args.n, "block_dim": args.block_dim, "result": "PASS"})
+    if args.kernel in ("matmul", "all"):
+        lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul")))
+        lib.call_matmul.argtypes = [
+            ctypes.c_uint32,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+        ]
+        rng = np.random.default_rng(1)
+        a_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+        b_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+        a = npu_from_cpu(a_cpu, args.device)
+        b = npu_from_cpu(b_cpu, args.device)
+        y = npu_from_cpu(np.zeros((16, 16), dtype=np.float32), args.device)
+        stream = stream_ptr()
+        run_repeated(lambda: lib.call_matmul(1, stream, tensor_ptr(y), tensor_ptr(a), tensor_ptr(b)))
+        ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32))
+        assert_close(y.cpu(), ref)
+        payloads.append({"kernel": "matmul", "shape": "16x16x16", "block_dim": 1, "result": "PASS"})
+    payload = {"result": "PASS", "results": payloads}
+    print(json.dumps(payload, indent=2))
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_ctypes.py
@@ -15,7 +15,14 @@ import torch_npu  # noqa: F401
 HERE = Path(__file__).resolve().parent
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    compile_kernel,
+    configure_torch_npu,
+    run_repeated,
+    stream_ptr,
+    tensor_ptr,
+)  # noqa: E402
 
 
 def npu_from_cpu(arr: np.ndarray, device: str) -> torch.Tensor:
@@ -53,10 +60,24 @@ def main() -> None:
         y = npu_from_cpu(np.zeros(args.n, dtype=np.float16), args.device)
         stream = stream_ptr()
         run_repeated(
-            lambda: lib.call_add(args.block_dim, stream, tensor_ptr(y), tensor_ptr(x), tensor_ptr(z), args.n)
+            lambda: lib.call_add(
+                args.block_dim,
+                stream,
+                tensor_ptr(y),
+                tensor_ptr(x),
+                tensor_ptr(z),
+                args.n,
+            )
         )
         assert_close(y.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
-        payloads.append({"kernel": "add", "n": args.n, "block_dim": args.block_dim, "result": "PASS"})
+        payloads.append(
+            {
+                "kernel": "add",
+                "n": args.n,
+                "block_dim": args.block_dim,
+                "result": "PASS",
+            }
+        )
     if args.kernel in ("matmul", "all"):
         lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul")))
         lib.call_matmul.argtypes = [
@@ -73,10 +94,16 @@ def main() -> None:
         b = npu_from_cpu(b_cpu, args.device)
         y = npu_from_cpu(np.zeros((16, 16), dtype=np.float32), args.device)
         stream = stream_ptr()
-        run_repeated(lambda: lib.call_matmul(1, stream, tensor_ptr(y), tensor_ptr(a), tensor_ptr(b)))
+        run_repeated(
+            lambda: lib.call_matmul(
+                1, stream, tensor_ptr(y), tensor_ptr(a), tensor_ptr(b)
+            )
+        )
         ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32))
         assert_close(y.cpu(), ref)
-        payloads.append({"kernel": "matmul", "shape": "16x16x16", "block_dim": 1, "result": "PASS"})
+        payloads.append(
+            {"kernel": "matmul", "shape": "16x16x16", "block_dim": 1, "result": "PASS"}
+        )
     payload = {"result": "PASS", "results": payloads}
     print(json.dumps(payload, indent=2))
     if args.output_json:

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_pybind.py
@@ -16,7 +16,12 @@ HERE = Path(__file__).resolve().parent
 BUILD = HERE / "build"
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, configure_torch_npu, run_repeated, stream_as_int  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    configure_torch_npu,
+    run_repeated,
+    stream_as_int,
+)  # noqa: E402
 
 
 def build_kernel(name: str) -> Path:
@@ -66,7 +71,9 @@ def main() -> None:
         y = npu_tensor(np.zeros(args.n, dtype=np.float16), args.device)
         run_repeated(lambda: mod.launch_add(y, x, z, args.n, args.block_dim, stream))
         assert_close(y.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
-        print(f"PASS dynamic_multi_core/a5 pybind add n={args.n} block_dim={args.block_dim}")
+        print(
+            f"PASS dynamic_multi_core/a5 pybind add n={args.n} block_dim={args.block_dim}"
+        )
 
     if args.kernel in ("matmul", "all"):
         rng = np.random.default_rng(1)

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_kernel_pybind.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch_npu  # noqa: F401
+from torch.utils.cpp_extension import load
+
+HERE = Path(__file__).resolve().parent
+BUILD = HERE / "build"
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, configure_torch_npu, run_repeated, stream_as_int  # noqa: E402
+
+
+def build_kernel(name: str) -> Path:
+    out = subprocess.check_output(["bash", str(HERE / "compile.sh"), name], text=True)
+    return Path(out.strip().splitlines()[-1])
+
+
+def build_module():
+    BUILD.mkdir(exist_ok=True)
+    ext_dir = BUILD / "torch_ext_dynamic_a5"
+    ext_dir.mkdir(exist_ok=True)
+    add_lib = build_kernel("add")
+    matmul_lib = build_kernel("matmul")
+    print("Using torch extension pybind path: pto_dynamic_a5_demo")
+    return load(
+        name="pto_dynamic_a5_demo",
+        sources=[str(HERE / "pybind.cpp")],
+        extra_ldflags=[str(add_lib), str(matmul_lib), f"-Wl,-rpath,{add_lib.parent}"],
+        build_directory=str(ext_dir),
+        verbose=False,
+    )
+
+
+def npu_tensor(arr: np.ndarray, device: str) -> torch.Tensor:
+    return torch.from_numpy(arr).to(device)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("add", "matmul", "all"), default="all")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--n", type=int, default=128)
+    parser.add_argument("--block-dim", type=int, default=8)
+    args = parser.parse_args()
+
+    configure_torch_npu(simulator_safe=True)
+    torch.npu.set_device(args.device)
+    mod = build_module()
+    stream = stream_as_int()
+
+    if args.kernel in ("add", "all"):
+        rng = np.random.default_rng(0)
+        x_cpu = rng.standard_normal(args.n).astype(np.float16)
+        z_cpu = rng.standard_normal(args.n).astype(np.float16)
+        x = npu_tensor(x_cpu, args.device)
+        z = npu_tensor(z_cpu, args.device)
+        y = npu_tensor(np.zeros(args.n, dtype=np.float16), args.device)
+        run_repeated(lambda: mod.launch_add(y, x, z, args.n, args.block_dim, stream))
+        assert_close(y.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
+        print(f"PASS dynamic_multi_core/a5 pybind add n={args.n} block_dim={args.block_dim}")
+
+    if args.kernel in ("matmul", "all"):
+        rng = np.random.default_rng(1)
+        a_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+        b_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+        a = npu_tensor(a_cpu, args.device)
+        b = npu_tensor(b_cpu, args.device)
+        out = npu_tensor(np.zeros((16, 16), dtype=np.float32), args.device)
+        run_repeated(lambda: mod.launch_matmul(out, a, b, 1, stream))
+        ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32))
+        assert_close(out.cpu(), ref)
+        print("PASS dynamic_multi_core/a5 pybind matmul shape=16x16x16")
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_mix_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_mix_ctypes.py
@@ -15,7 +15,14 @@ HERE = Path(__file__).resolve().parent
 TILE = 128
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    compile_kernel,
+    configure_torch_npu,
+    run_repeated,
+    stream_ptr,
+    tensor_ptr,
+)  # noqa: E402
 
 
 def npu_from_cpu(arr: np.ndarray, device: str) -> torch.Tensor:
@@ -50,7 +57,15 @@ def run_c2v(lib, device: str, block_dim: int, rounds: int) -> None:
     d = npu_from_cpu(d_cpu, device)
     c = npu_from_cpu(np.zeros((batch, TILE), dtype=np.float32), device)
     run_repeated(
-        lambda: lib.cv_matmul_add_c2v(block_dim, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), batch, stream_ptr())
+        lambda: lib.cv_matmul_add_c2v(
+            block_dim,
+            tensor_ptr(a),
+            tensor_ptr(b),
+            tensor_ptr(c),
+            tensor_ptr(d),
+            batch,
+            stream_ptr(),
+        )
     )
     ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32) + d_cpu)
     assert_close(c.cpu(), ref)
@@ -68,16 +83,30 @@ def run_v2c(lib, device: str, block_dim: int, rounds: int) -> None:
     d = npu_from_cpu(d_cpu, device)
     c = npu_from_cpu(np.zeros((batch, TILE), dtype=np.float16), device)
     run_repeated(
-        lambda: lib.cv_add_matmul_v2c(block_dim, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), batch, stream_ptr())
+        lambda: lib.cv_add_matmul_v2c(
+            block_dim,
+            tensor_ptr(a),
+            tensor_ptr(b),
+            tensor_ptr(c),
+            tensor_ptr(d),
+            batch,
+            stream_ptr(),
+        )
     )
-    ref = torch.from_numpy(((a_cpu + b_cpu).astype(np.float32) @ d_cpu.astype(np.float32)).astype(np.float16))
+    ref = torch.from_numpy(
+        ((a_cpu + b_cpu).astype(np.float32) @ d_cpu.astype(np.float32)).astype(
+            np.float16
+        )
+    )
     assert_close(c.cpu(), ref)
     print(f"PASS A5 add_matmul_v2c rounds={rounds} batch={batch} block_dim={block_dim}")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--kernel", choices=("matmul_add", "add_matmul", "all"), default="all")
+    parser.add_argument(
+        "--kernel", choices=("matmul_add", "add_matmul", "all"), default="all"
+    )
     parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
     parser.add_argument("--block-dim", type=int, default=8)
     parser.add_argument("--rounds", type=int, default=1)

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_mix_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_mix_ctypes.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+TILE = 128
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+
+
+def npu_from_cpu(arr: np.ndarray, device: str) -> torch.Tensor:
+    return torch.from_numpy(arr).to(device)
+
+
+def load():
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "mix")))
+    for name in ("cv_matmul_add_c2v", "cv_add_matmul_v2c"):
+        fn = getattr(lib, name)
+        fn.argtypes = [
+            ctypes.c_uint32,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_int64,
+            ctypes.c_void_p,
+        ]
+        fn.restype = None
+    return lib
+
+
+def run_c2v(lib, device: str, block_dim: int, rounds: int) -> None:
+    batch = rounds * block_dim * TILE
+    rng = np.random.default_rng(2)
+    a_cpu = rng.standard_normal((batch, TILE)).astype(np.float16)
+    b_cpu = rng.standard_normal((TILE, TILE)).astype(np.float16)
+    d_cpu = rng.standard_normal((batch, TILE)).astype(np.float32)
+    a = npu_from_cpu(a_cpu, device)
+    b = npu_from_cpu(b_cpu, device)
+    d = npu_from_cpu(d_cpu, device)
+    c = npu_from_cpu(np.zeros((batch, TILE), dtype=np.float32), device)
+    run_repeated(
+        lambda: lib.cv_matmul_add_c2v(block_dim, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), batch, stream_ptr())
+    )
+    ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32) + d_cpu)
+    assert_close(c.cpu(), ref)
+    print(f"PASS A5 matmul_add_c2v rounds={rounds} batch={batch} block_dim={block_dim}")
+
+
+def run_v2c(lib, device: str, block_dim: int, rounds: int) -> None:
+    batch = rounds * block_dim * TILE
+    rng = np.random.default_rng(3)
+    a_cpu = rng.standard_normal((batch, TILE)).astype(np.float16)
+    b_cpu = rng.standard_normal((batch, TILE)).astype(np.float16)
+    d_cpu = rng.standard_normal((TILE, TILE)).astype(np.float16)
+    a = npu_from_cpu(a_cpu, device)
+    b = npu_from_cpu(b_cpu, device)
+    d = npu_from_cpu(d_cpu, device)
+    c = npu_from_cpu(np.zeros((batch, TILE), dtype=np.float16), device)
+    run_repeated(
+        lambda: lib.cv_add_matmul_v2c(block_dim, tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), batch, stream_ptr())
+    )
+    ref = torch.from_numpy(((a_cpu + b_cpu).astype(np.float32) @ d_cpu.astype(np.float32)).astype(np.float16))
+    assert_close(c.cpu(), ref)
+    print(f"PASS A5 add_matmul_v2c rounds={rounds} batch={batch} block_dim={block_dim}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("matmul_add", "add_matmul", "all"), default="all")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--block-dim", type=int, default=8)
+    parser.add_argument("--rounds", type=int, default=1)
+    args = parser.parse_args()
+    configure_torch_npu(simulator_safe=True)
+    torch.npu.set_device(args.device)
+    lib = load()
+    if args.kernel in ("matmul_add", "all"):
+        run_c2v(lib, args.device, args.block_dim, args.rounds)
+    if args.kernel in ("add_matmul", "all"):
+        run_v2c(lib, args.device, args.block_dim, args.rounds)
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_sim.sh
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_sim.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-msprof}"
+shift || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUN_WITH_TIMEOUT="${REFERENCE_DIR}/run_with_timeout.sh"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+cd "${SCRIPT_DIR}"
+
+case "${MODE}" in
+  msprof)
+    export PTO_SIMULATOR=1
+    SIM_LIB="${ASCEND_HOME_PATH}/tools/simulator/Ascend950PR_9599/lib"
+    export LD_LIBRARY_PATH="${SIM_LIB}:${LD_LIBRARY_PATH:-}"
+    mkdir -p "${SCRIPT_DIR}/outputs/msprof_add"
+    RESULT_JSON="${SCRIPT_DIR}/outputs/msprof_add/result.json"
+    rm -f "${RESULT_JSON}"
+    MSPROF_TIMEOUT="${MSPROF_TIMEOUT:-60}" msprof op simulator \
+      --soc-version=Ascend950PR_9599 \
+      --timeout="${MSPROF_TIMEOUT:-60}" \
+      --output="${SCRIPT_DIR}/outputs/msprof_add" \
+      python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" --n 128 --output-json "${RESULT_JSON}" "$@"
+    python3 - "${RESULT_JSON}" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+sys.exit(0 if data.get("result") == "PASS" else 1)
+PY
+    ;;
+  cannsim)
+    export PTO_SIMULATOR=1
+    mkdir -p "${SCRIPT_DIR}/outputs/cannsim_add"
+    USER_OPTS="--n 128 $*"
+    set +e
+    cannsim record -s "${CANNSIM_SOC:-Ascend950}" \
+      -o "${SCRIPT_DIR}/outputs/cannsim_add" \
+      "${SCRIPT_DIR}/run_sim_entry.sh" \
+      -u "${USER_OPTS}"
+    rc=$?
+    set -e
+    if [[ "${rc}" -ne 0 && "${USER_OPTS}" == *"--output-json"* ]]; then
+      out_json="$(python3 - "${USER_OPTS}" <<'PY'
+import shlex, sys
+args = shlex.split(sys.argv[1])
+for i, arg in enumerate(args):
+    if arg == "--output-json" and i + 1 < len(args):
+        print(args[i + 1])
+        break
+PY
+)"
+      if [[ -n "${out_json}" && -f "${out_json}" ]]; then
+        python3 - "${out_json}" <<'PY'
+import json, sys
+from pathlib import Path
+data = json.loads(Path(sys.argv[1]).read_text())
+sys.exit(0 if data.get("result") == "PASS" else 1)
+PY
+        echo "cannsim exited ${rc} after writing PASS JSON; treating as success"
+        exit 0
+      fi
+    fi
+    exit "${rc}"
+    ;;
+  direct)
+    "${RUN_WITH_TIMEOUT}" python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  *)
+    echo "usage: $0 {msprof|cannsim|direct} [run_kernel_ctypes.py args]" >&2
+    exit 2
+    ;;
+esac

--- a/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_sim_entry.sh
+++ b/.skills/testing-pto-kernels/reference/dynamic_multi_core/a5/run_sim_entry.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+exec "${REFERENCE_DIR}/run_with_timeout.sh" python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"

--- a/.skills/testing-pto-kernels/reference/inference_integration/README.md
+++ b/.skills/testing-pto-kernels/reference/inference_integration/README.md
@@ -1,0 +1,12 @@
+# Inference Integration TODO
+
+This task intentionally does not verify vLLM, SGLang, or model-serving integration because the current environment does not provide those stacks.
+
+Future work should add a small verified path that:
+
+1. Builds a PTO kernel as a pybind/CMake deliverable.
+2. Loads it from the target inference runtime.
+3. Replaces one model operator with the PTO kernel.
+4. Runs a numeric end-to-end check and a small latency benchmark.
+
+Until then, do not claim whole-model inference integration from this skill.

--- a/.skills/testing-pto-kernels/reference/launch-methods.md
+++ b/.skills/testing-pto-kernels/reference/launch-methods.md
@@ -1,0 +1,136 @@
+# PTO Kernel Launch Methods
+
+## Quick Matrix
+
+| Method | Best for | Build artifact | Runtime |
+| --- | --- | --- | --- |
+| ctypes/JIT | Fast kernel iteration | one `*.so` from `bisheng -shared` | Python + torch-npu stream and tensor pointers |
+| pybind/CMake AOT | Formal deliverables | packaged Python extension | Python import with typed wrapper |
+| ACL C++ | Host/runtime validation | executable + kernel `*.so` | ACL init, malloc, memcpy, stream |
+| `msprof op simulator` | A2A3/A5 CA-model smoke + dumps | same torch/ctypes `*.so` | msprof injects CA model into Python |
+| `cannsim record` | A5 SoC simulator trace | executable wrapper | `cannsim record -s Ascend950 ... -u "..."` |
+| `-lruntime_camodel` | C++ CA-model samples | C++ executable linked to CA runtime | direct process execution on CPU model |
+
+## ctypes/JIT
+
+Use this by default while developing kernels.
+
+1. Compile with `bisheng -fPIC -shared -xcce ... kernel.cpp -o build/libkernel.so`.
+2. Load with `ctypes.CDLL`.
+3. Set `argtypes` for `call_kernel`.
+4. Pass `ctypes.c_void_p(tensor.data_ptr())` and `torch.npu.current_stream()._as_parameter_`.
+5. Synchronize and compare with a CPU/PyTorch reference.
+
+This is the pattern used by `dynamic_multi_core/*/run_kernel_ctypes.py`.
+
+Cache the stream pointer before repeated launches. Do not call `torch.npu.current_stream()` inside an inner timing loop or per-token/per-tile launch helper.
+
+## pybind/CMake AOT
+
+Use pybind when the kernel is becoming a deliverable, not just a test. Expose torch C++ `at::Tensor` arguments, then obtain tensor data pointers inside the C++ binding. Do not expose Python-level `tensor.data_ptr()` integers as the public interface.
+
+The local reference files include `dynamic_multi_core/a2a3/pybind.cpp`, `static_single_core/a2a3/pybind.cpp`, and `static_single_core/a5/pybind.cpp` as compact shapes of that workflow. The deliverable-style example is `static_single_core/a5/pybind_package`, which builds a pip-installable package linked to local kernel libraries. A pybind path is not accepted until the package/module builds, imports, launches a kernel, and verifies numerics on the target server.
+
+When packaging with setuptools/torch extensions, use `PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)` so the generated module name matches names such as `pto_static_a5_demo._C`.
+
+## ACL C++ Main
+
+Use `main.cpp` when testing host-side ACL details: device selection, `aclrtMalloc`, host/device copies, stream creation, launch, and cleanup. This is also the natural shape for direct `-lruntime_camodel` linking.
+
+## CA Model Modes
+
+### `msprof op simulator`
+
+A5 example:
+
+```bash
+export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/tools/simulator/Ascend950PR_9599/lib:${LD_LIBRARY_PATH:-}"
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=60 python3 run_kernel_ctypes.py ...
+```
+
+A2A3 example:
+
+```bash
+export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/tools/simulator/Ascend910B2/lib:${LD_LIBRARY_PATH:-}"
+msprof op simulator --soc-version=Ascend910B2 --timeout=120 python3 run_kernel_ctypes.py ...
+```
+
+Local wrappers:
+
+```bash
+cd static_single_core/a2a3 && ./run_sim.sh msprof --kernel add
+cd dynamic_multi_core/a2a3 && ./run_sim.sh msprof --kernel add --n 4096
+```
+
+This wraps the Python process, injects the simulator runtime, and lets torch-npu allocation/launch calls execute against the CPU CA model. Do not link the kernel `*.so` to `runtime_camodel` in this mode. Set `MSPROF_SOC_VERSION` when your install uses a different simulator package name.
+
+#### Suggested `MSPROF_TIMEOUT` values
+
+| Workload | SOC | Suggested timeout (seconds) |
+| --- | --- | --- |
+| Vector add smoke | A5 | 60 |
+| Cube matmul smoke | A5 | 60 |
+| Mix kernel (`rounds=1`) | A5 | 120–180 |
+| Static all kernels | A2A3 | 120 |
+| Dynamic add / matmul | A2A3 | 120 |
+
+Override with `MSPROF_TIMEOUT=<seconds>` when using `./run_sim.sh`.
+
+### `cannsim record`
+
+Prefer the local wrappers; they handle the known teardown segfault when PASS JSON is written:
+
+```bash
+cd dynamic_multi_core/a5
+./run_sim.sh cannsim --output-json outputs/add_cannsim.json
+```
+
+Raw invocation (user arguments go through `-u`, not trailing argv):
+
+```bash
+cannsim record -s Ascend950 -o outputs/cannsim \
+  ./run_sim_entry.sh -u "--n 128 --block-dim 8 --output-json outputs/result.json"
+```
+
+`cannsim` is A5-focused and can generate `trace_core*.json` reports. The user process may segfault during teardown after the kernel writes valid PASS JSON; treat that as success only when the JSON file exists and contains `"result": "PASS"`.
+
+### `-lruntime_camodel`
+
+The C++ executable links against `runtime_camodel` and simulator libraries directly. The local portable example is `static_single_core/a5/main.cpp`:
+
+```bash
+cd static_single_core/a5
+./run_sim.sh linked
+```
+
+Use this mode when future code samples already have an ACL C++ main and expect compile-time CA-model linkage.
+
+## Host-Type Launch Rules
+
+| Detected host | A2A3 kernels | A5 kernels |
+| --- | --- | --- |
+| Ascend910B (A2A3) | `direct`, ctypes, pybind, ACL | **`msprof` / `cannsim` / `linked` only** — do not use `./run_sim.sh direct` |
+| Ascend950 (A5) | CA model or cross-compile only | `direct`, ctypes, pybind, ACL |
+| CPU-only + CANN simulator | A2A3/A5 CA-model paths only | Same |
+
+On a 910B host, launching A5 `dav-c310` kernels through `./run_sim.sh direct` or bare `run_kernel_ctypes.py` on a real NPU will fail with vector-core error `507035`. This is expected; use the CA-model paths above.
+
+## Hang Detection
+
+Use two timeout layers for real-device and direct runner invocations:
+
+```bash
+cd reference
+PTO_PROCESS_TIMEOUT_S=60 ./run_with_timeout.sh python3 dynamic_multi_core/a2a3/run_kernel_ctypes.py --kernel add
+```
+
+| Layer | Tool | Default |
+| --- | --- | --- |
+| Whole process | `run_with_timeout.sh` / GNU `timeout` | 60 s device, 1800 s when `PTO_SIMULATOR=1` |
+| Per `synchronize()` | `pto_demo_utils.synchronize_device()` | 60 s (`PTO_SYNC_TIMEOUT_S`) |
+
+`./run_sim.sh direct`, `reproduce.sh`, and `run_sim_entry.sh` call `run_with_timeout.sh` automatically. `msprof op simulator --timeout=...` provides a separate whole-process bound for CA-model Python runs.
+
+## TODO: ACLgraph
+
+ACLgraph launch is intentionally not verified in this reference. Add only local templates after a PTO sample compiles and runs through ACLgraph.

--- a/.skills/testing-pto-kernels/reference/pto_demo_utils.py
+++ b/.skills/testing-pto-kernels/reference/pto_demo_utils.py
@@ -1,0 +1,123 @@
+"""Shared helpers for PTO kernel demo runners under reference/."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from concurrent import futures
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+REFERENCE_DIR = Path(__file__).resolve().parent
+
+# Match torch.testing.assert_close defaults (see SKILL.md Correctness Rules).
+RTOL_BY_DTYPE: dict[torch.dtype, float] = {
+    torch.float16: 1e-3,
+    torch.bfloat16: 1.6e-2,
+    torch.float32: 1.3e-6,
+}
+DEFAULT_ATOL = 1e-5
+DEFAULT_SYNC_TIMEOUT_S = float(os.environ.get("PTO_SYNC_TIMEOUT_S", "60"))
+DEFAULT_PROCESS_TIMEOUT_S = float(
+    os.environ.get("PTO_PROCESS_TIMEOUT_S", "1800" if os.environ.get("PTO_SIMULATOR") == "1" else "60")
+)
+
+
+def add_reference_to_path(here: Path) -> Path:
+    ref = here.parents[1]
+    ref_str = str(ref)
+    if ref_str not in sys.path:
+        sys.path.insert(0, ref_str)
+    return ref
+
+
+def configure_torch_npu(*, simulator_safe: bool = False) -> None:
+    torch.npu.config.allow_internal_format = False
+    if simulator_safe:
+        torch_npu.npu.set_compile_mode(jit_compile=False)
+
+
+def tensor_ptr(t: torch.Tensor) -> ctypes.c_void_p:
+    return ctypes.c_void_p(t.data_ptr())
+
+
+def stream_ptr() -> ctypes.c_void_p:
+    return torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+
+
+def stream_as_int() -> int:
+    return int(torch.npu.current_stream().npu_stream)
+
+
+def compile_kernel(compile_sh: Path, kernel: str) -> Path:
+    out = subprocess.check_output(["bash", str(compile_sh), kernel], text=True)
+    return Path(out.strip().splitlines()[-1])
+
+
+def cube_core_count(device: str) -> int:
+    props = torch.npu.get_device_properties(device)
+    return int(getattr(props, "cube_core_num", getattr(props, "multi_processor_count", 1)))
+
+
+def vector_core_count(device: str) -> int:
+    props = torch.npu.get_device_properties(device)
+    return int(getattr(props, "vector_core_num", cube_core_count(device) * 2))
+
+
+def _dtype_of(value: torch.Tensor | torch.dtype) -> torch.dtype:
+    return value.dtype if isinstance(value, torch.Tensor) else value
+
+
+def rtol_for(value: torch.Tensor | torch.dtype) -> float:
+    return RTOL_BY_DTYPE.get(_dtype_of(value), 1e-3)
+
+
+def assert_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    rtol: float | None = None,
+    atol: float | None = None,
+) -> None:
+    """Assert using SKILL.md thresholds unless explicit overrides are documented."""
+    ref_dtype = expected.dtype
+    torch.testing.assert_close(
+        actual,
+        expected,
+        rtol=rtol if rtol is not None else rtol_for(ref_dtype),
+        atol=atol if atol is not None else DEFAULT_ATOL,
+    )
+
+
+def is_simulator_mode() -> bool:
+    return os.environ.get("PTO_SIMULATOR", "").lower() not in ("", "0", "false", "no")
+
+
+def device_repeats() -> int:
+    if is_simulator_mode():
+        return 1
+    return int(os.environ.get("PTO_DEVICE_REPEATS", "5"))
+
+
+def synchronize_device(timeout_s: float | None = None) -> None:
+    timeout = DEFAULT_SYNC_TIMEOUT_S if timeout_s is None else timeout_s
+    with futures.ThreadPoolExecutor(max_workers=1) as pool:
+        fut = pool.submit(torch.npu.synchronize)
+        try:
+            fut.result(timeout=timeout)
+        except futures.TimeoutError as exc:
+            raise TimeoutError(
+                f"torch.npu.synchronize() exceeded {timeout}s; possible sync deadlock"
+            ) from exc
+
+
+def run_repeated(launch_fn: Callable[[], None], *, repeats: int | None = None) -> None:
+    """Launch a kernel repeatedly on real devices to surface sync bugs."""
+    for _ in range(device_repeats() if repeats is None else repeats):
+        launch_fn()
+        synchronize_device()

--- a/.skills/testing-pto-kernels/reference/pto_demo_utils.py
+++ b/.skills/testing-pto-kernels/reference/pto_demo_utils.py
@@ -24,7 +24,10 @@ RTOL_BY_DTYPE: dict[torch.dtype, float] = {
 DEFAULT_ATOL = 1e-5
 DEFAULT_SYNC_TIMEOUT_S = float(os.environ.get("PTO_SYNC_TIMEOUT_S", "60"))
 DEFAULT_PROCESS_TIMEOUT_S = float(
-    os.environ.get("PTO_PROCESS_TIMEOUT_S", "1800" if os.environ.get("PTO_SIMULATOR") == "1" else "60")
+    os.environ.get(
+        "PTO_PROCESS_TIMEOUT_S",
+        "1800" if os.environ.get("PTO_SIMULATOR") == "1" else "60",
+    )
 )
 
 
@@ -61,7 +64,9 @@ def compile_kernel(compile_sh: Path, kernel: str) -> Path:
 
 def cube_core_count(device: str) -> int:
     props = torch.npu.get_device_properties(device)
-    return int(getattr(props, "cube_core_num", getattr(props, "multi_processor_count", 1)))
+    return int(
+        getattr(props, "cube_core_num", getattr(props, "multi_processor_count", 1))
+    )
 
 
 def vector_core_count(device: str) -> int:

--- a/.skills/testing-pto-kernels/reference/reproduce.sh
+++ b/.skills/testing-pto-kernels/reference/reproduce.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Sequential smoke pass for the PTO kernel testing reference tree.
+# Exits non-zero on the first unexpected failure.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+NPU_DEVICE="${NPU_DEVICE:-npu:0}"
+RUN_WITH_TIMEOUT="${SCRIPT_DIR}/run_with_timeout.sh"
+
+source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+
+SOC="$(python3 - <<'PY'
+import acl
+print(acl.get_soc_name())
+PY
+)"
+
+echo "=== PTO reference smoke (SOC=${SOC}, NPU_DEVICE=${NPU_DEVICE}) ==="
+
+run() {
+  echo
+  echo ">>> $*"
+  "$@"
+}
+
+# --- A2A3 real device (910B hosts only) ---
+if [[ "${SOC}" == Ascend910B* ]]; then
+  run bash -c "cd '${SCRIPT_DIR}/dynamic_multi_core/a2a3' && NPU_DEVICE='${NPU_DEVICE}' '${RUN_WITH_TIMEOUT}' python3 run_kernel_ctypes.py --kernel all --n 4096 --m 128"
+  run bash -c "cd '${SCRIPT_DIR}/dynamic_multi_core/a2a3' && NPU_DEVICE='${NPU_DEVICE}' '${RUN_WITH_TIMEOUT}' python3 run_mix_ctypes.py --kernel all --rounds 1"
+  run bash -c "cd '${SCRIPT_DIR}/static_single_core/a2a3' && NPU_DEVICE='${NPU_DEVICE}' '${RUN_WITH_TIMEOUT}' python3 run_kernel_ctypes.py --kernel add"
+else
+  echo "Skipping A2A3 real-device tests (SOC=${SOC} is not Ascend910B*)"
+fi
+
+# --- A2A3 CA model ---
+run bash -c "cd '${SCRIPT_DIR}/static_single_core/a2a3' && MSPROF_SOC_VERSION=Ascend910B2 MSPROF_TIMEOUT=120 ./run_sim.sh msprof --kernel add"
+run bash -c "cd '${SCRIPT_DIR}/dynamic_multi_core/a2a3' && MSPROF_SOC_VERSION=Ascend910B2 MSPROF_TIMEOUT=120 ./run_sim.sh msprof --kernel add --n 4096"
+
+# --- A5 CA model (always use simulator paths on 910B hosts) ---
+run bash -c "cd '${SCRIPT_DIR}/dynamic_multi_core/a5' && MSPROF_TIMEOUT=60 ./run_sim.sh msprof --n 128 --block-dim 8"
+run bash -c "cd '${SCRIPT_DIR}/static_single_core/a5' && MSPROF_TIMEOUT=60 ./run_sim.sh msprof --kernel add"
+run bash -c "cd '${SCRIPT_DIR}/static_single_core/a5' && ./run_sim.sh linked"
+
+if [[ "${SOC}" == Ascend910B* ]]; then
+  echo
+  echo "NOTE: A5 ./run_sim.sh direct is intentionally skipped on Ascend910B hosts."
+  echo "      A5 kernels must use msprof, cannsim, or -lruntime_camodel here."
+fi
+
+echo
+echo "=== PASS: reference smoke completed ==="

--- a/.skills/testing-pto-kernels/reference/run_with_timeout.sh
+++ b/.skills/testing-pto-kernels/reference/run_with_timeout.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Wrap a runner command with a whole-process timeout.
+# Sync-only timeouts can miss hangs during compile, launch, or driver teardown.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 [--timeout SECONDS] <command...>" >&2
+  exit 2
+}
+
+TIMEOUT_SECS="${PTO_PROCESS_TIMEOUT_S:-}"
+KILL_AFTER="${PTO_PROCESS_KILL_AFTER_S:-10}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout)
+      [[ $# -ge 2 ]] || usage
+      TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[[ $# -gt 0 ]] || usage
+
+if [[ -z "${TIMEOUT_SECS}" ]]; then
+  if [[ "${PTO_SIMULATOR:-}" == "1" ]]; then
+    TIMEOUT_SECS=1800
+  else
+    TIMEOUT_SECS=60
+  fi
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+  echo "[pto] whole-process timeout: ${TIMEOUT_SECS}s (override with PTO_PROCESS_TIMEOUT_S)" >&2
+  exec timeout --foreground -k "${KILL_AFTER}" "${TIMEOUT_SECS}" "$@"
+fi
+
+echo "[pto] warning: GNU timeout not found; running without whole-process timeout" >&2
+exec "$@"

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/README.md
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/README.md
@@ -1,0 +1,41 @@
+# Static Single-Core A2A3
+
+This directory implements the PTO-ISA ST style for A2A3: fixed-shape kernels, direct `<<<1, nullptr, stream>>>` launch, a small ACL host driver, ctypes, and pybind launchers.
+
+## Local File Roles
+
+| Role | Source |
+| --- | --- |
+| Vector `add.cpp` | Static vector add kernel, shape `(64,64)`. |
+| Cube `matmul.cpp` | Static cube instruction checklist. |
+| Mix `matmul_add.cpp` | Static mix-kernel checklist. |
+| `main.cpp` | Minimal ACL host driver using `NPU_DEVICE`. |
+| `pybind.cpp` | Minimal pybind launcher for static add; public C++ API takes `at::Tensor`. |
+
+The local files keep the template roles and do not require another PTO-ISA test checkout.
+
+## Local Runnable Path
+
+Real-device smoke (`run_kernel_ctypes.py` defaults to `--kernel all`: add, matmul, matmul_add):
+
+```bash
+NPU_DEVICE=npu:0 python3 run_kernel_ctypes.py
+NPU_DEVICE=npu:0 python3 run_kernel_ctypes.py --kernel add
+NPU_DEVICE=npu:0 python3 run_kernel_pybind.py
+exe="$(bash compile.sh acl_add | tail -n 1)" && NPU_DEVICE=npu:0 "$exe" "$(pwd)/build/libstatic_add_a2a3.so"
+```
+
+A2A3 CA-model smoke via `msprof` (no physical NPU required for correctness):
+
+```bash
+./run_sim.sh msprof --kernel add
+./run_sim.sh msprof --kernel all
+```
+
+Override the simulator SOC when needed:
+
+```bash
+MSPROF_SOC_VERSION=Ascend910B2 MSPROF_TIMEOUT=120 ./run_sim.sh msprof --kernel add
+```
+
+`./run_sim.sh direct` runs `run_kernel_ctypes.py` on a real Ascend910B device.

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/add.cpp
@@ -1,0 +1,45 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr int ROWS = 64;
+constexpr int COLS = 64;
+constexpr uint32_t ELEMS = ROWS * COLS;
+
+__global__ AICORE void static_add_kernel(__gm__ half *out, __gm__ half *x,
+                                         __gm__ half *z) {
+#if defined(__DAV_C220_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+
+  using Shape5 = Shape<1, 1, 1, 1, ELEMS>;
+  using Stride5 = Stride<1, 1, 1, 1, 1>;
+  using Global = GlobalTensor<half, Shape5, Stride5>;
+  using VecTile = Tile<TileType::Vec, half, 1, ELEMS, BLayout::RowMajor, -1, -1>;
+
+  Global out_g(out);
+  Global x_g(x);
+  Global z_g(z);
+  VecTile x_t(1, ELEMS), z_t(1, ELEMS), out_t(1, ELEMS);
+  TASSIGN(x_t, 0x0);
+  TASSIGN(z_t, 0x8000);
+  TASSIGN(out_t, 0x10000);
+
+  TLOAD(x_t, x_g);
+  TLOAD(z_t, z_g);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  TADD(out_t, x_t, z_t);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  TSTORE(out_g, out_t);
+  pipe_barrier(PIPE_ALL);
+#endif
+}
+
+extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
+                                uint8_t *x, uint8_t *z) {
+  (void)block_dim;
+  static_add_kernel<<<1, nullptr, stream>>>((__gm__ half *)out, (__gm__ half *)x,
+                                            (__gm__ half *)z);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/add.cpp
@@ -15,7 +15,8 @@ __global__ AICORE void static_add_kernel(__gm__ half *out, __gm__ half *x,
   using Shape5 = Shape<1, 1, 1, 1, ELEMS>;
   using Stride5 = Stride<1, 1, 1, 1, 1>;
   using Global = GlobalTensor<half, Shape5, Stride5>;
-  using VecTile = Tile<TileType::Vec, half, 1, ELEMS, BLayout::RowMajor, -1, -1>;
+  using VecTile =
+      Tile<TileType::Vec, half, 1, ELEMS, BLayout::RowMajor, -1, -1>;
 
   Global out_g(out);
   Global x_g(x);
@@ -40,6 +41,6 @@ __global__ AICORE void static_add_kernel(__gm__ half *out, __gm__ half *x,
 extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
                                 uint8_t *x, uint8_t *z) {
   (void)block_dim;
-  static_add_kernel<<<1, nullptr, stream>>>((__gm__ half *)out, (__gm__ half *)x,
-                                            (__gm__ half *)z);
+  static_add_kernel<<<1, nullptr, stream>>>((__gm__ half *)out,
+                                            (__gm__ half *)x, (__gm__ half *)z);
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/compile.sh
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/compile.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL="${1:-add}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+mkdir -p "${BUILD_DIR}"
+
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+PTO_LIB_PATH="${PTO_LIB_PATH:-${ASCEND_HOME_PATH}}"
+BISHENG="${ASCEND_HOME_PATH}/bin/bisheng"
+if [[ ! -x "${BISHENG}" ]]; then
+  BISHENG="$(command -v bisheng)"
+fi
+
+case "${KERNEL}" in
+  add)
+    SRC="${SCRIPT_DIR}/add.cpp"
+    OUT="${BUILD_DIR}/libstatic_add_a2a3.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220-vec)
+    ;;
+  matmul)
+    SRC="${SCRIPT_DIR}/matmul.cpp"
+    OUT="${BUILD_DIR}/libstatic_matmul_a2a3.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220-cube)
+    ;;
+  matmul_add)
+    SRC="${SCRIPT_DIR}/matmul_add.cpp"
+    OUT="${BUILD_DIR}/libstatic_matmul_add_a2a3.so"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220)
+    ;;
+  acl_add)
+    SRC="${SCRIPT_DIR}/add.cpp"
+    OUT="${BUILD_DIR}/static_add_acl"
+    ARCH_FLAGS=(--cce-aicore-arch=dav-c220-vec)
+    ;;
+  *)
+    echo "usage: $0 {add|matmul|matmul_add}" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "${KERNEL}" == "acl_add" ]]; then
+  so_path="${BUILD_DIR}/libstatic_add_a2a3.so"
+  "${BISHENG}" -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
+    "${ARCH_FLAGS[@]}" \
+    -I"${PTO_LIB_PATH}/include" \
+    -I"${ASCEND_HOME_PATH}/include" \
+    -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+    "${SRC}" -o "${so_path}"
+  "${BISHENG}" -std=gnu++17 -O2 -Wno-macro-redefined -Wno-ignored-attributes \
+    -xc++ -include stdint.h -include stddef.h \
+    -I"${ASCEND_HOME_PATH}/include" \
+    -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+    "${SCRIPT_DIR}/main.cpp" -o "${OUT}" \
+    -L"${ASCEND_HOME_PATH}/lib64" -lascendcl -ldl -lstdc++ -lpthread \
+    -Wl,-rpath,"${ASCEND_HOME_PATH}/lib64"
+  echo "${OUT}"
+  exit 0
+fi
+
+"${BISHENG}" -fPIC -shared -xcce -DMEMORY_BASE -O2 -std=c++17 \
+  "${ARCH_FLAGS[@]}" \
+  -I"${PTO_LIB_PATH}/include" \
+  -I"${ASCEND_HOME_PATH}/include" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/runtime" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/profiling" \
+  -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+  "${SRC}" -o "${OUT}"
+
+echo "${OUT}"

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/main.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/main.cpp
@@ -1,0 +1,81 @@
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <iostream>
+#include <vector>
+
+using AddFn = void (*)(uint32_t, void *, uint8_t *, uint8_t *, uint8_t *);
+
+namespace {
+constexpr size_t kElems = 64 * 64;
+constexpr size_t kBytes = kElems * sizeof(uint16_t);
+constexpr uint16_t kHalfOne = 0x3c00;
+constexpr uint16_t kHalfTwo = 0x4000;
+constexpr uint16_t kHalfThree = 0x4200;
+
+void check_acl(aclError ret, const char *what) {
+  if (ret != ACL_SUCCESS) {
+    std::cerr << what << " failed, aclError=" << ret << "\n";
+    std::exit(1);
+  }
+}
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: " << argv[0] << " /path/to/libstatic_add_a2a3.so\n";
+    return 2;
+  }
+  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  if (handle == nullptr) {
+    std::cerr << "dlopen failed: " << dlerror() << "\n";
+    return 1;
+  }
+  auto call_add = reinterpret_cast<AddFn>(dlsym(handle, "call_static_add"));
+  if (call_add == nullptr) {
+    std::cerr << "dlsym failed: call_static_add\n";
+    return 1;
+  }
+
+  std::vector<uint16_t> x(kElems, kHalfOne), z(kElems, kHalfTwo), out(kElems, 0);
+  int device_id = 0;
+  if (const char *env = std::getenv("NPU_DEVICE")) {
+    std::string value(env);
+    auto pos = value.find(':');
+    device_id = std::stoi(pos == std::string::npos ? value : value.substr(pos + 1));
+  }
+
+  check_acl(aclInit(nullptr), "aclInit");
+  check_acl(aclrtSetDevice(device_id), "aclrtSetDevice");
+  aclrtStream stream = nullptr;
+  check_acl(aclrtCreateStream(&stream), "aclrtCreateStream");
+
+  void *x_dev = nullptr, *z_dev = nullptr, *out_dev = nullptr;
+  check_acl(aclrtMalloc(&x_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "malloc x");
+  check_acl(aclrtMalloc(&z_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "malloc z");
+  check_acl(aclrtMalloc(&out_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "malloc out");
+  check_acl(aclrtMemcpy(x_dev, kBytes, x.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy x");
+  check_acl(aclrtMemcpy(z_dev, kBytes, z.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy z");
+  call_add(1, stream, static_cast<uint8_t *>(out_dev), static_cast<uint8_t *>(x_dev),
+           static_cast<uint8_t *>(z_dev));
+  check_acl(aclrtSynchronizeStream(stream), "sync");
+  check_acl(aclrtMemcpy(out.data(), kBytes, out_dev, kBytes, ACL_MEMCPY_DEVICE_TO_HOST), "copy out");
+
+  size_t errors = 0;
+  for (uint16_t v : out) errors += (v != kHalfThree);
+
+  aclrtFree(out_dev);
+  aclrtFree(z_dev);
+  aclrtFree(x_dev);
+  aclrtDestroyStream(stream);
+  aclrtResetDevice(device_id);
+  aclFinalize();
+
+  if (errors) {
+    std::cerr << "FAIL static A2A3 ACL add errors=" << errors << "\n";
+    return 1;
+  }
+  std::cout << "PASS static_single_core/a2a3 ACL add\n";
+  return 0;
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/main.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/main.cpp
@@ -1,7 +1,8 @@
 #include <acl/acl.h>
+#include <dlfcn.h>
+
 #include <cstdint>
 #include <cstdlib>
-#include <dlfcn.h>
 #include <iostream>
 #include <vector>
 
@@ -38,12 +39,14 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  std::vector<uint16_t> x(kElems, kHalfOne), z(kElems, kHalfTwo), out(kElems, 0);
+  std::vector<uint16_t> x(kElems, kHalfOne), z(kElems, kHalfTwo),
+      out(kElems, 0);
   int device_id = 0;
   if (const char *env = std::getenv("NPU_DEVICE")) {
     std::string value(env);
     auto pos = value.find(':');
-    device_id = std::stoi(pos == std::string::npos ? value : value.substr(pos + 1));
+    device_id =
+        std::stoi(pos == std::string::npos ? value : value.substr(pos + 1));
   }
 
   check_acl(aclInit(nullptr), "aclInit");
@@ -54,13 +57,20 @@ int main(int argc, char **argv) {
   void *x_dev = nullptr, *z_dev = nullptr, *out_dev = nullptr;
   check_acl(aclrtMalloc(&x_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "malloc x");
   check_acl(aclrtMalloc(&z_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "malloc z");
-  check_acl(aclrtMalloc(&out_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "malloc out");
-  check_acl(aclrtMemcpy(x_dev, kBytes, x.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy x");
-  check_acl(aclrtMemcpy(z_dev, kBytes, z.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy z");
-  call_add(1, stream, static_cast<uint8_t *>(out_dev), static_cast<uint8_t *>(x_dev),
-           static_cast<uint8_t *>(z_dev));
+  check_acl(aclrtMalloc(&out_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST),
+            "malloc out");
+  check_acl(
+      aclrtMemcpy(x_dev, kBytes, x.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+      "copy x");
+  check_acl(
+      aclrtMemcpy(z_dev, kBytes, z.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+      "copy z");
+  call_add(1, stream, static_cast<uint8_t *>(out_dev),
+           static_cast<uint8_t *>(x_dev), static_cast<uint8_t *>(z_dev));
   check_acl(aclrtSynchronizeStream(stream), "sync");
-  check_acl(aclrtMemcpy(out.data(), kBytes, out_dev, kBytes, ACL_MEMCPY_DEVICE_TO_HOST), "copy out");
+  check_acl(aclrtMemcpy(out.data(), kBytes, out_dev, kBytes,
+                        ACL_MEMCPY_DEVICE_TO_HOST),
+            "copy out");
 
   size_t errors = 0;
   for (uint16_t v : out) errors += (v != kHalfThree);

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul.cpp
@@ -1,0 +1,56 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr int TILE = 128;
+
+#if defined(__CCE_AICORE__)
+using Global = GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
+                            BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
+using L1Tile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE, TILE,
+                    SLayout::RowMajor, 512>;
+using Left = TileLeft<half, TILE, TILE>;
+using Right = TileRight<half, TILE, TILE>;
+using Acc = TileAcc<float, TILE, TILE>;
+
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void Sync(uint32_t id) {
+  set_flag(Src, Dst, static_cast<event_t>(id));
+  wait_flag(Src, Dst, static_cast<event_t>(id));
+}
+#endif
+
+__global__ AICORE void static_matmul_kernel(__gm__ half *a, __gm__ half *b,
+                                            __gm__ half *c) {
+#if defined(__DAV_C220_CUBE__)
+  L1Tile a_l1, b_l1;
+  Left a_l0;
+  Right b_l0;
+  Acc c_l0;
+  TASSIGN(a_l1, 0x0);
+  TASSIGN(b_l1, TILE * TILE * sizeof(half));
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(c_l0, 0x0);
+
+  Global a_g(a), b_g(b), c_g(c);
+  TLOAD(a_l1, a_g);
+  TLOAD(b_l1, b_g);
+  Sync<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(a_l0, a_l1);
+  TMOV(b_l0, b_l1);
+  Sync<PIPE_MTE1, PIPE_M>(0);
+  TMATMUL(c_l0, a_l0, b_l0);
+  Sync<PIPE_M, PIPE_FIX>(0);
+  TSTORE(c_g, c_l0);
+  pipe_barrier(PIPE_ALL);
+#endif
+}
+
+extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *a,
+                            uint8_t *b, uint8_t *c, uint32_t m) {
+  (void)block_dim;
+  (void)m;
+  static_matmul_kernel<<<1, nullptr, stream>>>((__gm__ half *)a, (__gm__ half *)b,
+                                               (__gm__ half *)c);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul.cpp
@@ -5,10 +5,11 @@ using namespace pto;
 constexpr int TILE = 128;
 
 #if defined(__CCE_AICORE__)
-using Global = GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
-                            BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
-using L1Tile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE, TILE,
-                    SLayout::RowMajor, 512>;
+using Global =
+    GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
+                 BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
+using L1Tile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE,
+                    TILE, SLayout::RowMajor, 512>;
 using Left = TileLeft<half, TILE, TILE>;
 using Right = TileRight<half, TILE, TILE>;
 using Acc = TileAcc<float, TILE, TILE>;
@@ -51,6 +52,6 @@ extern "C" void call_matmul(uint32_t block_dim, void *stream, uint8_t *a,
                             uint8_t *b, uint8_t *c, uint32_t m) {
   (void)block_dim;
   (void)m;
-  static_matmul_kernel<<<1, nullptr, stream>>>((__gm__ half *)a, (__gm__ half *)b,
-                                               (__gm__ half *)c);
+  static_matmul_kernel<<<1, nullptr, stream>>>(
+      (__gm__ half *)a, (__gm__ half *)b, (__gm__ half *)c);
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul_add.cpp
@@ -1,30 +1,34 @@
-#include <pto/pto-inst.hpp>
 #include <runtime/rt_ffts.h>
+
+#include <pto/pto-inst.hpp>
 
 using namespace pto;
 
-// Minimal static mix kernel: one Cube block computes A@B into GM workspace, then
-// two Vector subblocks add D and store C. Shape is fixed to 128x128.
+// Minimal static mix kernel: one Cube block computes A@B into GM workspace,
+// then two Vector subblocks add D and store C. Shape is fixed to 128x128.
 constexpr int TILE = 128;
 constexpr int HALF = 64;
 constexpr int VEC_NUM = 2;
 constexpr int FLAG_C2V = 6;
 
 #ifdef __CCE_AICORE__
-using Global = GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
-                            BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
-using HalfGlobal = GlobalTensor<half, TileShape2D<half, HALF, TILE, Layout::ND>,
-                                BaseShape2D<half, HALF, TILE, Layout::ND>, Layout::ND>;
-using MatTile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE, TILE,
-                     SLayout::RowMajor, 512>;
+using Global =
+    GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
+                 BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
+using HalfGlobal =
+    GlobalTensor<half, TileShape2D<half, HALF, TILE, Layout::ND>,
+                 BaseShape2D<half, HALF, TILE, Layout::ND>, Layout::ND>;
+using MatTile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE,
+                     TILE, SLayout::RowMajor, 512>;
 using Left = TileLeft<half, TILE, TILE>;
 using Right = TileRight<half, TILE, TILE>;
 using Acc = TileAcc<float, TILE, TILE>;
-using Vec = Tile<TileType::Vec, half, HALF, TILE, BLayout::RowMajor, HALF, TILE>;
+using Vec =
+    Tile<TileType::Vec, half, HALF, TILE, BLayout::RowMajor, HALF, TILE>;
 
 template <pipe_t Pipe>
 inline AICORE void Signal(int32_t flag) {
-    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+  ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
 }
 template <pipe_t Src, pipe_t Dst>
 inline AICORE void Sync(uint32_t id) {
@@ -33,8 +37,9 @@ inline AICORE void Sync(uint32_t id) {
 }
 #endif
 
-__global__ AICORE void static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ half *c,
-                                         __gm__ half *d, __gm__ half *workspace,
+__global__ AICORE void static_matmul_add(__gm__ half *a, __gm__ half *b,
+                                         __gm__ half *c, __gm__ half *d,
+                                         __gm__ half *workspace,
                                          uint64_t ffts_addr) {
 #ifdef __CCE_AICORE__
   const int vid = get_subblockid();
@@ -70,7 +75,8 @@ __global__ AICORE void static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ 
   TASSIGN(d_t, HALF * TILE * sizeof(half));
   wait_flag_dev(FLAG_C2V);
   const int row = vid * HALF;
-  HalfGlobal ws_g(workspace + row * TILE), d_g(d + row * TILE), c_g(c + row * TILE);
+  HalfGlobal ws_g(workspace + row * TILE), d_g(d + row * TILE),
+      c_g(c + row * TILE);
   TLOAD(ws_t, ws_g);
   TLOAD(d_t, d_g);
   pipe_barrier(PIPE_ALL);
@@ -83,13 +89,14 @@ __global__ AICORE void static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ 
 }
 
 extern "C" void call(uint32_t block_dim, void *stream, uint8_t *a, uint8_t *b,
-                     uint8_t *c, uint8_t *d, uint8_t *workspace, int64_t batch) {
+                     uint8_t *c, uint8_t *d, uint8_t *workspace,
+                     int64_t batch) {
   (void)block_dim;
   (void)batch;
   uint32_t ffts_len = 0;
   uint64_t ffts_addr = 0;
   rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
-  static_matmul_add<<<1, nullptr, stream>>>((__gm__ half *)a, (__gm__ half *)b,
-                                            (__gm__ half *)c, (__gm__ half *)d,
-                                            (__gm__ half *)workspace, ffts_addr);
+  static_matmul_add<<<1, nullptr, stream>>>(
+      (__gm__ half *)a, (__gm__ half *)b, (__gm__ half *)c, (__gm__ half *)d,
+      (__gm__ half *)workspace, ffts_addr);
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/matmul_add.cpp
@@ -1,0 +1,95 @@
+#include <pto/pto-inst.hpp>
+#include <runtime/rt_ffts.h>
+
+using namespace pto;
+
+// Minimal static mix kernel: one Cube block computes A@B into GM workspace, then
+// two Vector subblocks add D and store C. Shape is fixed to 128x128.
+constexpr int TILE = 128;
+constexpr int HALF = 64;
+constexpr int VEC_NUM = 2;
+constexpr int FLAG_C2V = 6;
+
+#ifdef __CCE_AICORE__
+using Global = GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
+                            BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
+using HalfGlobal = GlobalTensor<half, TileShape2D<half, HALF, TILE, Layout::ND>,
+                                BaseShape2D<half, HALF, TILE, Layout::ND>, Layout::ND>;
+using MatTile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE, TILE,
+                     SLayout::RowMajor, 512>;
+using Left = TileLeft<half, TILE, TILE>;
+using Right = TileRight<half, TILE, TILE>;
+using Acc = TileAcc<float, TILE, TILE>;
+using Vec = Tile<TileType::Vec, half, HALF, TILE, BLayout::RowMajor, HALF, TILE>;
+
+template <pipe_t Pipe>
+inline AICORE void Signal(int32_t flag) {
+    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+}
+template <pipe_t Src, pipe_t Dst>
+inline AICORE void Sync(uint32_t id) {
+  set_flag(Src, Dst, static_cast<event_t>(id));
+  wait_flag(Src, Dst, static_cast<event_t>(id));
+}
+#endif
+
+__global__ AICORE void static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ half *c,
+                                         __gm__ half *d, __gm__ half *workspace,
+                                         uint64_t ffts_addr) {
+#ifdef __CCE_AICORE__
+  const int vid = get_subblockid();
+  set_ffts_base_addr(ffts_addr);
+#if defined(__DAV_C220_CUBE__)
+  MatTile a_l1, b_l1;
+  Left a_l0;
+  Right b_l0;
+  Acc acc;
+  TASSIGN(a_l1, 0x0);
+  TASSIGN(b_l1, TILE * TILE * sizeof(half));
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(acc, 0x0);
+  Global a_g(a), b_g(b), ws_g(workspace);
+  TLOAD(a_l1, a_g);
+  TLOAD(b_l1, b_g);
+  Sync<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(a_l0, a_l1);
+  TMOV(b_l0, b_l1);
+  Sync<PIPE_MTE1, PIPE_M>(0);
+  TMATMUL(acc, a_l0, b_l0);
+  Sync<PIPE_M, PIPE_FIX>(0);
+  TSTORE(ws_g, acc);
+  pipe_barrier(PIPE_ALL);
+  Signal<PIPE_FIX>(FLAG_C2V);
+#endif
+#if defined(__DAV_C220_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  Vec ws_t, d_t;
+  TASSIGN(ws_t, 0x0);
+  TASSIGN(d_t, HALF * TILE * sizeof(half));
+  wait_flag_dev(FLAG_C2V);
+  const int row = vid * HALF;
+  HalfGlobal ws_g(workspace + row * TILE), d_g(d + row * TILE), c_g(c + row * TILE);
+  TLOAD(ws_t, ws_g);
+  TLOAD(d_t, d_g);
+  pipe_barrier(PIPE_ALL);
+  TADD(ws_t, ws_t, d_t);
+  Sync<PIPE_V, PIPE_MTE3>(0);
+  TSTORE(c_g, ws_t);
+  pipe_barrier(PIPE_ALL);
+#endif
+#endif
+}
+
+extern "C" void call(uint32_t block_dim, void *stream, uint8_t *a, uint8_t *b,
+                     uint8_t *c, uint8_t *d, uint8_t *workspace, int64_t batch) {
+  (void)block_dim;
+  (void)batch;
+  uint32_t ffts_len = 0;
+  uint64_t ffts_addr = 0;
+  rtGetC2cCtrlAddr(&ffts_addr, &ffts_len);
+  static_matmul_add<<<1, nullptr, stream>>>((__gm__ half *)a, (__gm__ half *)b,
+                                            (__gm__ half *)c, (__gm__ half *)d,
+                                            (__gm__ half *)workspace, ffts_addr);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/pybind.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+
 #include <cstdint>
 #include <string>
 
@@ -6,10 +7,12 @@ namespace py = pybind11;
 extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
                                 uint8_t *x, uint8_t *z);
 
-void launch_static_add(const at::Tensor &out,
-                       const at::Tensor &x, const at::Tensor &z, uintptr_t stream) {
-  call_static_add(1, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
-                  static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()));
+void launch_static_add(const at::Tensor &out, const at::Tensor &x,
+                       const at::Tensor &z, uintptr_t stream) {
+  call_static_add(1, reinterpret_cast<void *>(stream),
+                  static_cast<uint8_t *>(out.data_ptr()),
+                  static_cast<uint8_t *>(x.data_ptr()),
+                  static_cast<uint8_t *>(z.data_ptr()));
 }
 
 #ifndef TORCH_EXTENSION_NAME
@@ -18,6 +21,6 @@ void launch_static_add(const at::Tensor &out,
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.doc() = "Static A2A3 PTO pybind launcher";
-  m.def("launch_static_add", &launch_static_add, py::arg("out"),
-        py::arg("x"), py::arg("z"), py::arg("stream"));
+  m.def("launch_static_add", &launch_static_add, py::arg("out"), py::arg("x"),
+        py::arg("z"), py::arg("stream"));
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/pybind.cpp
@@ -1,0 +1,23 @@
+#include <torch/extension.h>
+#include <cstdint>
+#include <string>
+
+namespace py = pybind11;
+extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
+                                uint8_t *x, uint8_t *z);
+
+void launch_static_add(const at::Tensor &out,
+                       const at::Tensor &x, const at::Tensor &z, uintptr_t stream) {
+  call_static_add(1, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
+                  static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()));
+}
+
+#ifndef TORCH_EXTENSION_NAME
+#define TORCH_EXTENSION_NAME pto_static_a2a3_demo
+#endif
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.doc() = "Static A2A3 PTO pybind launcher";
+  m.def("launch_static_add", &launch_static_add, py::arg("out"),
+        py::arg("x"), py::arg("z"), py::arg("stream"));
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_ctypes.py
@@ -12,7 +12,14 @@ import torch_npu  # noqa: F401
 
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    compile_kernel,
+    configure_torch_npu,
+    run_repeated,
+    stream_ptr,
+    tensor_ptr,
+)  # noqa: E402
 
 
 def run_add(device: str) -> None:
@@ -31,7 +38,9 @@ def run_add(device: str) -> None:
     z = torch.randn(64, 64, device=device, dtype=torch.float16)
     out = torch.empty_like(x)
     run_repeated(
-        lambda: lib.call_static_add(1, stream_ptr(), tensor_ptr(out), tensor_ptr(x), tensor_ptr(z))
+        lambda: lib.call_static_add(
+            1, stream_ptr(), tensor_ptr(out), tensor_ptr(x), tensor_ptr(z)
+        )
     )
     assert_close(out, x + z)
     print("PASS static_single_core/a2a3 add shape=(64,64)")
@@ -52,7 +61,9 @@ def run_matmul(device: str) -> None:
     b = torch.randn(128, 128, device=device, dtype=torch.float16)
     c = torch.empty(128, 128, device=device, dtype=torch.float16)
     run_repeated(
-        lambda: lib.call_matmul(1, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), 128)
+        lambda: lib.call_matmul(
+            1, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), 128
+        )
     )
     assert_close(c, torch.matmul(a, b))
     print("PASS static_single_core/a2a3 matmul shape=(128,128)x(128,128)")
@@ -96,7 +107,9 @@ def run_mix(device: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--kernel", choices=("add", "matmul", "matmul_add", "all"), default="all")
+    parser.add_argument(
+        "--kernel", choices=("add", "matmul", "matmul_add", "all"), default="all"
+    )
     args = parser.parse_args()
     device = os.environ.get("NPU_DEVICE", "npu:0")
     configure_torch_npu()

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_ctypes.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+import sys
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+
+
+def run_add(device: str) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "add")))
+    lib.call_static_add.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    lib.call_static_add.restype = None
+
+    torch.manual_seed(0)
+    x = torch.randn(64, 64, device=device, dtype=torch.float16)
+    z = torch.randn(64, 64, device=device, dtype=torch.float16)
+    out = torch.empty_like(x)
+    run_repeated(
+        lambda: lib.call_static_add(1, stream_ptr(), tensor_ptr(out), tensor_ptr(x), tensor_ptr(z))
+    )
+    assert_close(out, x + z)
+    print("PASS static_single_core/a2a3 add shape=(64,64)")
+
+
+def run_matmul(device: str) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul")))
+    lib.call_matmul.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    ]
+    torch.manual_seed(1)
+    a = torch.randn(128, 128, device=device, dtype=torch.float16)
+    b = torch.randn(128, 128, device=device, dtype=torch.float16)
+    c = torch.empty(128, 128, device=device, dtype=torch.float16)
+    run_repeated(
+        lambda: lib.call_matmul(1, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), 128)
+    )
+    assert_close(c, torch.matmul(a, b))
+    print("PASS static_single_core/a2a3 matmul shape=(128,128)x(128,128)")
+
+
+def run_mix(device: str) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul_add")))
+    lib.call.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_int64,
+    ]
+    block_dim = 1
+    batch = 128
+    torch.manual_seed(2)
+    a = torch.randn(batch, 128, device=device, dtype=torch.float16)
+    b = torch.randn(128, 128, device=device, dtype=torch.float16)
+    d = torch.randn(batch, 128, device=device, dtype=torch.float16)
+    c = torch.empty_like(a)
+    ws = torch.empty(128, 128, device=device, dtype=torch.float16)
+    run_repeated(
+        lambda: lib.call(
+            block_dim,
+            stream_ptr(),
+            tensor_ptr(a),
+            tensor_ptr(b),
+            tensor_ptr(c),
+            tensor_ptr(d),
+            tensor_ptr(ws),
+            batch,
+        )
+    )
+    assert_close(c, (a @ b + d).to(torch.float16))
+    print(f"PASS static_single_core/a2a3 matmul_add rounds=1 batch={batch}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("add", "matmul", "matmul_add", "all"), default="all")
+    args = parser.parse_args()
+    device = os.environ.get("NPU_DEVICE", "npu:0")
+    configure_torch_npu()
+    torch.npu.set_device(device)
+    if args.kernel in ("add", "all"):
+        run_add(device)
+    if args.kernel in ("matmul", "all"):
+        run_matmul(device)
+    if args.kernel in ("matmul_add", "all"):
+        run_mix(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_pybind.py
@@ -14,7 +14,12 @@ HERE = Path(__file__).resolve().parent
 BUILD = HERE / "build"
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, configure_torch_npu, run_repeated, stream_as_int  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    configure_torch_npu,
+    run_repeated,
+    stream_as_int,
+)  # noqa: E402
 
 
 def build_kernel() -> Path:

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_kernel_pybind.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+import torch_npu  # noqa: F401
+from torch.utils.cpp_extension import load
+
+HERE = Path(__file__).resolve().parent
+BUILD = HERE / "build"
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, configure_torch_npu, run_repeated, stream_as_int  # noqa: E402
+
+
+def build_kernel() -> Path:
+    out = subprocess.check_output(["bash", str(HERE / "compile.sh"), "add"], text=True)
+    return Path(out.strip().splitlines()[-1])
+
+
+def build_module():
+    BUILD.mkdir(exist_ok=True)
+    ext_dir = BUILD / "torch_ext_static"
+    ext_dir.mkdir(exist_ok=True)
+    add_lib = build_kernel()
+    print("Using pybind launch path: torch.utils.cpp_extension.load")
+    return load(
+        name="pto_static_a2a3_demo",
+        sources=[str(HERE / "pybind.cpp")],
+        extra_ldflags=[str(add_lib), f"-Wl,-rpath,{add_lib.parent}"],
+        build_directory=str(ext_dir),
+        verbose=False,
+    )
+
+
+def main() -> None:
+    device = os.environ.get("NPU_DEVICE", "npu:0")
+    configure_torch_npu()
+    torch.npu.set_device(device)
+    mod = build_module()
+    torch.manual_seed(0)
+    x = torch.randn(64, 64, device=device, dtype=torch.float16)
+    z = torch.randn(64, 64, device=device, dtype=torch.float16)
+    out = torch.empty_like(x)
+    run_repeated(lambda: mod.launch_static_add(out, x, z, stream_as_int()))
+    assert_close(out, x + z)
+    print("PASS static_single_core/a2a3 pybind add shape=(64,64)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_sim.sh
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a2a3/run_sim.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-msprof}"
+shift || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUN_WITH_TIMEOUT="${REFERENCE_DIR}/run_with_timeout.sh"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+SOC_VERSION="${MSPROF_SOC_VERSION:-Ascend910B2}"
+source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+cd "${SCRIPT_DIR}"
+
+case "${MODE}" in
+  msprof)
+    export PTO_SIMULATOR=1
+    SIM_LIB="${ASCEND_HOME_PATH}/tools/simulator/${SOC_VERSION}/lib"
+    export LD_LIBRARY_PATH="${SIM_LIB}:${LD_LIBRARY_PATH:-}"
+    MSPROF_TIMEOUT="${MSPROF_TIMEOUT:-120}" msprof op simulator \
+      --soc-version="${SOC_VERSION}" \
+      --timeout="${MSPROF_TIMEOUT}" \
+      --output="${SCRIPT_DIR}/outputs/msprof_static" \
+      python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  direct)
+    "${RUN_WITH_TIMEOUT}" python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  *)
+    echo "usage: $0 {msprof|direct} [run_kernel_ctypes.py args]" >&2
+    exit 2
+    ;;
+esac

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/README.md
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/README.md
@@ -18,17 +18,19 @@ This directory implements the PTO-ISA ST style for A5 with fixed-shape vector ad
 ```bash
 ./run_sim.sh msprof --kernel add
 ./run_sim.sh msprof --kernel matmul
-./run_sim.sh msprof --kernel matmul_add
+MSPROF_TIMEOUT=180 ./run_sim.sh msprof --kernel matmul_add
 ./run_sim.sh cannsim
 ./run_sim.sh linked
-msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=120 \
   --output=outputs/msprof_static_pybind \
   python3 run_kernel_pybind.py
 cd pybind_package
 python3 -m pip install --no-build-isolation -e .
-msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=180 \
   --output=outputs/msprof_static_pybind_pip \
   python3 ../run_kernel_pybind.py
 ```
 
 `./run_sim.sh linked` builds `main.cpp`, links `-lruntime_camodel`, and runs the static add kernel directly against the CPU CA model.
+
+On A5 static `msprof` runs, the child process may exit with `bad_function_call` during teardown after printing `PASS`. Treat that as success when the `PASS` line appears.

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/README.md
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/README.md
@@ -1,0 +1,34 @@
+# Static Single-Core A5
+
+This directory implements the PTO-ISA ST style for A5 with fixed-shape vector add and cube matmul kernels. Run them through the CA model on servers without Ascend950 hardware.
+
+## Local File Roles
+
+| Role | Source |
+| --- | --- |
+| Vector `add.cpp` | Static vector add kernel, shape `(64,64)`. |
+| Cube `matmul.cpp` | Static cube matmul kernel, shape `(16,16)x(16,16)`. |
+| Mix `matmul_add.cpp` | Static C2V mix smoke, `C = A @ B + D`. |
+| `main.cpp` | Self-contained ACL C++ host driver for the `-lruntime_camodel` path. |
+| `pybind.cpp` | Minimal pybind launcher for static add and matmul; public C++ API takes `at::Tensor`. |
+| `pybind_package/` | Minimal pip-installable pybind package for deliverable-style AOT. |
+
+## Local Runnable CA-Model Smoke
+
+```bash
+./run_sim.sh msprof --kernel add
+./run_sim.sh msprof --kernel matmul
+./run_sim.sh msprof --kernel matmul_add
+./run_sim.sh cannsim
+./run_sim.sh linked
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_static_pybind \
+  python3 run_kernel_pybind.py
+cd pybind_package
+python3 -m pip install --no-build-isolation -e .
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_static_pybind_pip \
+  python3 ../run_kernel_pybind.py
+```
+
+`./run_sim.sh linked` builds `main.cpp`, links `-lruntime_camodel`, and runs the static add kernel directly against the CPU CA model.

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/add.cpp
@@ -1,0 +1,45 @@
+#include "pto/pto-inst.hpp"
+
+using namespace pto;
+
+constexpr int ROWS = 64;
+constexpr int COLS = 64;
+constexpr uint32_t ELEMS = ROWS * COLS;
+
+__global__ AICORE void static_add_kernel(__gm__ half *out, __gm__ half *x,
+                                         __gm__ half *z) {
+#if defined(__DAV_VEC__)
+  using DynShape = pto::Shape<-1, -1, -1, -1, -1>;
+  using DynStride = pto::Stride<-1, -1, -1, -1, -1>;
+  using Global = GlobalTensor<half, DynShape, DynStride>;
+  Global out_g(out, pto::Shape(1, 1, 1, 1, ELEMS),
+               pto::Stride(ELEMS, ELEMS, ELEMS, ELEMS, 1));
+  Global x_g(x, pto::Shape(1, 1, 1, 1, ELEMS),
+             pto::Stride(ELEMS, ELEMS, ELEMS, ELEMS, 1));
+  Global z_g(z, pto::Shape(1, 1, 1, 1, ELEMS),
+             pto::Stride(ELEMS, ELEMS, ELEMS, ELEMS, 1));
+
+  using VecTile = Tile<TileType::Vec, half, 1, ELEMS, BLayout::RowMajor, -1, -1>;
+  VecTile x_t(1, ELEMS), z_t(1, ELEMS), out_t(1, ELEMS);
+  TASSIGN(x_t, 0x0);
+  TASSIGN(z_t, 0x8000);
+  TASSIGN(out_t, 0x10000);
+
+  TLOAD(x_t, x_g);
+  TLOAD(z_t, z_g);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  TADD(out_t, x_t, z_t);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  TSTORE(out_g, out_t);
+  pipe_barrier(PIPE_ALL);
+#endif
+}
+
+extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
+                                uint8_t *x, uint8_t *z) {
+  (void)block_dim;
+  static_add_kernel<<<1, nullptr, stream>>>((__gm__ half *)out, (__gm__ half *)x,
+                                            (__gm__ half *)z);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/add.cpp
@@ -19,7 +19,8 @@ __global__ AICORE void static_add_kernel(__gm__ half *out, __gm__ half *x,
   Global z_g(z, pto::Shape(1, 1, 1, 1, ELEMS),
              pto::Stride(ELEMS, ELEMS, ELEMS, ELEMS, 1));
 
-  using VecTile = Tile<TileType::Vec, half, 1, ELEMS, BLayout::RowMajor, -1, -1>;
+  using VecTile =
+      Tile<TileType::Vec, half, 1, ELEMS, BLayout::RowMajor, -1, -1>;
   VecTile x_t(1, ELEMS), z_t(1, ELEMS), out_t(1, ELEMS);
   TASSIGN(x_t, 0x0);
   TASSIGN(z_t, 0x8000);
@@ -40,6 +41,6 @@ __global__ AICORE void static_add_kernel(__gm__ half *out, __gm__ half *x,
 extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
                                 uint8_t *x, uint8_t *z) {
   (void)block_dim;
-  static_add_kernel<<<1, nullptr, stream>>>((__gm__ half *)out, (__gm__ half *)x,
-                                            (__gm__ half *)z);
+  static_add_kernel<<<1, nullptr, stream>>>((__gm__ half *)out,
+                                            (__gm__ half *)x, (__gm__ half *)z);
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/compile.sh
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/compile.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL="${1:-add}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+mkdir -p "${BUILD_DIR}"
+
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+PTO_LIB_PATH="${PTO_LIB_PATH:-${ASCEND_HOME_PATH}}"
+BISHENG="${ASCEND_HOME_PATH}/bin/bisheng"
+if [[ ! -x "${BISHENG}" ]]; then
+  BISHENG="$(command -v bisheng)"
+fi
+
+case "${KERNEL}" in
+  add)
+    SRC="${SCRIPT_DIR}/add.cpp"
+    OUT="${BUILD_DIR}/libstatic_add_a5.so"
+    ARCH="dav-c310-vec"
+    ;;
+  matmul)
+    SRC="${SCRIPT_DIR}/matmul.cpp"
+    OUT="${BUILD_DIR}/libstatic_matmul_a5.so"
+    ARCH="dav-c310-cube"
+    ;;
+  matmul_add)
+    SRC="${SCRIPT_DIR}/matmul_add.cpp"
+    OUT="${BUILD_DIR}/libstatic_matmul_add_a5.so"
+    ARCH="dav-c310"
+    ;;
+  acl_add)
+    SRC="${SCRIPT_DIR}/add.cpp"
+    OUT="${BUILD_DIR}/static_add_acl"
+    ARCH="dav-c310-vec"
+    ;;
+  *)
+    echo "usage: $0 {add|matmul|matmul_add|acl_add}" >&2
+    exit 2
+    ;;
+esac
+
+COMMON_KERNEL_FLAGS=(
+  -I"${PTO_LIB_PATH}/include" \
+  -I"${ASCEND_HOME_PATH}/include" \
+  -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/profiling" \
+  -I"${ASCEND_HOME_PATH}/pkg_inc/runtime/runtime" \
+  -std=gnu++17 -O2 -Wno-macro-redefined -Wno-ignored-attributes \
+  -fPIC -xcce -Xhost-start -Xhost-end \
+  -mllvm -cce-aicore-stack-size=0x8000 \
+  -mllvm -cce-aicore-function-stack-size=0x8000 \
+  -mllvm -cce-aicore-record-overflow=true \
+  -mllvm -cce-aicore-addr-transform \
+  -mllvm -cce-aicore-dcci-insert-for-scalar=false \
+  --cce-aicore-arch="${ARCH}" -DREGISTER_BASE
+)
+
+if [[ "${KERNEL}" == "acl_add" ]]; then
+  "${BISHENG}" "${COMMON_KERNEL_FLAGS[@]}" -c "${SRC}" -o "${BUILD_DIR}/acl_add_kernel.o"
+  kernel_so="${BUILD_DIR}/libstatic_add_a5.so"
+  "${BISHENG}" -fPIC -shared --cce-fatobj-link \
+    -Wl,-soname,"$(basename "${kernel_so}")" \
+    "${BUILD_DIR}/acl_add_kernel.o" -o "${kernel_so}"
+  "${BISHENG}" \
+    -I"${ASCEND_HOME_PATH}/include" \
+    -I"${ASCEND_DRIVER_PATH:-/usr/local/Ascend/driver}/kernel/inc" \
+    -std=gnu++17 -O2 -Wno-macro-redefined -Wno-ignored-attributes \
+    -xc++ -include stdint.h -include stddef.h \
+    -c "${SCRIPT_DIR}/main.cpp" -o "${BUILD_DIR}/main.o"
+  sim_lib="${ASCEND_HOME_PATH}/tools/simulator/Ascend950PR_9599/lib"
+  "${BISHENG}" "${BUILD_DIR}/main.o" -o "${OUT}" \
+    -L"${BUILD_DIR}" -lstatic_add_a5 \
+    -L"${ASCEND_HOME_PATH}/lib64" -L"${sim_lib}" \
+    -lruntime_camodel -lstdc++ -lascendcl -lm -lc_sec -ldl -lpthread \
+    -Wl,-rpath,"${BUILD_DIR}:${ASCEND_HOME_PATH}/lib64:${sim_lib}"
+else
+  "${BISHENG}" "${COMMON_KERNEL_FLAGS[@]}" -c "${SRC}" -o "${BUILD_DIR}/${KERNEL}.o"
+  "${BISHENG}" -fPIC -shared --cce-fatobj-link \
+    -Wl,-soname,"$(basename "${OUT}")" \
+    "${BUILD_DIR}/${KERNEL}.o" -o "${OUT}"
+fi
+
+echo "${OUT}"

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/main.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/main.cpp
@@ -1,4 +1,5 @@
 #include <acl/acl.h>
+
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -35,16 +36,25 @@ int main() {
   void *x_dev = nullptr;
   void *z_dev = nullptr;
   void *out_dev = nullptr;
-  check_acl(aclrtMalloc(&x_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "aclrtMalloc x");
-  check_acl(aclrtMalloc(&z_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "aclrtMalloc z");
-  check_acl(aclrtMalloc(&out_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "aclrtMalloc out");
-  check_acl(aclrtMemcpy(x_dev, kBytes, x.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy x");
-  check_acl(aclrtMemcpy(z_dev, kBytes, z.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy z");
+  check_acl(aclrtMalloc(&x_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST),
+            "aclrtMalloc x");
+  check_acl(aclrtMalloc(&z_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST),
+            "aclrtMalloc z");
+  check_acl(aclrtMalloc(&out_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST),
+            "aclrtMalloc out");
+  check_acl(
+      aclrtMemcpy(x_dev, kBytes, x.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+      "copy x");
+  check_acl(
+      aclrtMemcpy(z_dev, kBytes, z.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+      "copy z");
 
-  call_static_add(1, stream, static_cast<uint8_t *>(out_dev), static_cast<uint8_t *>(x_dev),
-                  static_cast<uint8_t *>(z_dev));
+  call_static_add(1, stream, static_cast<uint8_t *>(out_dev),
+                  static_cast<uint8_t *>(x_dev), static_cast<uint8_t *>(z_dev));
   check_acl(aclrtSynchronizeStream(stream), "aclrtSynchronizeStream");
-  check_acl(aclrtMemcpy(out.data(), kBytes, out_dev, kBytes, ACL_MEMCPY_DEVICE_TO_HOST), "copy out");
+  check_acl(aclrtMemcpy(out.data(), kBytes, out_dev, kBytes,
+                        ACL_MEMCPY_DEVICE_TO_HOST),
+            "copy out");
 
   size_t errors = 0;
   for (uint16_t v : out) {
@@ -59,7 +69,8 @@ int main() {
   aclFinalize();
 
   if (errors != 0) {
-    std::cerr << "FAIL static A5 ACL/runtime_camodel add errors=" << errors << "\n";
+    std::cerr << "FAIL static A5 ACL/runtime_camodel add errors=" << errors
+              << "\n";
     return 1;
   }
   std::cout << "PASS static_single_core/a5 ACL runtime_camodel add\n";

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/main.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/main.cpp
@@ -1,0 +1,67 @@
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
+                                uint8_t *x, uint8_t *z);
+
+namespace {
+constexpr size_t kElems = 64 * 64;
+constexpr size_t kBytes = kElems * sizeof(uint16_t);
+constexpr uint16_t kHalfOne = 0x3c00;    // fp16 1.0
+constexpr uint16_t kHalfTwo = 0x4000;    // fp16 2.0
+constexpr uint16_t kHalfThree = 0x4200;  // fp16 3.0
+
+void check_acl(aclError ret, const char *what) {
+  if (ret != ACL_SUCCESS) {
+    std::cerr << what << " failed, aclError=" << ret << "\n";
+    std::exit(1);
+  }
+}
+}  // namespace
+
+int main() {
+  std::vector<uint16_t> x(kElems, kHalfOne);
+  std::vector<uint16_t> z(kElems, kHalfTwo);
+  std::vector<uint16_t> out(kElems, 0);
+
+  check_acl(aclInit(nullptr), "aclInit");
+  check_acl(aclrtSetDevice(0), "aclrtSetDevice");
+  aclrtStream stream = nullptr;
+  check_acl(aclrtCreateStream(&stream), "aclrtCreateStream");
+
+  void *x_dev = nullptr;
+  void *z_dev = nullptr;
+  void *out_dev = nullptr;
+  check_acl(aclrtMalloc(&x_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "aclrtMalloc x");
+  check_acl(aclrtMalloc(&z_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "aclrtMalloc z");
+  check_acl(aclrtMalloc(&out_dev, kBytes, ACL_MEM_MALLOC_HUGE_FIRST), "aclrtMalloc out");
+  check_acl(aclrtMemcpy(x_dev, kBytes, x.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy x");
+  check_acl(aclrtMemcpy(z_dev, kBytes, z.data(), kBytes, ACL_MEMCPY_HOST_TO_DEVICE), "copy z");
+
+  call_static_add(1, stream, static_cast<uint8_t *>(out_dev), static_cast<uint8_t *>(x_dev),
+                  static_cast<uint8_t *>(z_dev));
+  check_acl(aclrtSynchronizeStream(stream), "aclrtSynchronizeStream");
+  check_acl(aclrtMemcpy(out.data(), kBytes, out_dev, kBytes, ACL_MEMCPY_DEVICE_TO_HOST), "copy out");
+
+  size_t errors = 0;
+  for (uint16_t v : out) {
+    if (v != kHalfThree) ++errors;
+  }
+
+  aclrtFree(out_dev);
+  aclrtFree(z_dev);
+  aclrtFree(x_dev);
+  aclrtDestroyStream(stream);
+  aclrtResetDevice(0);
+  aclFinalize();
+
+  if (errors != 0) {
+    std::cerr << "FAIL static A5 ACL/runtime_camodel add errors=" << errors << "\n";
+    return 1;
+  }
+  std::cout << "PASS static_single_core/a5 ACL runtime_camodel add\n";
+  return 0;
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul.cpp
@@ -1,5 +1,5 @@
-#include <pto/pto-inst.hpp>
 #include <pto/common/pto_tile.hpp>
+#include <pto/pto-inst.hpp>
 
 using namespace pto;
 
@@ -15,7 +15,7 @@ __global__ AICORE void static_matmul_kernel(__gm__ float *out, __gm__ half *a,
   using GlobalB = GlobalTensor<half, pto::Shape<1, 1, 1, K, N>,
                                pto::Stride<K * N, K * N, K * N, N, 1>>;
   using GlobalC = GlobalTensor<float, pto::Shape<1, 1, 1, M, N>,
-                                pto::Stride<M * N, M * N, M * N, N, 1>>;
+                               pto::Stride<M * N, M * N, M * N, N, 1>>;
 
   GlobalA a_g(a);
   GlobalB b_g(b);
@@ -55,9 +55,9 @@ __global__ AICORE void static_matmul_kernel(__gm__ float *out, __gm__ half *a,
 #endif
 }
 
-extern "C" void call_static_matmul(uint32_t block_dim, void *stream, uint8_t *out,
-                                   uint8_t *a, uint8_t *b) {
+extern "C" void call_static_matmul(uint32_t block_dim, void *stream,
+                                   uint8_t *out, uint8_t *a, uint8_t *b) {
   (void)block_dim;
-  static_matmul_kernel<<<1, nullptr, stream>>>((__gm__ float *)out,
-                                               (__gm__ half *)a, (__gm__ half *)b);
+  static_matmul_kernel<<<1, nullptr, stream>>>(
+      (__gm__ float *)out, (__gm__ half *)a, (__gm__ half *)b);
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul.cpp
@@ -1,0 +1,63 @@
+#include <pto/pto-inst.hpp>
+#include <pto/common/pto_tile.hpp>
+
+using namespace pto;
+
+constexpr int M = 16;
+constexpr int K = 16;
+constexpr int N = 16;
+
+__global__ AICORE void static_matmul_kernel(__gm__ float *out, __gm__ half *a,
+                                            __gm__ half *b) {
+#if defined(__DAV_CUBE__)
+  using GlobalA = GlobalTensor<half, pto::Shape<1, 1, 1, M, K>,
+                               pto::Stride<M * K, M * K, M * K, K, 1>>;
+  using GlobalB = GlobalTensor<half, pto::Shape<1, 1, 1, K, N>,
+                               pto::Stride<K * N, K * N, K * N, N, 1>>;
+  using GlobalC = GlobalTensor<float, pto::Shape<1, 1, 1, M, N>,
+                                pto::Stride<M * N, M * N, M * N, N, 1>>;
+
+  GlobalA a_g(a);
+  GlobalB b_g(b);
+  GlobalC c_g(out);
+
+  using MatA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, M, K,
+                    SLayout::RowMajor, 512>;
+  using MatB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, K, N,
+                    SLayout::RowMajor, 512>;
+  using Left = TileLeft<half, M, K, M, K>;
+  using Right = TileRight<half, K, N, K, N>;
+  using Acc = TileAcc<float, M, N, M, N>;
+
+  MatA a_l1;
+  MatB b_l1;
+  Left a_l0;
+  Right b_l0;
+  Acc c_l0;
+  TASSIGN(a_l1, 0x0);
+  TASSIGN(b_l1, 0x10000);
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(c_l0, 0x0);
+
+  TLOAD(a_l1, a_g);
+  TLOAD(b_l1, b_g);
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  TMOV(a_l0, a_l1);
+  TMOV(b_l0, b_l1);
+  set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+  wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+  TMATMUL(c_l0, a_l0, b_l0);
+  set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+  TSTORE(c_g, c_l0);
+#endif
+}
+
+extern "C" void call_static_matmul(uint32_t block_dim, void *stream, uint8_t *out,
+                                   uint8_t *a, uint8_t *b) {
+  (void)block_dim;
+  static_matmul_kernel<<<1, nullptr, stream>>>((__gm__ float *)out,
+                                               (__gm__ half *)a, (__gm__ half *)b);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul_add.cpp
@@ -9,12 +9,14 @@ constexpr uint16_t FLAG_FREE = 1;
 constexpr uint16_t VEC_FLAG_OFFSET = 16;
 
 #if defined(__CCE_AICORE__)
-using Global = GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
-                            BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
-using HalfFloat = GlobalTensor<float, TileShape2D<float, HALF_TILE, TILE, Layout::ND>,
-                               BaseShape2D<float, HALF_TILE, TILE, Layout::ND>, Layout::ND>;
-using L1Tile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE, TILE,
-                    SLayout::RowMajor, 512, PadValue::Zero>;
+using Global =
+    GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
+                 BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
+using HalfFloat =
+    GlobalTensor<float, TileShape2D<float, HALF_TILE, TILE, Layout::ND>,
+                 BaseShape2D<float, HALF_TILE, TILE, Layout::ND>, Layout::ND>;
+using L1Tile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE,
+                    TILE, SLayout::RowMajor, 512, PadValue::Zero>;
 using Left = TileLeft<half, TILE, TILE>;
 using Right = TileRight<half, TILE, TILE>;
 using Acc = TileAcc<float, TILE, TILE>;
@@ -40,8 +42,9 @@ AICORE inline void WaitBoth(uint16_t flag) {
 }
 #endif
 
-AICORE void run_static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ float *c,
-                                  __gm__ float *d, int64_t batch) {
+AICORE void run_static_matmul_add(__gm__ half *a, __gm__ half *b,
+                                  __gm__ float *c, __gm__ float *d,
+                                  int64_t batch) {
 #if defined(__CCE_AICORE__)
   const int cid = static_cast<int>(get_block_idx());
   const int vid = static_cast<int>(get_subblockid());
@@ -94,15 +97,17 @@ AICORE void run_static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ float *
 #endif
 }
 
-extern "C" __global__ AICORE void static_matmul_add_kernel(
-    __gm__ uint8_t *a, __gm__ uint8_t *b, __gm__ uint8_t *c, __gm__ uint8_t *d,
-    int64_t batch) {
+extern "C" __global__ AICORE void static_matmul_add_kernel(__gm__ uint8_t *a,
+                                                           __gm__ uint8_t *b,
+                                                           __gm__ uint8_t *c,
+                                                           __gm__ uint8_t *d,
+                                                           int64_t batch) {
   run_static_matmul_add((__gm__ half *)a, (__gm__ half *)b, (__gm__ float *)c,
                         (__gm__ float *)d, batch);
 }
 
-extern "C" void call_static_matmul_add(uint32_t block_dim, void *stream, uint8_t *a,
-                                       uint8_t *b, uint8_t *c, uint8_t *d,
-                                       int64_t batch) {
+extern "C" void call_static_matmul_add(uint32_t block_dim, void *stream,
+                                       uint8_t *a, uint8_t *b, uint8_t *c,
+                                       uint8_t *d, int64_t batch) {
   static_matmul_add_kernel<<<block_dim, nullptr, stream>>>(a, b, c, d, batch);
 }

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul_add.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/matmul_add.cpp
@@ -1,0 +1,108 @@
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr int TILE = 128;
+constexpr int HALF_TILE = 64;
+constexpr uint16_t FLAG_READY = 0;
+constexpr uint16_t FLAG_FREE = 1;
+constexpr uint16_t VEC_FLAG_OFFSET = 16;
+
+#if defined(__CCE_AICORE__)
+using Global = GlobalTensor<half, TileShape2D<half, TILE, TILE, Layout::ND>,
+                            BaseShape2D<half, TILE, TILE, Layout::ND>, Layout::ND>;
+using HalfFloat = GlobalTensor<float, TileShape2D<float, HALF_TILE, TILE, Layout::ND>,
+                               BaseShape2D<float, HALF_TILE, TILE, Layout::ND>, Layout::ND>;
+using L1Tile = Tile<TileType::Mat, half, TILE, TILE, BLayout::ColMajor, TILE, TILE,
+                    SLayout::RowMajor, 512, PadValue::Zero>;
+using Left = TileLeft<half, TILE, TILE>;
+using Right = TileRight<half, TILE, TILE>;
+using Acc = TileAcc<float, TILE, TILE>;
+using VecF = Tile<TileType::Vec, float, HALF_TILE, TILE, BLayout::RowMajor,
+                  HALF_TILE, TILE>;
+
+template <pipe_t Src, pipe_t Dst>
+AICORE inline void Sync(uint32_t id) {
+  set_flag(Src, Dst, static_cast<event_t>(id));
+  wait_flag(Src, Dst, static_cast<event_t>(id));
+}
+
+template <pipe_t Pipe>
+AICORE inline void SignalBoth(uint16_t flag) {
+  set_intra_block(Pipe, flag);
+  set_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+}
+
+template <pipe_t Pipe>
+AICORE inline void WaitBoth(uint16_t flag) {
+  wait_intra_block(Pipe, flag);
+  wait_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+}
+#endif
+
+AICORE void run_static_matmul_add(__gm__ half *a, __gm__ half *b, __gm__ float *c,
+                                  __gm__ float *d, int64_t batch) {
+#if defined(__CCE_AICORE__)
+  const int cid = static_cast<int>(get_block_idx());
+  const int vid = static_cast<int>(get_subblockid());
+  const int row_base = cid * TILE;
+  if (row_base >= batch) return;
+
+#if defined(__DAV_CUBE__)
+  L1Tile a_l1, b_l1;
+  Left a_l0;
+  Right b_l0;
+  Acc acc;
+  VecF acc_v;
+  TASSIGN(a_l1, 0x0);
+  TASSIGN(b_l1, TILE * TILE * sizeof(half));
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(acc, 0x0);
+  TASSIGN(acc_v, 0x20000);
+
+  Global a_g(a + row_base * TILE), b_g(b);
+  TLOAD(a_l1, a_g);
+  TLOAD(b_l1, b_g);
+  Sync<PIPE_MTE2, PIPE_MTE1>(0);
+  TMOV(a_l0, a_l1);
+  TMOV(b_l0, b_l1);
+  Sync<PIPE_MTE1, PIPE_M>(0);
+  TMATMUL(acc, a_l0, b_l0);
+  Sync<PIPE_M, PIPE_FIX>(0);
+  TMOV<VecF, Acc, AccToVecMode::DualModeSplitM>(acc_v, acc);
+  pipe_barrier(PIPE_ALL);
+  SignalBoth<PIPE_FIX>(FLAG_READY);
+  WaitBoth<PIPE_FIX>(FLAG_FREE);
+#endif
+
+#if defined(__DAV_VEC__)
+  VecF acc_v, d_v;
+  TASSIGN(acc_v, 0x20000);
+  TASSIGN(d_v, 0x0);
+  wait_intra_block(PIPE_V, FLAG_READY);
+  const int row = row_base + vid * HALF_TILE;
+  HalfFloat d_g(d + row * TILE), c_g(c + row * TILE);
+  TLOAD(d_v, d_g);
+  Sync<PIPE_MTE2, PIPE_V>(0);
+  TADD(acc_v, acc_v, d_v);
+  Sync<PIPE_V, PIPE_MTE3>(0);
+  TSTORE(c_g, acc_v);
+  pipe_barrier(PIPE_ALL);
+  set_intra_block(PIPE_V, FLAG_FREE);
+#endif
+#endif
+}
+
+extern "C" __global__ AICORE void static_matmul_add_kernel(
+    __gm__ uint8_t *a, __gm__ uint8_t *b, __gm__ uint8_t *c, __gm__ uint8_t *d,
+    int64_t batch) {
+  run_static_matmul_add((__gm__ half *)a, (__gm__ half *)b, (__gm__ float *)c,
+                        (__gm__ float *)d, batch);
+}
+
+extern "C" void call_static_matmul_add(uint32_t block_dim, void *stream, uint8_t *a,
+                                       uint8_t *b, uint8_t *c, uint8_t *d,
+                                       int64_t batch) {
+  static_matmul_add_kernel<<<block_dim, nullptr, stream>>>(a, b, c, d, batch);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind.cpp
@@ -1,0 +1,30 @@
+#include <torch/extension.h>
+#include <cstdint>
+#include <string>
+
+namespace py = pybind11;
+extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
+                                uint8_t *x, uint8_t *z);
+extern "C" void call_static_matmul(uint32_t block_dim, void *stream, uint8_t *out,
+                                   uint8_t *a, uint8_t *b);
+
+void launch_static_add(const at::Tensor &out,
+                       const at::Tensor &x, const at::Tensor &z, uintptr_t stream) {
+  call_static_add(1, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
+                  static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()));
+}
+
+void launch_static_matmul(const at::Tensor &out,
+                          const at::Tensor &a, const at::Tensor &b, uintptr_t stream) {
+  call_static_matmul(1, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
+                     static_cast<uint8_t *>(a.data_ptr()), static_cast<uint8_t *>(b.data_ptr()));
+}
+
+#ifndef TORCH_EXTENSION_NAME
+#define TORCH_EXTENSION_NAME pto_static_a5_demo
+#endif
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("launch_static_add", &launch_static_add);
+  m.def("launch_static_matmul", &launch_static_matmul);
+}

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind.cpp
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind.cpp
@@ -1,23 +1,28 @@
 #include <torch/extension.h>
+
 #include <cstdint>
 #include <string>
 
 namespace py = pybind11;
 extern "C" void call_static_add(uint32_t block_dim, void *stream, uint8_t *out,
                                 uint8_t *x, uint8_t *z);
-extern "C" void call_static_matmul(uint32_t block_dim, void *stream, uint8_t *out,
-                                   uint8_t *a, uint8_t *b);
+extern "C" void call_static_matmul(uint32_t block_dim, void *stream,
+                                   uint8_t *out, uint8_t *a, uint8_t *b);
 
-void launch_static_add(const at::Tensor &out,
-                       const at::Tensor &x, const at::Tensor &z, uintptr_t stream) {
-  call_static_add(1, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
-                  static_cast<uint8_t *>(x.data_ptr()), static_cast<uint8_t *>(z.data_ptr()));
+void launch_static_add(const at::Tensor &out, const at::Tensor &x,
+                       const at::Tensor &z, uintptr_t stream) {
+  call_static_add(1, reinterpret_cast<void *>(stream),
+                  static_cast<uint8_t *>(out.data_ptr()),
+                  static_cast<uint8_t *>(x.data_ptr()),
+                  static_cast<uint8_t *>(z.data_ptr()));
 }
 
-void launch_static_matmul(const at::Tensor &out,
-                          const at::Tensor &a, const at::Tensor &b, uintptr_t stream) {
-  call_static_matmul(1, reinterpret_cast<void *>(stream), static_cast<uint8_t *>(out.data_ptr()),
-                     static_cast<uint8_t *>(a.data_ptr()), static_cast<uint8_t *>(b.data_ptr()));
+void launch_static_matmul(const at::Tensor &out, const at::Tensor &a,
+                          const at::Tensor &b, uintptr_t stream) {
+  call_static_matmul(1, reinterpret_cast<void *>(stream),
+                     static_cast<uint8_t *>(out.data_ptr()),
+                     static_cast<uint8_t *>(a.data_ptr()),
+                     static_cast<uint8_t *>(b.data_ptr()));
 }
 
 #ifndef TORCH_EXTENSION_NAME

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/README.md
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/README.md
@@ -1,0 +1,16 @@
+# Static A5 Pybind Package
+
+Minimal pip-installable torch extension package for the static A5 demo.
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package
+python3 -m pip install --no-build-isolation -e .
+```
+
+The build step first compiles `../add.cpp` and `../matmul.cpp` with `bisheng`,
+copies the generated kernel shared libraries into the Python package, then links
+the torch C++ extension with `$ORIGIN` rpath so `_C` can import after install.
+The public interface accepts torch tensors, not raw `data_ptr()` integers.
+
+`--no-build-isolation` is intentional: the extension must use the same already
+installed `torch` and `torch_npu` environment as the runtime.

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/pto_static_a5_demo/__init__.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/pto_static_a5_demo/__init__.py
@@ -1,0 +1,14 @@
+import torch  # noqa: F401
+import torch_npu  # noqa: F401
+
+from . import _C
+
+
+def add(out, x, z, stream: int):
+    _C.launch_static_add(out, x, z, stream)
+    return out
+
+
+def matmul(out, a, b, stream: int):
+    _C.launch_static_matmul(out, a, b, stream)
+    return out

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/pyproject.toml
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/setup.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/setup.py
@@ -41,7 +41,9 @@ setup(
     version="0.0.0",
     packages=["pto_static_a5_demo"],
     package_dir={"pto_static_a5_demo": "pto_static_a5_demo"},
-    package_data={"pto_static_a5_demo": ["libstatic_add_a5.so", "libstatic_matmul_a5.so"]},
+    package_data={
+        "pto_static_a5_demo": ["libstatic_add_a5.so", "libstatic_matmul_a5.so"]
+    },
     ext_modules=[
         CppExtension(
             "pto_static_a5_demo._C",

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/setup.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package/setup.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import shutil
+from pathlib import Path
+
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILD = ROOT / "build"
+PACKAGE_DIR = Path(__file__).resolve().parent / "pto_static_a5_demo"
+
+
+def build_kernel(name: str) -> Path:
+    out = subprocess.check_output(["bash", str(ROOT / "compile.sh"), name], text=True)
+    return Path(out.strip().splitlines()[-1])
+
+
+class BuildWithKernels(BuildExtension):
+    def build_extensions(self):
+        add_lib = build_kernel("add")
+        matmul_lib = build_kernel("matmul")
+        PACKAGE_DIR.mkdir(parents=True, exist_ok=True)
+        packaged_add = PACKAGE_DIR / add_lib.name
+        packaged_matmul = PACKAGE_DIR / matmul_lib.name
+        shutil.copy2(add_lib, packaged_add)
+        shutil.copy2(matmul_lib, packaged_matmul)
+        for ext in self.extensions:
+            ext.extra_link_args = [
+                *getattr(ext, "extra_link_args", []),
+                str(packaged_add),
+                str(packaged_matmul),
+                "-Wl,-rpath,$ORIGIN",
+            ]
+        super().build_extensions()
+
+
+setup(
+    name="pto-static-a5-demo",
+    version="0.0.0",
+    packages=["pto_static_a5_demo"],
+    package_dir={"pto_static_a5_demo": "pto_static_a5_demo"},
+    package_data={"pto_static_a5_demo": ["libstatic_add_a5.so", "libstatic_matmul_a5.so"]},
+    ext_modules=[
+        CppExtension(
+            "pto_static_a5_demo._C",
+            [str(ROOT / "pybind.cpp")],
+            extra_compile_args=["-O2", "-std=c++17"],
+            runtime_library_dirs=[str(BUILD)],
+        )
+    ],
+    cmdclass={"build_ext": BuildWithKernels},
+)

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_ctypes.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch_npu  # noqa: F401
+
+HERE = Path(__file__).resolve().parent
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+
+
+def npu_tensor(arr: np.ndarray, device: str) -> torch.Tensor:
+    return torch.from_numpy(arr).to(device)
+
+
+def run_add(device: str) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "add")))
+    lib.call_static_add.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    rng = np.random.default_rng(0)
+    x_cpu = rng.standard_normal((64, 64)).astype(np.float16)
+    z_cpu = rng.standard_normal((64, 64)).astype(np.float16)
+    out = npu_tensor(np.zeros((64, 64), dtype=np.float16), device)
+    x = npu_tensor(x_cpu, device)
+    z = npu_tensor(z_cpu, device)
+    run_repeated(lambda: lib.call_static_add(1, stream_ptr(), tensor_ptr(out), tensor_ptr(x), tensor_ptr(z)))
+    assert_close(out.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
+    print("PASS static_single_core/a5 add shape=(64,64)")
+
+
+def run_matmul(device: str) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul")))
+    lib.call_static_matmul.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    rng = np.random.default_rng(1)
+    a_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+    b_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+    out = npu_tensor(np.zeros((16, 16), dtype=np.float32), device)
+    a = npu_tensor(a_cpu, device)
+    b = npu_tensor(b_cpu, device)
+    run_repeated(lambda: lib.call_static_matmul(1, stream_ptr(), tensor_ptr(out), tensor_ptr(a), tensor_ptr(b)))
+    ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32))
+    assert_close(out.cpu(), ref)
+    print("PASS static_single_core/a5 matmul shape=(16,16)x(16,16)")
+
+
+def run_matmul_add(device: str) -> None:
+    lib = ctypes.CDLL(str(compile_kernel(HERE / "compile.sh", "matmul_add")))
+    lib.call_static_matmul_add.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_int64,
+    ]
+    block_dim = 8
+    batch = block_dim * 128
+    rng = np.random.default_rng(2)
+    a_cpu = rng.standard_normal((batch, 128)).astype(np.float16)
+    b_cpu = rng.standard_normal((128, 128)).astype(np.float16)
+    d_cpu = rng.standard_normal((batch, 128)).astype(np.float32)
+    a = npu_tensor(a_cpu, device)
+    b = npu_tensor(b_cpu, device)
+    d = npu_tensor(d_cpu, device)
+    c = npu_tensor(np.zeros((batch, 128), dtype=np.float32), device)
+    run_repeated(
+        lambda: lib.call_static_matmul_add(block_dim, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), batch)
+    )
+    ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32) + d_cpu)
+    assert_close(c.cpu(), ref)
+    print(f"PASS static_single_core/a5 matmul_add rounds=1 batch={batch}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kernel", choices=("add", "matmul", "matmul_add", "all"), default="all")
+    parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args()
+    configure_torch_npu(simulator_safe=True)
+    torch.npu.set_device(args.device)
+    if args.kernel in ("add", "all"):
+        run_add(args.device)
+    if args.kernel in ("matmul", "all"):
+        run_matmul(args.device)
+    if args.kernel in ("matmul_add", "all"):
+        run_matmul_add(args.device)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps({"result": "PASS", "kernel": args.kernel}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_ctypes.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_ctypes.py
@@ -15,7 +15,14 @@ import torch_npu  # noqa: F401
 HERE = Path(__file__).resolve().parent
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, compile_kernel, configure_torch_npu, run_repeated, stream_ptr, tensor_ptr  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    compile_kernel,
+    configure_torch_npu,
+    run_repeated,
+    stream_ptr,
+    tensor_ptr,
+)  # noqa: E402
 
 
 def npu_tensor(arr: np.ndarray, device: str) -> torch.Tensor:
@@ -37,7 +44,11 @@ def run_add(device: str) -> None:
     out = npu_tensor(np.zeros((64, 64), dtype=np.float16), device)
     x = npu_tensor(x_cpu, device)
     z = npu_tensor(z_cpu, device)
-    run_repeated(lambda: lib.call_static_add(1, stream_ptr(), tensor_ptr(out), tensor_ptr(x), tensor_ptr(z)))
+    run_repeated(
+        lambda: lib.call_static_add(
+            1, stream_ptr(), tensor_ptr(out), tensor_ptr(x), tensor_ptr(z)
+        )
+    )
     assert_close(out.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
     print("PASS static_single_core/a5 add shape=(64,64)")
 
@@ -57,7 +68,11 @@ def run_matmul(device: str) -> None:
     out = npu_tensor(np.zeros((16, 16), dtype=np.float32), device)
     a = npu_tensor(a_cpu, device)
     b = npu_tensor(b_cpu, device)
-    run_repeated(lambda: lib.call_static_matmul(1, stream_ptr(), tensor_ptr(out), tensor_ptr(a), tensor_ptr(b)))
+    run_repeated(
+        lambda: lib.call_static_matmul(
+            1, stream_ptr(), tensor_ptr(out), tensor_ptr(a), tensor_ptr(b)
+        )
+    )
     ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32))
     assert_close(out.cpu(), ref)
     print("PASS static_single_core/a5 matmul shape=(16,16)x(16,16)")
@@ -85,7 +100,15 @@ def run_matmul_add(device: str) -> None:
     d = npu_tensor(d_cpu, device)
     c = npu_tensor(np.zeros((batch, 128), dtype=np.float32), device)
     run_repeated(
-        lambda: lib.call_static_matmul_add(block_dim, stream_ptr(), tensor_ptr(a), tensor_ptr(b), tensor_ptr(c), tensor_ptr(d), batch)
+        lambda: lib.call_static_matmul_add(
+            block_dim,
+            stream_ptr(),
+            tensor_ptr(a),
+            tensor_ptr(b),
+            tensor_ptr(c),
+            tensor_ptr(d),
+            batch,
+        )
     )
     ref = torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32) + d_cpu)
     assert_close(c.cpu(), ref)
@@ -94,7 +117,9 @@ def run_matmul_add(device: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--kernel", choices=("add", "matmul", "matmul_add", "all"), default="all")
+    parser.add_argument(
+        "--kernel", choices=("add", "matmul", "matmul_add", "all"), default="all"
+    )
     parser.add_argument("--device", default=os.environ.get("NPU_DEVICE", "npu:0"))
     parser.add_argument("--output-json", type=Path)
     args = parser.parse_args()
@@ -108,7 +133,9 @@ def main() -> None:
         run_matmul_add(args.device)
     if args.output_json:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
-        args.output_json.write_text(json.dumps({"result": "PASS", "kernel": args.kernel}, indent=2))
+        args.output_json.write_text(
+            json.dumps({"result": "PASS", "kernel": args.kernel}, indent=2)
+        )
 
 
 if __name__ == "__main__":

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_pybind.py
@@ -15,7 +15,12 @@ HERE = Path(__file__).resolve().parent
 BUILD = HERE / "build"
 
 sys.path.insert(0, str(HERE.parents[1]))
-from pto_demo_utils import assert_close, configure_torch_npu, run_repeated, stream_as_int  # noqa: E402
+from pto_demo_utils import (
+    assert_close,
+    configure_torch_npu,
+    run_repeated,
+    stream_as_int,
+)  # noqa: E402
 
 
 def build_kernel(name: str) -> Path:
@@ -79,7 +84,10 @@ def main() -> None:
         run_repeated(lambda: pkg.matmul(mat_out, a, b, stream))
     else:
         run_repeated(lambda: mod.launch_static_matmul(mat_out, a, b, stream))
-    assert_close(mat_out.cpu(), torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32)))
+    assert_close(
+        mat_out.cpu(),
+        torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32)),
+    )
     print("PASS static_single_core/a5 pybind matmul")
 
 

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_pybind.py
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/run_kernel_pybind.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch_npu  # noqa: F401
+from torch.utils.cpp_extension import load
+
+HERE = Path(__file__).resolve().parent
+BUILD = HERE / "build"
+
+sys.path.insert(0, str(HERE.parents[1]))
+from pto_demo_utils import assert_close, configure_torch_npu, run_repeated, stream_as_int  # noqa: E402
+
+
+def build_kernel(name: str) -> Path:
+    out = subprocess.check_output(["bash", str(HERE / "compile.sh"), name], text=True)
+    return Path(out.strip().splitlines()[-1])
+
+
+def build_module():
+    BUILD.mkdir(exist_ok=True)
+    ext_dir = BUILD / "torch_ext_static_a5"
+    ext_dir.mkdir(exist_ok=True)
+    add_lib = build_kernel("add")
+    matmul_lib = build_kernel("matmul")
+    return load(
+        name="pto_static_a5_demo",
+        sources=[str(HERE / "pybind.cpp")],
+        extra_ldflags=[str(add_lib), str(matmul_lib)],
+        build_directory=str(ext_dir),
+        verbose=False,
+    )
+
+
+def npu_tensor(arr: np.ndarray, device: str) -> torch.Tensor:
+    return torch.from_numpy(arr).to(device)
+
+
+def main() -> None:
+    device = os.environ.get("NPU_DEVICE", "npu:0")
+    configure_torch_npu(simulator_safe=True)
+    torch.npu.set_device(device)
+    try:
+        import pto_static_a5_demo as pkg
+    except ImportError:
+        pkg = None
+        print("Using pybind launch path: torch.utils.cpp_extension.load")
+        mod = build_module()
+    else:
+        print("Using pybind launch path: installed pto_static_a5_demo package")
+        mod = None
+    stream = stream_as_int()
+
+    rng = np.random.default_rng(0)
+    x_cpu = rng.standard_normal((64, 64)).astype(np.float16)
+    z_cpu = rng.standard_normal((64, 64)).astype(np.float16)
+    x = npu_tensor(x_cpu, device)
+    z = npu_tensor(z_cpu, device)
+    out = npu_tensor(np.zeros((64, 64), dtype=np.float16), device)
+    if pkg is not None:
+        run_repeated(lambda: pkg.add(out, x, z, stream))
+    else:
+        run_repeated(lambda: mod.launch_static_add(out, x, z, stream))
+    assert_close(out.cpu(), torch.from_numpy((x_cpu + z_cpu).astype(np.float16)))
+    print("PASS static_single_core/a5 pybind add")
+
+    a_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+    b_cpu = rng.standard_normal((16, 16)).astype(np.float16)
+    a = npu_tensor(a_cpu, device)
+    b = npu_tensor(b_cpu, device)
+    mat_out = npu_tensor(np.zeros((16, 16), dtype=np.float32), device)
+    if pkg is not None:
+        run_repeated(lambda: pkg.matmul(mat_out, a, b, stream))
+    else:
+        run_repeated(lambda: mod.launch_static_matmul(mat_out, a, b, stream))
+    assert_close(mat_out.cpu(), torch.from_numpy(a_cpu.astype(np.float32) @ b_cpu.astype(np.float32)))
+    print("PASS static_single_core/a5 pybind matmul")
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/run_sim.sh
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/run_sim.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-msprof}"
+shift || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RUN_WITH_TIMEOUT="${REFERENCE_DIR}/run_with_timeout.sh"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/cann-9.0.0}}"
+source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+cd "${SCRIPT_DIR}"
+
+case "${MODE}" in
+  msprof)
+    export PTO_SIMULATOR=1
+    SIM_LIB="${ASCEND_HOME_PATH}/tools/simulator/Ascend950PR_9599/lib"
+    export LD_LIBRARY_PATH="${SIM_LIB}:${LD_LIBRARY_PATH:-}"
+    MSPROF_TIMEOUT="${MSPROF_TIMEOUT:-60}" msprof op simulator \
+      --soc-version=Ascend950PR_9599 \
+      --timeout="${MSPROF_TIMEOUT:-60}" \
+      --output="${SCRIPT_DIR}/outputs/msprof_static" \
+      python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  linked)
+    export PTO_SIMULATOR=1
+    sim_lib="${ASCEND_HOME_PATH}/tools/simulator/Ascend950PR_9599/lib"
+    export LD_LIBRARY_PATH="${sim_lib}:${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH:-}"
+    exe="$(bash "${SCRIPT_DIR}/compile.sh" acl_add | tail -n 1)"
+    "${RUN_WITH_TIMEOUT}" "${exe}"
+    ;;
+  cannsim)
+    export PTO_SIMULATOR=1
+    mkdir -p "${SCRIPT_DIR}/outputs/cannsim_static"
+    USER_OPTS="--kernel add --output-json outputs/static_add_cannsim.json $*"
+    set +e
+    cannsim record -s "${CANNSIM_SOC:-Ascend950}" \
+      -o "${SCRIPT_DIR}/outputs/cannsim_static" \
+      "${SCRIPT_DIR}/run_sim_entry.sh" \
+      -u "${USER_OPTS}"
+    rc=$?
+    set -e
+    if [[ "${rc}" -ne 0 ]]; then
+      if [[ -f "${SCRIPT_DIR}/outputs/static_add_cannsim.json" ]]; then
+        python3 - "${SCRIPT_DIR}/outputs/static_add_cannsim.json" <<'PY'
+import json, sys
+from pathlib import Path
+data = json.loads(Path(sys.argv[1]).read_text())
+sys.exit(0 if data.get("result") == "PASS" else 1)
+PY
+        echo "cannsim exited ${rc} after writing PASS JSON; treating as success"
+        exit 0
+      fi
+      exit "${rc}"
+    fi
+    ;;
+  direct)
+    "${RUN_WITH_TIMEOUT}" python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"
+    ;;
+  *)
+    echo "usage: $0 {msprof|cannsim|linked|direct} [run_kernel_ctypes.py args]" >&2
+    exit 2
+    ;;
+esac

--- a/.skills/testing-pto-kernels/reference/static_single_core/a5/run_sim_entry.sh
+++ b/.skills/testing-pto-kernels/reference/static_single_core/a5/run_sim_entry.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+exec "${REFERENCE_DIR}/run_with_timeout.sh" python3 "${SCRIPT_DIR}/run_kernel_ctypes.py" "$@"

--- a/.skills/testing-pto-kernels/reference/synchronization-and-architecture.md
+++ b/.skills/testing-pto-kernels/reference/synchronization-and-architecture.md
@@ -1,0 +1,70 @@
+# Synchronization And Architecture Notes
+
+## A2A3 vs A5
+
+| Topic | A2A3 / Ascend910B / DAV_2201 | A5 / Ascend950 / DAV_3510 |
+| --- | --- | --- |
+| PTO test dir | `tests/npu/a2a3/src/st/testcase` | `tests/npu/a5/src/st/testcase` |
+| Include dir | `include/pto/npu/a2a3` | `include/pto/npu/a5` |
+| Vector flag | `dav-c220-vec` | `dav-c310-vec` |
+| Cube flag | `dav-c220-cube` or `--cce-soc-core-type=CubeCore` | `dav-c310-cube` |
+| Mix flag | `dav-c220` | `dav-c310` |
+| Memory macro | `-DMEMORY_BASE` | `-DREGISTER_BASE` |
+| Typical core ratio | Cube:Vector = 1:2 | Cube:Vector = 1:2 |
+| Important buffer delta | UB 192 KiB, L0C 128 KiB | UB 248 KiB, L0C 256 KiB |
+
+Use runtime APIs for exact core counts and memory sizes. INI files are useful clues but not the final source of truth.
+
+## Mix Kernels
+
+Use "mix kernel" for kernels where Cube and Vector sides cooperate in one launch.
+
+### A2A3 Pattern
+
+Local files: `dynamic_multi_core/a2a3/matmul_add.cpp` and `dynamic_multi_core/a2a3/add_matmul.cpp`.
+
+- `matmul_add_c2v`: Cube computes `A @ B`, stores to workspace, Vector adds `D`.
+- `add_matmul_v2c`: Vector computes `A + B`, stores to workspace, Cube computes matmul.
+- `raw_flag` is the clearest reference for manual FFTS.
+- `gm_pipe` is the safer multi-round `TPipe` variant when newer PTO-ISA headers are available.
+
+Known pitfalls:
+
+- TileData `TPUSH`/`TPOP` with two Vec subblocks can desynchronize FIFO slot indices in multi-round kernels. Use `FIFO_DEPTH=1`, `gm_pipe`, or raw FFTS flags.
+- Do not reuse conflicting FFTS `FlagID` values for kernels called sequentially in one process.
+- Add `pipe_barrier(PIPE_ALL)` after the last `TSTORE` from L0C to avoid next-call `TMATMUL` read/write conflicts.
+
+### A5 Pattern
+
+Local files: `dynamic_multi_core/a5/matmul_add.cpp` and `dynamic_multi_core/a5/add_matmul.cpp`.
+
+A5 has direct local Cube/Vector paths:
+
+- Cube to Vector: `TMOV<VecTileFloat, AccTile, AccToVecMode::DualModeSplitM>` lowers to `copy_matrix_cc_to_ub`.
+- Vector to Cube: convert Vec ND to NZ, then `TINSERT` into L1; this lowers to `copy_ubuf_to_cbuf`.
+- Use `set_intra_block` / `wait_intra_block` and wait for both Vec subblocks (`flag` and `flag + 16` where required by the helper).
+
+Porting checklist:
+
+- Replace A2A3 guards such as `__DAV_C220_CUBE__` with A5-generic `__DAV_CUBE__` and `__DAV_VEC__`.
+- Compile mixed kernels with `--cce-aicore-arch=dav-c310`.
+- Convert Vec row-major data to NZ layout before Cube consumes it.
+- Separate data-ready flags from slot-free flags in persistent V2C kernels.
+- Benchmark hot copy loops separately from setup work.
+
+## Static vs Dynamic Launch
+
+Static single-core samples usually launch one block and one testcase shape:
+
+```cpp
+runTAdd<...><<<1, nullptr, stream>>>(out, src0, src1);
+```
+
+Dynamic multi-core samples usually launch physical core count and loop over runtime work:
+
+```cpp
+kernel<<<block_dim, nullptr, stream>>>(...);
+// inside kernel: for each tile assigned to get_block_idx()
+```
+
+Use the static form to learn instruction syntax. Use the dynamic form for real workload testing.

--- a/.skills/testing-pto-kernels/reference/third_party/pto-isa/README.md
+++ b/.skills/testing-pto-kernels/reference/third_party/pto-isa/README.md
@@ -1,0 +1,39 @@
+# PTO-ISA Headers
+
+A PTO kernel needs `pto/pto-inst.hpp`.
+
+## Default: CANN-Shipped Headers
+
+Use this when the kernel only needs stable APIs:
+
+```bash
+export PTO_LIB_PATH="${ASCEND_HOME_PATH}"
+```
+
+Compile with:
+
+```bash
+-I${PTO_LIB_PATH}/include
+```
+
+## Pinned Checkout
+
+Use a local checkout when a sample needs newer APIs than CANN provides:
+
+```bash
+export PTO_LIB_PATH=/path/to/pto-isa
+```
+
+Examples that may need newer headers include `TALLOC`, `TPOP(GlobalData)`, `TFREE`, or recent A5 direct-copy helpers.
+
+## Submodule Pattern
+
+For deliverable code, prefer a pinned submodule or documented commit:
+
+```bash
+git submodule add https://gitcode.com/cann/pto-isa.git third_party/pto-isa
+git submodule update --init --recursive
+export PTO_LIB_PATH=$PWD/third_party/pto-isa
+```
+
+Do not vendor a large PTO-ISA source tree into this skill reference unless a future task explicitly needs an offline snapshot.

--- a/.skills/testing-pto-kernels/reference/training_integration/README.md
+++ b/.skills/testing-pto-kernels/reference/training_integration/README.md
@@ -1,0 +1,12 @@
+# Training Integration TODO
+
+This task intentionally does not verify torch autograd, TorchTitan, or training-loop integration because the current environment does not provide those stacks.
+
+Future work should add:
+
+1. A pybind/CMake PTO forward kernel.
+2. A verified backward kernel or a documented PyTorch fallback.
+3. A `torch.autograd.Function` wrapper.
+4. A tiny training step that checks gradients and loss movement.
+
+Until then, do not claim training integration from this skill.

--- a/.skills/testing-pto-kernels/reference/verification-log.md
+++ b/.skills/testing-pto-kernels/reference/verification-log.md
@@ -1,6 +1,6 @@
 # Verification Log
 
-Latest full reproduction: **2026-06-10** — see [`../reproduction-report-2026-06-10.md`](../reproduction-report-2026-06-10.md).  
+Latest full reproduction: **2026-06-10** — see [`../reproduction-report-2026-06-10.md`](../reproduction-report-2026-06-10.md).
 Quick re-smoke: `cd reference && NPU_DEVICE=npu:0 ./reproduce.sh`
 
 ---
@@ -430,4 +430,3 @@ The local pybind verification is covered by `A2A3 Dynamic pybind/CMake` above. I
 ## Not Verified In This Task
 
 - ACLgraph launch, vLLM/SGLang inference integration, TorchTitan/autograd integration.
-

--- a/.skills/testing-pto-kernels/reference/verification-log.md
+++ b/.skills/testing-pto-kernels/reference/verification-log.md
@@ -1,0 +1,433 @@
+# Verification Log
+
+Latest full reproduction: **2026-06-10** — see [`../reproduction-report-2026-06-10.md`](../reproduction-report-2026-06-10.md).  
+Quick re-smoke: `cd reference && NPU_DEVICE=npu:0 ./reproduce.sh`
+
+---
+
+Date: 2026-06-08
+
+Environment:
+
+- Host workspace: `/workdir`
+- CANN: `/usr/local/Ascend/cann-9.0.0`
+- `bisheng`: `/usr/local/Ascend/cann-9.0.0/bin/bisheng`
+- Python: `3.11.15`
+- Device server: `npu-smi info` reported Ascend910B2 devices.
+
+Only commands listed here were executed during this skill update.
+
+## A2A3 Dynamic ctypes: Vector Add
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+NPU_DEVICE=npu:4 python3 run_kernel_ctypes.py --kernel add --n 4096
+```
+
+Result:
+
+```text
+PASS add n=4096 block_dim=48
+```
+
+Notes:
+
+- The local `dav-c220-vec` add sample initializes A2A3 vector mask state with `set_mask_norm(); set_vector_mask(-1, -1);` and is verified with `vector_core_num=48`. UB capacity is per core; query the target device's `ub_size` rather than treating total `block_dim` as a UB capacity multiplier.
+- All local smoke checks use `pto_demo_utils.assert_close` with `torch.testing.assert_close` defaults: fp16 `rtol=1e-3, atol=1e-5`; fp32 `rtol=1.3e-6, atol=1e-5`. Real-device runners repeat each launch 5 times; CA-model paths set `PTO_SIMULATOR=1` for a single repeat.
+
+## A2A3 Dynamic ctypes: simple_matmul
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+NPU_DEVICE=npu:4 python3 run_kernel_ctypes.py --kernel matmul --m 128
+```
+
+Result:
+
+```text
+PASS simple_matmul m=128 block_dim=1
+```
+
+Final source recompile:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+bash compile.sh matmul
+```
+
+Result:
+
+```text
+/workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3/build/libmatmul.so
+```
+
+## A2A3 Dynamic pybind/CMake
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+NPU_DEVICE=npu:4 python3 run_kernel_pybind.py --kernel all --n 4096 --m 128
+```
+
+Result:
+
+```text
+PASS pybind add n=4096 block_dim=48
+PASS pybind simple_matmul m=128 block_dim=1
+```
+
+The pybind module exposes torch-style `at::Tensor` arguments, imports the resulting `pto_dynamic_a2a3_demo` module, then launches the local device libraries.
+
+## A2A3 Dynamic Benchmark Template
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+NPU_DEVICE=npu:1 python3 benchmark.py --kernel all --warmup 1 --repeats 3 \
+  --add-sizes 4096 --matmul-m 128 --csv outputs/benchmark_smoke.csv
+```
+
+Result:
+
+```text
+add             n=4096                   1     293.32     361.93     156.26       0.08     0.0000
+simple_matmul   m=128,k=128,n=128        1     173.30     773.08     865.95       0.57     0.0242
+Wrote outputs/benchmark_smoke.csv
+```
+
+Notes:
+
+- The add benchmark chooses active blocks by tile capacity; spreading a very small vector over all physical cores can trigger vector UB issues under event timing.
+- Use larger shape lists and more repeats for real reporting.
+
+## A2A3 Dynamic Mix Kernels
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+NPU_DEVICE=npu:5 python3 run_mix_ctypes.py --kernel all --rounds 1
+```
+
+Result:
+
+```text
+PASS A2A3 matmul_add_c2v rounds=1 batch=3072
+PASS A2A3 add_matmul_v2c rounds=1 batch=3072
+```
+
+## A2A3 CA Model: msprof op simulator
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a2a3
+MSPROF_SOC_VERSION=Ascend910B2 MSPROF_TIMEOUT=120 ./run_sim.sh msprof --kernel all
+```
+
+Result:
+
+```text
+PASS static_single_core/a2a3 add shape=(64,64)
+PASS static_single_core/a2a3 matmul shape=(128,128)x(128,128)
+PASS static_single_core/a2a3 matmul_add rounds=1 batch=128
+```
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a2a3
+MSPROF_SOC_VERSION=Ascend910B2 MSPROF_TIMEOUT=120 ./run_sim.sh msprof --kernel add --n 4096
+```
+
+Result:
+
+```text
+PASS add n=4096 block_dim=48
+```
+
+Notes:
+
+- Simulator libs live under `${ASCEND_HOME_PATH}/tools/simulator/Ascend910B2/lib`.
+- `run_sim.sh` sources `setenv.bash`, sets `LD_LIBRARY_PATH`, and wraps `msprof op simulator`.
+- Use `./run_sim.sh direct` for the same ctypes runners on real Ascend910B hardware.
+
+## A2A3 Static Single-Core Add
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a2a3
+NPU_DEVICE=npu:5 python3 run_kernel_ctypes.py
+```
+
+Result:
+
+```text
+PASS static_single_core/a2a3 add shape=(64,64)
+```
+
+Additional static A2A3 verification:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a2a3
+NPU_DEVICE=npu:5 python3 run_kernel_ctypes.py
+NPU_DEVICE=npu:5 python3 run_kernel_pybind.py
+exe="$(bash compile.sh acl_add | tail -n 1)" && NPU_DEVICE=npu:5 "$exe" "$(pwd)/build/libstatic_add_a2a3.so"
+```
+
+Result:
+
+```text
+PASS static_single_core/a2a3 add shape=(64,64)
+PASS static_single_core/a2a3 matmul shape=(128,128)x(128,128)
+PASS static_single_core/a2a3 matmul_add rounds=1 batch=128
+PASS static_single_core/a2a3 pybind add shape=(64,64)
+PASS static_single_core/a2a3 ACL add
+```
+
+The static A2A3 `matmul_add.cpp` is self-contained; it does not include code from the dynamic example directory.
+
+## A5 Dynamic ctypes: Compile
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+bash compile.sh add
+```
+
+Result:
+
+```text
+/workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5/build/libadd_a5.so
+```
+
+## A5 Dynamic CA Model: msprof op simulator
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+MSPROF_TIMEOUT=30 bash run_sim.sh msprof --n 128 --block-dim 8
+```
+
+Result:
+
+```json
+{
+  "kernel": "add",
+  "n": 128,
+  "block_dim": 8,
+  "result": "PASS"
+}
+```
+
+Observed simulator wall time was about one minute including startup and profiling parse.
+
+## A5 Dynamic CA Model: Cube Matmul
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+MSPROF_TIMEOUT=30 bash run_sim.sh msprof --kernel matmul
+```
+
+Result:
+
+```text
+PASS dynamic matmul shape=16x16x16 block_dim=1
+```
+
+## A5 Dynamic CA Model: pybind
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_dynamic_pybind \
+  python3 run_kernel_pybind.py --kernel all --n 128 --block-dim 8
+```
+
+Result:
+
+```text
+Using torch extension pybind path: pto_dynamic_a5_demo
+PASS dynamic_multi_core/a5 pybind add n=128 block_dim=8
+PASS dynamic_multi_core/a5 pybind matmul shape=16x16x16
+```
+
+## A5 Dynamic CA Model: Mix Kernels
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_mix_c2v \
+  python3 run_mix_ctypes.py --kernel matmul_add --rounds 1 --block-dim 8
+```
+
+Result:
+
+```text
+PASS A5 matmul_add_c2v rounds=1 batch=1024 block_dim=8
+```
+
+Rechecked with strict `atol=1e-5`: PASS.
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_mix_v2c \
+  python3 run_mix_ctypes.py --kernel add_matmul --rounds 1 --block-dim 8
+```
+
+Result:
+
+```text
+PASS A5 add_matmul_v2c rounds=1 batch=1024 block_dim=8
+```
+
+Rechecked with strict `atol=1e-5`: PASS.
+
+## A5 Dynamic CA Model: cannsim
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/dynamic_multi_core/a5
+bash run_sim.sh cannsim --output-json outputs/add_cannsim_rerun.json
+```
+
+Result:
+
+```json
+{
+  "kernel": "add",
+  "n": 128,
+  "block_dim": 8,
+  "result": "PASS"
+}
+```
+
+Notes:
+
+- `cannsim` executed the kernel and wrote PASS JSON, then the user process segfaulted during teardown. `run_sim.sh` now treats this known pattern as success only when the requested JSON file exists and contains `"result": "PASS"`.
+
+## A5 Static Single-Core CA Model
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5
+MSPROF_TIMEOUT=30 bash run_sim.sh msprof --kernel add
+MSPROF_TIMEOUT=30 bash run_sim.sh msprof --kernel matmul
+```
+
+Result:
+
+```text
+PASS static_single_core/a5 add shape=(64,64)
+PASS static_single_core/a5 matmul shape=(16,16)x(16,16)
+```
+
+Static cannsim add wrapper:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5
+bash run_sim.sh cannsim
+```
+
+Result:
+
+```text
+PASS static_single_core/a5 add shape=(64,64)
+cannsim exited 1 after writing PASS JSON; treating as success
+```
+
+Additional static A5 verification:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5
+MSPROF_TIMEOUT=30 bash run_sim.sh msprof --kernel matmul_add
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_static_pybind \
+  python3 run_kernel_pybind.py
+```
+
+Result:
+
+```text
+PASS static_single_core/a5 matmul_add rounds=1 batch=1024
+PASS static_single_core/a5 pybind add
+PASS static_single_core/a5 pybind matmul
+```
+
+Pip-installable pybind package verification:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package
+python3 -m pip install --no-build-isolation -e .
+msprof op simulator --soc-version=Ascend950PR_9599 --timeout=30 \
+  --output=outputs/msprof_static_pybind_pip \
+  python3 ../run_kernel_pybind.py
+```
+
+Result:
+
+```text
+PASS static_single_core/a5 pybind add
+PASS static_single_core/a5 pybind matmul
+```
+
+The package was also checked with a direct import after editable install:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5/pybind_package
+python3 -m pip install --no-build-isolation -e .
+python3 - <<'PY'
+import pto_static_a5_demo
+print("import ok", pto_static_a5_demo.__name__)
+PY
+```
+
+Result:
+
+```text
+import ok pto_static_a5_demo
+```
+
+## A5 Static C++ CA Model: `-lruntime_camodel`
+
+Command:
+
+```bash
+cd /workdir/pto-skills/testing-pto-kernels/reference/static_single_core/a5
+bash run_sim.sh linked
+```
+
+Result:
+
+```text
+PASS static_single_core/a5 ACL runtime_camodel add
+```
+
+## Pybind/CMake AOT
+
+The local pybind verification is covered by `A2A3 Dynamic pybind/CMake` above. It builds and imports `dynamic_multi_core/a2a3/pybind.cpp` and launches the same local device libraries as the ctypes runner.
+
+## Not Verified In This Task
+
+- ACLgraph launch, vLLM/SGLang inference integration, TorchTitan/autograd integration.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,4 @@ wheel.packages = ["python/pto_kernels"]
 
 
 [tool.ruff]
-exclude = ["build"]
+exclude = ["build", ".skills"]


### PR DESCRIPTION
Those are the critical & minimum information that I keep telling agent all the time. Condense them as reusable skills.

**Reproduce:** All samples are validated inside Docker image https://github.com/learning-chip/agent_docker_npu/pull/9, with CANN 9.0.0, torch-npu, pybind pre-installed.

Best used together with the other skills:
- https://gitcode.com/cann/pto-isa/blob/master/agents/skills/pto-isa-operator-implementation/SKILL.md
- https://gitcode.com/cann/cannbot-skills/blob/master/ops/npu-arch/SKILL.md
- https://gitcode.com/cann/cannbot-skills/blob/master/ops/ops-simulator/SKILL.md
- https://gitcode.com/cann/cannbot-skills/blob/master/ops/ops-profiling/SKILL.md
- https://gitcode.com/cann/cannbot-skills/blob/master/ops/ops-precision-standard/SKILL.md

# TODO for testing skills

This PR focuses on single-kernel testing. Leave as TODO for future PRs:
- [ ] ACLgraph integration (Ref those template [op-plugin/cpp_extension](https://gitcode.com/Ascend/op-plugin/tree/7.3.0/examples/cpp_extension), [vllm-ascend/torch_binding_meta.cpp](https://github.com/vllm-project/vllm-ascend/blob/v0.20.2rc1/csrc/torch_binding_meta.cpp))
- [ ] Inference engine sglang/vllm-ascend integration and testing
- [ ] Training engine autograd/torchtitan-npu integration and testing

# TODO for the rest of skills

Still missing PTO performance optimization skills; this is the major next work item.

Something similar to [ascendc-performance-best-practices](https://gitcode.com/cann/cannbot-skills/tree/master/ops/ascendc-performance-best-practices) and [ascendc-regbase-best-practice](https://gitcode.com/cann/cannbot-skills/blob/master/ops/ascendc-regbase-best-practice)