### PR TITLE
feature(make): makefile compile_a5_<kernel_name> target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,17 @@ compile_%:
 		$(CSRC_KERNEL_DIR)/kernel_$*.cpp \
 		-o libkernel_$*.so
 
+compile_a5_%:
+	mkdir -p build/lib/
+	bisheng -fPIC -shared -xcce -DREGISTER_BASE -O2 -std=gnu++17 \
+		-I$(CSRC_KERNEL_DIR) \
+		-I$(PTO_LIB_PATH)/include \
+		--cce-aicore-arch=dav-c310 \
+		-mllvm -cce-aicore-stack-size=0x8000 \
+		-mllvm -cce-aicore-function-stack-size=0x8000 \
+		-Wno-ignored-attributes \
+		$(CSRC_KERNEL_DIR)/kernel_$*.cpp \
+		-o build/lib/libkernel_$*.so
 
 install:
 	python3 -m pip install --force-reinstall pto_kernels-*.whl

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -475,6 +475,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
                                          uint32_t num_bsnd_heads = 0,
                                          uint32_t is_lower = 0,
                                          __gm__ int32_t* cu_seqlens = nullptr) {
+  using pto::Stride;
+
   /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;  // fractal size for half /bf16


### PR DESCRIPTION
Changelog:
* Adds makefile target for quickly compiling A5 kernels.
* Fixes C++ namespace issue with `pto::Stride`.

```
make compile_a5_tri_inv_rec_unroll                                                                                           
mkdir -p build/lib/                                                                                                                                                                 
bisheng -fPIC -shared -xcce -DREGISTER_BASE -O2 -std=gnu++17 \                                                                                                                      
        -Icsrc/kernel \                                                                                                                                                             
        -I/usr/local/Ascend/cann-9.0.0/include \                                                                                                                                    
        --cce-aicore-arch=dav-c310 \                                                                                                                                                
        -mllvm -cce-aicore-stack-size=0x8000 \                                                                                                                                      
        -mllvm -cce-aicore-function-stack-size=0x8000 \                                                                                                                             
        -Wno-ignored-attributes \                                                                                                                                                   
        csrc/kernel/kernel_tri_inv_rec_unroll.cpp \                                                                                                                                 
        -o build/lib/libkernel_tri_inv_rec_unroll.so                                                                                                                                
csrc/kernel/kernel_tri_inv_rec_unroll.cpp:492:7: error: reference to 'Stride' is ambiguous                                                                                          
      Stride<1, 1, 1, -1, 1>>::type;                                                                                                                                                
      ^                                                                                                                                                                             
/usr/local/Ascend/cann-9.0.0/tools/bisheng_compiler/lib/clang/15.0.5/include/__clang_cce_vector_intrinsics.h:114:12: note: candidate found by name lookup is 'Stride'               
enum class Stride {                                                                                                                                                                 
           ^                                                                                                                                                                        
/usr/local/Ascend/cann-9.0.0/include/pto/common/pto_tile.hpp:139:8: note: candidate found by name lookup is 'pto::Stride'                                                           
struct Stride {                                                                                                                                                                     
       ^                                                                                                                                                                            
csrc/kernel/kernel_tri_inv_rec_unroll.cpp:496:35: error: reference to 'Stride' is ambiguous                                                                                         
  using GlobalTileDynamicStride = Stride<1, 1, 1, DYNAMIC, 1>;                 
/usr/local/Ascend/cann-9.0.0/tools/bisheng_compiler/lib/clang/15.0.5/include/__clang_cce_vector_intrinsics.h:114:12: note: candidate found by name lookup is 'Stride'
enum class Stride {
           ^
/usr/local/Ascend/cann-9.0.0/include/pto/common/pto_tile.hpp:139:8: note: candidate found by name lookup is 'pto::Stride'
struct Stride {
       ^
csrc/kernel/kernel_tri_inv_rec_unroll.cpp:508:7: error: reference to 'Stride' is ambiguous
      Stride<1, 1, 1, -1, 1>>::type;
      ^
/usr/local/Ascend/cann-9.0.0/tools/bisheng_compiler/lib/clang/15.0.5/include/__clang_cce_vector_intrinsics.h:114:12: note: candidate found by name lookup is 'Stride'
enum class Stride {
           ^
/usr/local/Ascend/cann-9.0.0/include/pto/common/pto_tile.hpp:139:8: note: candidate found by name lookup is 'pto::Stride'
struct Stride {
       ^
3 errors generated.
csrc/kernel/kernel_tri_inv_rec_unroll.cpp:492:7: error: reference to 'Stride' is ambiguous
      Stride<1, 1, 1, -1, 1>>::type;
      ^
/usr/local/Ascend/cann-9.0.0/tools/bisheng_compiler/lib/clang/15.0.5/include/__clang_cce_vector_intrinsics.h:114:12: note: candidate found by name lookup is 'Stride'
enum class Stride {
           ^
/usr/local/Ascend/cann-9.0.0/include/pto/common/pto_tile.hpp:139:8: note: candidate found by name lookup is 'pto::Stride'
struct Stride {
       ^
csrc/kernel/kernel_tri_inv_rec_unroll.cpp:496:35: error: reference to 'Stride' is ambiguous
  using GlobalTileDynamicStride = Stride<1, 1, 1, DYNAMIC, 1>;
                                  ^
/usr/local/Ascend/cann-9.0.0/tools/bisheng_compiler/lib/clang/15.0.5/include/__clang_cce_vector_intrinsics.h:114:12: note: candidate found by name lookup is 'Stride'
enum class Stride {
           ^
/usr/local/Ascend/cann-9.0.0/include/pto/common/pto_tile.hpp:139:8: note: candidate found by name lookup is 'pto::Stride'
struct Stride {
       ^
csrc/kernel/kernel_tri_inv_rec_unroll.cpp:508:7: error: reference to 'Stride' is ambiguous
      Stride<1, 1, 1, -1, 1>>::type;
      ^
/usr/local/Ascend/cann-9.0.0/tools/bisheng_compiler/lib/clang/15.0.5/include/__clang_cce_vector_intrinsics.h:114:12: note: candidate found by name lookup is 'Stride'
enum class Stride {
           ^
/usr/local/Ascend/cann-9.0.0/include/pto/common/pto_tile.hpp:139:8: note: candidate found by name lookup is 'pto::Stride'
struct Stride {
       ^
3 errors generated.
make: *** [Makefile:39: compile_a5_tri_inv_rec_unroll] Error 1

```