### PR TITLE
Add support for NZ fractals in l0A

### DIFF
--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -38,9 +38,15 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
   constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
+#ifdef __DAV_C310__
+  constexpr BLayout OuterLayout =
+      is_left ? BLayout::ColMajor : BLayout::RowMajor;
+#else
+  constexpr BLayout OuterLayout = BLayout::RowMajor;
+#endif
 
-  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
-       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
+       FractalSize, InnerLayout, TileConfig::fractalABSize>
       fractals[NumFractals];
   const std::uintptr_t starting_address =
       reinterpret_cast<std::uintptr_t>(dst.data());
@@ -86,7 +92,12 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
-
+#ifdef __DAV_C310__
+  constexpr BLayout OuterLayout =
+      is_left ? BLayout::ColMajor : BLayout::RowMajor;
+#else
+  constexpr BLayout OuterLayout = BLayout::RowMajor;
+#endif
   // For left: copy even blocks 0, 2, 4, ... (starting_block=0)
   // For right: copy odd blocks 1, 3, 5, ... (starting_block=1)
   // Default: left→even(0), right→odd(1). swap_parity flips this.
@@ -97,8 +108,8 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   const uint32_t num_fractals_per_block = block_size / FractalSize;
 
   // might need fewer fractals if block_size < FractalSize
-  Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor,
-       FractalSize, FractalSize, InnerLayout, TileConfig::fractalABSize>
+  Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
+       FractalSize, InnerLayout, TileConfig::fractalABSize>
       fractals[MatrixSize / FractalSize];
 
   const std::uintptr_t starting_address =

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -117,10 +117,17 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
     for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
       for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
+#ifdef __DAV_C310__
+        const uint32_t row_stride = is_left ? FractalSize : MatrixSize;
+        const uint32_t col_stride = is_left ? MatrixSize : FractalSIze;
+#else
+        const uint32_t row_stride = MatrixSize;
+        const uint32_t col_stride = FractalSize;
+#endif
         const uint32_t offset =
             b * (MatrixSize + FractalSize) * block_size /* block_offset */ +
-            i * MatrixSize * FractalSize /* col_fractal_offset */ +
-            j * FractalSize * FractalSize /* row_fractal_offset */;
+            j * col_stride * FractalSize /* col_fractal_offset */ +
+            i * row_stride * FractalSize /* row_fractal_offset */;
         TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
         TEXTRACT(fractals[b], src, b * block_size + i * FractalSize,
                  b * block_size + j * FractalSize);

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -38,12 +38,7 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
   constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
-#ifdef __DAV_C310__
-  constexpr BLayout OuterLayout =
-      is_left ? BLayout::ColMajor : BLayout::RowMajor;
-#else
-  constexpr BLayout OuterLayout = BLayout::RowMajor;
-#endif
+  constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
 
   Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
        FractalSize, InnerLayout, TileConfig::fractalABSize>
@@ -92,12 +87,7 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
   constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
   constexpr SLayout InnerLayout =
       is_left ? SLayout::RowMajor : SLayout::ColMajor;
-#ifdef __DAV_C310__
-  constexpr BLayout OuterLayout =
-      is_left ? BLayout::ColMajor : BLayout::RowMajor;
-#else
-  constexpr BLayout OuterLayout = BLayout::RowMajor;
-#endif
+  constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
   // For left: copy even blocks 0, 2, 4, ... (starting_block=0)
   // For right: copy odd blocks 1, 3, 5, ... (starting_block=1)
   // Default: left→even(0), right→odd(1). swap_parity flips this.
@@ -119,7 +109,7 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
       for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
 #ifdef __DAV_C310__
         const uint32_t row_stride = is_left ? FractalSize : MatrixSize;
-        const uint32_t col_stride = is_left ? MatrixSize : FractalSIze;
+        const uint32_t col_stride = is_left ? MatrixSize : FractalSize;
 #else
         const uint32_t row_stride = MatrixSize;
         const uint32_t col_stride = FractalSize;

--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -144,4 +144,25 @@ AICORE inline void SyncAll() {
 #endif
 }
 
+/**
+ * @brief Returns the outer matrix layout based on the target architecture and
+ * matrix orientation.
+ *
+ * On DAV C310 targets, the layout depends on whether the matrix is "left-sided"
+ * (L0A). DAV C310: L0A is NZ, L0B is ZN. Older: L0A is ZZ, L0B is ZN.
+ *
+ * Link:
+ * https://pto-isa.github.io/docs/isa/cube/nz-fractal-layout/#per-buffer-nz-layouts
+ *
+ * @param is_left Whether the matrix is on the left side (L0A) or not (L0B).
+ * @return The appropriate @c BLayout for the target architecture.
+ */
+constexpr pto::BLayout GetOuterLayout(bool is_left) {
+#ifdef __DAV_C310__
+  return is_left ? pto::BLayout::ColMajor : pto::BLayout::RowMajor;
+#else
+  return pto::BLayout::RowMajor;
+#endif
+}
+
 }  // namespace kernel_utils


### PR DESCRIPTION
In newer architectures, we need to support `NZ` layout for L0A matrices.