### PR TITLE
feature(cmake): update to new Ascend CMake infra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,19 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(PIP_INSTALL "True if building via pip" OFF)
 
+# Kernel toolchain selection.
+#
+# ON (default)  ASC language (find_package(ASC)), as in cann/ops-sparse. Needs
+# CANN >= 9.0 and ASCEND_HOME_PATH on the environment. OFF           legacy
+# ascendc.cmake, kept for comparison until the ASC path has had more mileage.
+#
+# Both paths reach the kernels through the pto_launch_* shims (see
+# csrc/host/kernel_launchers.h), so the host code is identical either way and
+# neither path depends on the code-generated aclrtlaunch_<kernel>.h headers that
+# only the legacy toolchain emits.
+option(USE_ASC_LANGUAGE
+       "Compile kernels with the ASC language toolchain (CANN >= 9.0)" ON)
+
 set(BASE_MODE
     "MEMORY"
     CACHE STRING "Base addressing mode: MEMORY or REGISTER")
@@ -53,6 +66,23 @@ elseif(DEFINED ENV{ASCEND_HOME_PATH})
       CACHE PATH "ASCEND CANN package installation directory" FORCE)
 endif()
 
+# SOC_VERSION -> NPU_ARCH: the ASC compiler takes the target architecture
+# instead of SOC_VERSION.
+string(TOLOWER "${SOC_VERSION}" SOC_VERSION_LOWER)
+if(SOC_VERSION_LOWER MATCHES "^ascend910b" OR SOC_VERSION_LOWER MATCHES
+                                              "^ascend910_93")
+  set(NPU_ARCH "dav-2201")
+elseif(SOC_VERSION_LOWER MATCHES "^ascend950")
+  set(NPU_ARCH "dav-3510")
+elseif(SOC_VERSION_LOWER MATCHES "^ascend310p")
+  set(NPU_ARCH "dav-2002")
+else()
+  message(
+    FATAL_ERROR
+      "Unsupported SOC_VERSION: ${SOC_VERSION}. Supported: ascend910b*, ascend910_93*, ascend950*, ascend310p*"
+  )
+endif()
+
 set(ASCEND_DRIVER_PATH /usr/local/Ascend/driver)
 set(CMAKE_COMPILER bisheng)
 set(CMAKE_C_COMPILER ${CMAKE_COMPILER})
@@ -69,23 +99,46 @@ set(CMAKE_CPP_COMPILE_OPTIONS -xc++ "SHELL:-include stdint.h"
 include_directories(${ASCEND_HOME_PATH}/include
                     ${ASCEND_DRIVER_PATH}/kernel/inc)
 
-if(EXISTS ${ASCEND_CANN_PACKAGE_PATH}/tools/tikcpp/ascendc_kernel_cmake)
-  set(ASCENDC_CMAKE_DIR
-      ${ASCEND_CANN_PACKAGE_PATH}/tools/tikcpp/ascendc_kernel_cmake)
-elseif(EXISTS ${ASCEND_CANN_PACKAGE_PATH}/compiler/tikcpp/ascendc_kernel_cmake)
-  set(ASCENDC_CMAKE_DIR
-      ${ASCEND_CANN_PACKAGE_PATH}/compiler/tikcpp/ascendc_kernel_cmake)
-elseif(EXISTS ${ASCEND_CANN_PACKAGE_PATH}/ascendc_devkit/tikcpp/samples/cmake)
-  set(ASCENDC_CMAKE_DIR
-      ${ASCEND_CANN_PACKAGE_PATH}/ascendc_devkit/tikcpp/samples/cmake)
-else()
-  message(
-    FATAL_ERROR
-      "ascendc_kernel_cmake does not exist, please check whether the cann package is installed."
-  )
-endif()
+if(USE_ASC_LANGUAGE)
+  # find_package(ASC) provides the ASC language plus ASC-flavoured
+  # ascendc_library / ascendc_compile_definitions / ascendc_include_directories.
+  # enable_language(ASC) only resolves once find_package has put the ASC plugin
+  # on CMAKE_MODULE_PATH.
+  if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(
+      FATAL_ERROR
+        "USE_ASC_LANGUAGE requires ASCEND_HOME_PATH, source <cann>/set_env.sh first."
+    )
+  endif()
+  find_package(ASC REQUIRED)
+  enable_language(ASC)
 
-include(${ASCENDC_CMAKE_DIR}/ascendc.cmake)
+  # CMakeASCInformation.cmake derives CMAKE_ASC_CREATE_SHARED_MODULE from
+  # CMAKE_ASC_CREATE_SHARED_LIBRARY before that one is defined, so it ends up
+  # empty and MODULE targets (the pybind11 extension) fail to generate.
+  if(NOT CMAKE_ASC_CREATE_SHARED_MODULE)
+    set(CMAKE_ASC_CREATE_SHARED_MODULE "${CMAKE_ASC_CREATE_SHARED_LIBRARY}")
+  endif()
+else()
+  if(EXISTS ${ASCEND_CANN_PACKAGE_PATH}/tools/tikcpp/ascendc_kernel_cmake)
+    set(ASCENDC_CMAKE_DIR
+        ${ASCEND_CANN_PACKAGE_PATH}/tools/tikcpp/ascendc_kernel_cmake)
+  elseif(EXISTS
+         ${ASCEND_CANN_PACKAGE_PATH}/compiler/tikcpp/ascendc_kernel_cmake)
+    set(ASCENDC_CMAKE_DIR
+        ${ASCEND_CANN_PACKAGE_PATH}/compiler/tikcpp/ascendc_kernel_cmake)
+  elseif(EXISTS ${ASCEND_CANN_PACKAGE_PATH}/ascendc_devkit/tikcpp/samples/cmake)
+    set(ASCENDC_CMAKE_DIR
+        ${ASCEND_CANN_PACKAGE_PATH}/ascendc_devkit/tikcpp/samples/cmake)
+  else()
+    message(
+      FATAL_ERROR
+        "ascendc_kernel_cmake does not exist, please check whether the cann package is installed."
+    )
+  endif()
+
+  include(${ASCENDC_CMAKE_DIR}/ascendc.cmake)
+endif()
 
 include(FetchContent)
 
@@ -114,6 +167,8 @@ string(REPLACE "path string is NULL" "" TORCH_NPU_PATH "${TORCH_NPU_PATH}")
 
 message("***********************************************************")
 message("* ASCEND_CANN_PACKAGE_PATH : ${ASCEND_CANN_PACKAGE_PATH}")
+message("* USE_ASC_LANGUAGE         : ${USE_ASC_LANGUAGE}")
+message("* SOC_VERSION / NPU_ARCH   : ${SOC_VERSION} / ${NPU_ARCH}")
 message("* TORCH_INSTALL_PREFIX     : ${TORCH_INSTALL_PREFIX}")
 message("* TORCH_NPU_PATH           : ${TORCH_NPU_PATH}")
 message("* TORCH_LIBRARIES          : ${TORCH_LIBRARIES}")
@@ -147,6 +202,18 @@ ascendc_include_directories(
   no_workspace_kernel PRIVATE ${libpto_isa_headers_SOURCE_DIR}/include
   ${libpto_isa_headers_SOURCE_DIR}/include/pto/common)
 
+if(USE_ASC_LANGUAGE)
+  # pto_kernels_ops is linked with RUNPATH $ORIGIN/build/lib, so the kernel
+  # library has to land there whichever toolchain built it.
+  set_target_properties(no_workspace_kernel PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                                                       ${CMAKE_BINARY_DIR}/lib)
+  target_compile_options(
+    no_workspace_kernel
+    PRIVATE $<$<COMPILE_LANGUAGE:ASC>:--npu-arch=${NPU_ARCH}>)
+  target_link_libraries(no_workspace_kernel PRIVATE tiling_api platform
+                                                    ascendalog)
+endif()
+
 if(BASE_MODE STREQUAL "MEMORY")
   message(STATUS "BASE_MODE is MEMORY")
   ascendc_compile_definitions(no_workspace_kernel PRIVATE -DMEMORY_BASE)
@@ -157,6 +224,10 @@ else()
   message(FATAL_ERROR "BASE_MODE must be MEMORY or REGISTER, got: ${BASE_MODE}")
 endif()
 
+# The host wrappers reach the kernels through the pto_launch_* shims declared in
+# csrc/host/kernel_launchers.h, which keep the `<<<>>>` launches inside the
+# kernel translation units. The extension therefore stays plain C++ and builds
+# unchanged under either toolchain.
 pybind11_add_module(pto_kernels_ops csrc/host/pybind11.cpp)
 # pybind11 does not work with C++20, so we set C++17 for the pybind11 module
 # target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,10 +224,6 @@ else()
   message(FATAL_ERROR "BASE_MODE must be MEMORY or REGISTER, got: ${BASE_MODE}")
 endif()
 
-# The host wrappers reach the kernels through the pto_launch_* shims declared in
-# csrc/host/kernel_launchers.h, which keep the `<<<>>>` launches inside the
-# kernel translation units. The extension therefore stays plain C++ and builds
-# unchanged under either toolchain.
 pybind11_add_module(pto_kernels_ops csrc/host/pybind11.cpp)
 # pybind11 does not work with C++20, so we set C++17 for the pybind11 module
 # target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,6 @@ if(USE_ASC_LANGUAGE)
   target_compile_options(
     no_workspace_kernel
     PRIVATE $<$<COMPILE_LANGUAGE:ASC>:--npu-arch=${NPU_ARCH}>)
-  target_link_libraries(no_workspace_kernel PRIVATE tiling_api platform
-                                                    ascendalog)
 endif()
 
 if(BASE_MODE STREQUAL "MEMORY")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,10 @@ option(PIP_INSTALL "True if building via pip" OFF)
 # CANN >= 9.0 and ASCEND_HOME_PATH on the environment. OFF           legacy
 # ascendc.cmake, kept for comparison until the ASC path has had more mileage.
 #
-# Both paths reach the kernels through the pto_launch_* shims (see
-# csrc/host/kernel_launchers.h), so the host code is identical either way and
-# neither path depends on the code-generated aclrtlaunch_<kernel>.h headers that
-# only the legacy toolchain emits.
+# Both paths reach the kernels through the pto_launch_* shims (declared in the
+# csrc/host/torch_*.h header that uses them), so the host code is identical
+# either way and neither path depends on the code-generated
+# aclrtlaunch_<kernel>.h headers that only the legacy toolchain emits.
 option(USE_ASC_LANGUAGE
        "Compile kernels with the ASC language toolchain (CANN >= 9.0)" ON)
 

--- a/csrc/host/torch_abs.h
+++ b/csrc/host/torch_abs.h
@@ -13,6 +13,19 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_vabs_fp16(uint32_t blockDim, void* stream, void* x, void* z,
+                          uint32_t in_length);
+
+void pto_launch_vabs_fp32(uint32_t blockDim, void* stream, void* x, void* z,
+                          uint32_t in_length);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_abs.h
+++ b/csrc/host/torch_abs.h
@@ -11,8 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_vabs_fp16.h"
-#include "aclrtlaunch_vabs_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_abs.h
+++ b/csrc/host/torch_abs.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_vabs_fp16(uint32_t blockDim, void* stream, void* x, void* z,

--- a/csrc/host/torch_batch_matrix_square.h
+++ b/csrc/host/torch_batch_matrix_square.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_batch_matrix_square_fp16(uint32_t blockDim, void* stream,

--- a/csrc/host/torch_batch_matrix_square.h
+++ b/csrc/host/torch_batch_matrix_square.h
@@ -13,6 +13,21 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_batch_matrix_square_fp16(uint32_t blockDim, void* stream,
+                                         void* z, void* x,
+                                         uint32_t matrix_size);
+
+void pto_launch_batch_matrix_square_fp32(uint32_t blockDim, void* stream,
+                                         void* z, void* x,
+                                         uint32_t matrix_size);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_batch_matrix_square.h
+++ b/csrc/host/torch_batch_matrix_square.h
@@ -11,8 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_batch_matrix_square_fp16.h"
-#include "aclrtlaunch_batch_matrix_square_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_csr_gather.h
+++ b/csrc/host/torch_csr_gather.h
@@ -11,8 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_csr_gather_fp16.h"
-#include "aclrtlaunch_csr_gather_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_csr_gather.h
+++ b/csrc/host/torch_csr_gather.h
@@ -13,6 +13,21 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_csr_gather_fp16(uint32_t blockDim, void* stream, void* values,
+                                void* indices, void* x, void* z,
+                                uint32_t x_size, uint32_t indices_size);
+
+void pto_launch_csr_gather_fp32(uint32_t blockDim, void* stream, void* values,
+                                void* indices, void* x, void* z,
+                                uint32_t x_size, uint32_t indices_size);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_csr_gather.h
+++ b/csrc/host/torch_csr_gather.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_csr_gather_fp16(uint32_t blockDim, void* stream, void* values,

--- a/csrc/host/torch_gdn_chunk_cumsum.h
+++ b/csrc/host/torch_gdn_chunk_cumsum.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_gdn_chunk_cumsum_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_gdn_chunk_cumsum.h
+++ b/csrc/host/torch_gdn_chunk_cumsum.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_gdn_chunk_cumsum_fp32(uint32_t blockDim, void* stream,

--- a/csrc/host/torch_gdn_chunk_cumsum.h
+++ b/csrc/host/torch_gdn_chunk_cumsum.h
@@ -13,6 +13,18 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_gdn_chunk_cumsum_fp32(uint32_t blockDim, void* stream,
+                                      void* g_ptr, void* g_sum_ptr,
+                                      void* cu_seqlens, int64_t batch_size,
+                                      int64_t seq_len);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_gdn_chunk_h.h
+++ b/csrc/host/torch_gdn_chunk_h.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_gdn_chunk_h(uint32_t blockDim, void* stream, void* K, void* W,

--- a/csrc/host/torch_gdn_chunk_h.h
+++ b/csrc/host/torch_gdn_chunk_h.h
@@ -13,6 +13,19 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_gdn_chunk_h(uint32_t blockDim, void* stream, void* K, void* W,
+                            void* U, void* G, void* S, void* V, void* FS,
+                            void* workspace, void* cu_seqlens,
+                            int64_t batch_size, int64_t seq_len,
+                            int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_gdn_chunk_h.h
+++ b/csrc/host/torch_gdn_chunk_h.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_gdn_chunk_h.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_gdn_chunk_o.h
+++ b/csrc/host/torch_gdn_chunk_o.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_gdn_chunk_o(uint32_t blockDim, void* stream, void* Q_handle,

--- a/csrc/host/torch_gdn_chunk_o.h
+++ b/csrc/host/torch_gdn_chunk_o.h
@@ -13,6 +13,21 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_gdn_chunk_o(uint32_t blockDim, void* stream, void* Q_handle,
+                            void* K_handle, void* V_handle, void* S_handle,
+                            void* G_handle, void* Msk_handle,
+                            void* workspace_qk, void* workspace_qs_qkv,
+                            void* workspace_qk_gated, void* O_handle,
+                            void* cu_seqlens, int64_t batch_size,
+                            int64_t seq_len, int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_gdn_chunk_o.h
+++ b/csrc/host/torch_gdn_chunk_o.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_gdn_chunk_o.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_gdn_scaled_dot_kkt.h
+++ b/csrc/host/torch_gdn_scaled_dot_kkt.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_gdn_scaled_dot_kkt(uint32_t blockDim, void* stream,

--- a/csrc/host/torch_gdn_scaled_dot_kkt.h
+++ b/csrc/host/torch_gdn_scaled_dot_kkt.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_gdn_scaled_dot_kkt.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_gdn_scaled_dot_kkt.h
+++ b/csrc/host/torch_gdn_scaled_dot_kkt.h
@@ -13,6 +13,20 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_gdn_scaled_dot_kkt(uint32_t blockDim, void* stream,
+                                   void* K_handle, void* Beta_handle,
+                                   void* G_handle, void* Msk_handle,
+                                   void* workspace_handle, void* A_handle,
+                                   void* cu_seqlens, int64_t batch_size,
+                                   int64_t seq_len, int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_gdn_wy_fast.h
+++ b/csrc/host/torch_gdn_wy_fast.h
@@ -13,7 +13,6 @@ for the full License text.
 
 #include <vector>
 
-#include "aclrtlaunch_gdn_wy_fast.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_gdn_wy_fast.h
+++ b/csrc/host/torch_gdn_wy_fast.h
@@ -15,9 +15,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_gdn_wy_fast(uint32_t blockDim, void* stream, void* K_handle,

--- a/csrc/host/torch_gdn_wy_fast.h
+++ b/csrc/host/torch_gdn_wy_fast.h
@@ -15,6 +15,21 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_gdn_wy_fast(uint32_t blockDim, void* stream, void* K_handle,
+                            void* V_handle, void* Beta_handle, void* G_handle,
+                            void* A_handle, void* workspace_a1_handle,
+                            void* workspace_a2_handle, void* W_handle,
+                            void* U_handle, void* cu_seqlens,
+                            int64_t batch_size, int64_t seq_len,
+                            int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_kda_chunk_h.h
+++ b/csrc/host/torch_kda_chunk_h.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_kda_chunk_h.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_kda_chunk_h.h
+++ b/csrc/host/torch_kda_chunk_h.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_kda_chunk_h(uint32_t blockDim, void* stream, void* K, void* W,

--- a/csrc/host/torch_kda_chunk_h.h
+++ b/csrc/host/torch_kda_chunk_h.h
@@ -13,6 +13,19 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_kda_chunk_h(uint32_t blockDim, void* stream, void* K, void* W,
+                            void* U, void* G, void* S, void* V_corr,
+                            void* workspace, void* cu_seqlens,
+                            int64_t batch_size, int64_t seq_len,
+                            int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_kda_chunk_o.h
+++ b/csrc/host/torch_kda_chunk_o.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_kda_chunk_o(uint32_t blockDim, void* stream, void* Q, void* K,

--- a/csrc/host/torch_kda_chunk_o.h
+++ b/csrc/host/torch_kda_chunk_o.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_kda_chunk_o.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_kda_chunk_o.h
+++ b/csrc/host/torch_kda_chunk_o.h
@@ -13,6 +13,19 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_kda_chunk_o(uint32_t blockDim, void* stream, void* Q, void* K,
+                            void* V_corr, void* S, void* G, void* Mask,
+                            void* workspace, void* O, void* cu_seqlens,
+                            int64_t batch_size, int64_t seq_len,
+                            int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_kda_gate_cumsum.h
+++ b/csrc/host/torch_kda_gate_cumsum.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_kda_gate_cumsum.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_kda_gate_cumsum.h
+++ b/csrc/host/torch_kda_gate_cumsum.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_kda_gate_cumsum(uint32_t blockDim, void* stream, void* g_ptr,

--- a/csrc/host/torch_kda_gate_cumsum.h
+++ b/csrc/host/torch_kda_gate_cumsum.h
@@ -13,6 +13,17 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_kda_gate_cumsum(uint32_t blockDim, void* stream, void* g_ptr,
+                                void* g_sum_ptr, void* cu_seqlens,
+                                int64_t batch_size, int64_t seq_len);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_kda_kkt.h
+++ b/csrc/host/torch_kda_kkt.h
@@ -13,6 +13,18 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_kda_kkt(uint32_t blockDim, void* stream, void* k_ptr,
+                        void* g_cs_ptr, void* beta_ptr, void* mask_ptr,
+                        void* L_out_ptr, void* cu_seqlens, int64_t batch_size,
+                        int64_t seq_len, int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_kda_kkt.h
+++ b/csrc/host/torch_kda_kkt.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_kda_kkt(uint32_t blockDim, void* stream, void* k_ptr,

--- a/csrc/host/torch_kda_kkt.h
+++ b/csrc/host/torch_kda_kkt.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_kda_kkt.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_kda_wy.h
+++ b/csrc/host/torch_kda_wy.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_kda_wy(uint32_t blockDim, void* stream, void* K_handle,

--- a/csrc/host/torch_kda_wy.h
+++ b/csrc/host/torch_kda_wy.h
@@ -13,6 +13,20 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_kda_wy(uint32_t blockDim, void* stream, void* K_handle,
+                       void* V_handle, void* Beta_handle, void* G_handle,
+                       void* A_handle, void* workspace_a2_handle,
+                       void* workspace_keff_handle, void* U_handle,
+                       void* W_handle, void* cu_seqlens, int64_t batch_size,
+                       int64_t seq_len, int64_t total_tokens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_kda_wy.h
+++ b/csrc/host/torch_kda_wy.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_kda_wy.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -11,8 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_scan_ul1_fp16.h"
-#include "aclrtlaunch_scan_ul1_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -13,6 +13,19 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_scan_ul1_fp16(uint32_t blockDim, void* stream, void* x, void* o,
+                              void* u, void* l, void* s, uint32_t matrix_size);
+
+void pto_launch_scan_ul1_fp32(uint32_t blockDim, void* stream, void* x, void* o,
+                              void* u, void* l, void* s, uint32_t matrix_size);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_scan_ul1.h
+++ b/csrc/host/torch_scan_ul1.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_scan_ul1_fp16(uint32_t blockDim, void* stream, void* x, void* o,

--- a/csrc/host/torch_simple_matmul.h
+++ b/csrc/host/torch_simple_matmul.h
@@ -11,9 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_simple_matmul_bf16.h"
-#include "aclrtlaunch_simple_matmul_fp16.h"
-#include "aclrtlaunch_simple_matmul_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_simple_matmul.h
+++ b/csrc/host/torch_simple_matmul.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_simple_matmul_bf16(uint32_t blockDim, void* stream, void* a,

--- a/csrc/host/torch_simple_matmul.h
+++ b/csrc/host/torch_simple_matmul.h
@@ -13,6 +13,22 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_simple_matmul_bf16(uint32_t blockDim, void* stream, void* a,
+                                   void* b, void* c, uint32_t matrix_size);
+
+void pto_launch_simple_matmul_fp16(uint32_t blockDim, void* stream, void* a,
+                                   void* b, void* c, uint32_t matrix_size);
+
+void pto_launch_simple_matmul_fp32(uint32_t blockDim, void* stream, void* a,
+                                   void* b, void* c, uint32_t matrix_size);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_swiglu.h
+++ b/csrc/host/torch_swiglu.h
@@ -15,6 +15,16 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_swiglu_fp16(uint32_t blockDim, void* stream, void* x, void* y,
+                            uint32_t batch, uint32_t input_n);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_swiglu.h
+++ b/csrc/host/torch_swiglu.h
@@ -15,15 +15,9 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
-extern "C" {
-
-void pto_launch_swiglu_fp16(uint32_t blockDim, void* stream, void* x, void* y,
-                            uint32_t batch, uint32_t input_n);
-
-}  // extern "C"
+extern "C" void pto_launch_swiglu_fp16(uint32_t blockDim, void* stream, void* x,
+                                       void* y, uint32_t batch,
+                                       uint32_t input_n);
 
 namespace pto_isa_ops {
 

--- a/csrc/host/torch_swiglu.h
+++ b/csrc/host/torch_swiglu.h
@@ -13,7 +13,6 @@ for the full License text.
 
 #include <limits>
 
-#include "aclrtlaunch_swiglu_fp16.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_tri_inv.h
+++ b/csrc/host/torch_tri_inv.h
@@ -11,8 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_triv_inv_col_sweep_fp16.h"
-#include "aclrtlaunch_triv_inv_col_sweep_fp32.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_tri_inv.h
+++ b/csrc/host/torch_tri_inv.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_triv_inv_col_sweep_fp16(uint32_t blockDim, void* stream,

--- a/csrc/host/torch_tri_inv.h
+++ b/csrc/host/torch_tri_inv.h
@@ -13,6 +13,21 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_triv_inv_col_sweep_fp16(uint32_t blockDim, void* stream,
+                                        void* x, void* z, uint32_t in_length,
+                                        uint32_t matrix_size);
+
+void pto_launch_triv_inv_col_sweep_fp32(uint32_t blockDim, void* stream,
+                                        void* x, void* z, uint32_t in_length,
+                                        uint32_t matrix_size);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_tri_inv_ns.h
+++ b/csrc/host/torch_tri_inv_ns.h
@@ -15,6 +15,19 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_tri_inv_ns_fp16(uint32_t blockDim, void* stream,
+                                void* tensor_out, void* tensor_in,
+                                void* identity_neg_in, void* identity_over_n_in,
+                                uint32_t matrix_size, uint32_t num_iters,
+                                uint32_t num_matrices);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_tri_inv_ns.h
+++ b/csrc/host/torch_tri_inv_ns.h
@@ -15,18 +15,10 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
-extern "C" {
-
-void pto_launch_tri_inv_ns_fp16(uint32_t blockDim, void* stream,
-                                void* tensor_out, void* tensor_in,
-                                void* identity_neg_in, void* identity_over_n_in,
-                                uint32_t matrix_size, uint32_t num_iters,
-                                uint32_t num_matrices);
-
-}  // extern "C"
+extern "C" void pto_launch_tri_inv_ns_fp16(
+    uint32_t blockDim, void* stream, void* tensor_out, void* tensor_in,
+    void* identity_neg_in, void* identity_over_n_in, uint32_t matrix_size,
+    uint32_t num_iters, uint32_t num_matrices);
 
 namespace pto_isa_ops {
 

--- a/csrc/host/torch_tri_inv_ns.h
+++ b/csrc/host/torch_tri_inv_ns.h
@@ -13,7 +13,6 @@ for the full License text.
 
 #include <cmath>
 
-#include "aclrtlaunch_tri_inv_ns_fp16.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_tri_inv_rec_unroll.h
+++ b/csrc/host/torch_tri_inv_rec_unroll.h
@@ -11,8 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_tri_inv_rec_unroll_bf16.h"
-#include "aclrtlaunch_tri_inv_rec_unroll_fp16.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_tri_inv_rec_unroll.h
+++ b/csrc/host/torch_tri_inv_rec_unroll.h
@@ -13,9 +13,6 @@ for the full License text.
 
 #include "utils.h"
 
-// Declarations of the launch shims defined alongside the kernel in
-// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
 extern "C" {
 
 void pto_launch_tri_inv_rec_unroll_bf16(

--- a/csrc/host/torch_tri_inv_rec_unroll.h
+++ b/csrc/host/torch_tri_inv_rec_unroll.h
@@ -13,6 +13,23 @@ for the full License text.
 
 #include "utils.h"
 
+// Declarations of the launch shims defined alongside the kernel in
+// csrc/kernel/. They wrap the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_tri_inv_rec_unroll_bf16(
+    uint32_t blockDim, void* stream, void* tensor_out, void* tensor_in,
+    void* minus_eye_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, uint32_t is_lower, void* cu_seqlens);
+
+void pto_launch_tri_inv_rec_unroll_fp16(
+    uint32_t blockDim, void* stream, void* tensor_out, void* tensor_in,
+    void* minus_eye_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, uint32_t is_lower, void* cu_seqlens);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_tri_inv_trick.h
+++ b/csrc/host/torch_tri_inv_trick.h
@@ -13,6 +13,18 @@ for the full License text.
 
 #include "utils.h"
 
+// Declaration of the launch shim defined alongside the kernel in
+// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
+// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
+extern "C" {
+
+void pto_launch_tri_inv_trick_fp16(uint32_t blockDim, void* stream,
+                                   void* tensor_out, void* tensor_in,
+                                   void* identity_in, uint32_t matrix_size,
+                                   uint32_t max_block_size);
+
+}  // extern "C"
+
 namespace pto_isa_ops {
 
 /**

--- a/csrc/host/torch_tri_inv_trick.h
+++ b/csrc/host/torch_tri_inv_trick.h
@@ -11,7 +11,6 @@ for the full License text.
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
-#include "aclrtlaunch_tri_inv_trick_fp16.h"
 #include "utils.h"
 
 namespace pto_isa_ops {

--- a/csrc/host/torch_tri_inv_trick.h
+++ b/csrc/host/torch_tri_inv_trick.h
@@ -13,17 +13,11 @@ for the full License text.
 
 #include "utils.h"
 
-// Declaration of the launch shim defined alongside the kernel in
-// csrc/kernel/. It wraps the `<<<>>>` launch so that this host code can stay
-// plain C++ and build under either kernel toolchain (see USE_ASC_LANGUAGE).
-extern "C" {
-
-void pto_launch_tri_inv_trick_fp16(uint32_t blockDim, void* stream,
-                                   void* tensor_out, void* tensor_in,
-                                   void* identity_in, uint32_t matrix_size,
-                                   uint32_t max_block_size);
-
-}  // extern "C"
+extern "C" void pto_launch_tri_inv_trick_fp16(uint32_t blockDim, void* stream,
+                                              void* tensor_out, void* tensor_in,
+                                              void* identity_in,
+                                              uint32_t matrix_size,
+                                              uint32_t max_block_size);
 
 namespace pto_isa_ops {
 

--- a/csrc/host/utils.h
+++ b/csrc/host/utils.h
@@ -15,6 +15,7 @@ full text of the License.
 #include <acl/acl.h>
 #include <torch/library.h>
 
+#include "kernel_launchers.h"
 #include "torch_npu/csrc/core/npu/NPUStream.h"
 #include "torch_npu/csrc/framework/OpCommand.h"
 
@@ -132,18 +133,18 @@ constexpr auto ConvertTypes(Ts&... args) {
   return std::make_tuple(ConvertType(args)...);
 }
 
-#define EXEC_KERNEL_CMD(kernel_name, blockdim, ...)                            \
-  do {                                                                         \
-    auto acl_stream = c10_npu::getCurrentNPUStream().stream(false);            \
-    auto converted_params = pto_isa_ops::ConvertTypes(__VA_ARGS__);            \
-    auto acl_call = [acl_stream, blockdim, converted_params]() -> int {        \
-      std::apply(                                                              \
-          [&](auto&&... params) {                                              \
-            ACLRT_LAUNCH_KERNEL(kernel_name)(blockdim, acl_stream, params...); \
-          },                                                                   \
-          converted_params);                                                   \
-      return 0;                                                                \
-    };                                                                         \
-    at_npu::native::OpCommand::RunOpApi(#kernel_name, acl_call);               \
+#define EXEC_KERNEL_CMD(kernel_name, blockdim, ...)                     \
+  do {                                                                  \
+    auto acl_stream = c10_npu::getCurrentNPUStream().stream(false);     \
+    auto converted_params = pto_isa_ops::ConvertTypes(__VA_ARGS__);     \
+    auto acl_call = [acl_stream, blockdim, converted_params]() -> int { \
+      std::apply(                                                       \
+          [&](auto&&... params) {                                       \
+            pto_launch_##kernel_name(blockdim, acl_stream, params...);  \
+          },                                                            \
+          converted_params);                                            \
+      return 0;                                                         \
+    };                                                                  \
+    at_npu::native::OpCommand::RunOpApi(#kernel_name, acl_call);        \
   } while (false)
 }  // namespace pto_isa_ops

--- a/csrc/host/utils.h
+++ b/csrc/host/utils.h
@@ -15,7 +15,8 @@ full text of the License.
 #include <acl/acl.h>
 #include <torch/library.h>
 
-#include "kernel_launchers.h"
+#include <cstdint>
+
 #include "torch_npu/csrc/core/npu/NPUStream.h"
 #include "torch_npu/csrc/framework/OpCommand.h"
 

--- a/csrc/kernel/kernel_abs.cpp
+++ b/csrc/kernel/kernel_abs.cpp
@@ -134,3 +134,16 @@ extern "C" void call_vabs_fp16(uint32_t blockDim, void* stream, uint8_t* x,
                                uint8_t* y, uint32_t in_length) {
   vabs_fp16<<<blockDim * 2, nullptr, stream>>>(x, y, in_length);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_vabs_fp16(uint32_t blockDim, void* stream, void* x,
+                                     void* z, uint32_t in_length) {
+  vabs_fp16<<<blockDim, nullptr, stream>>>((GM_ADDR)x, (GM_ADDR)z, in_length);
+}
+
+extern "C" void pto_launch_vabs_fp32(uint32_t blockDim, void* stream, void* x,
+                                     void* z, uint32_t in_length) {
+  vabs_fp32<<<blockDim, nullptr, stream>>>((GM_ADDR)x, (GM_ADDR)z, in_length);
+}

--- a/csrc/kernel/kernel_batch_matrix_square.cpp
+++ b/csrc/kernel/kernel_batch_matrix_square.cpp
@@ -124,3 +124,22 @@ extern "C" __global__ AICORE void batch_matrix_square_fp32(
   (void)matrix_size;
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_batch_matrix_square_fp16(uint32_t blockDim,
+                                                    void* stream, void* z,
+                                                    void* x,
+                                                    uint32_t matrix_size) {
+  batch_matrix_square_fp16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)z, (__gm__ void*)x, matrix_size);
+}
+
+extern "C" void pto_launch_batch_matrix_square_fp32(uint32_t blockDim,
+                                                    void* stream, void* z,
+                                                    void* x,
+                                                    uint32_t matrix_size) {
+  batch_matrix_square_fp32<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)z, (__gm__ void*)x, matrix_size);
+}

--- a/csrc/kernel/kernel_csr_gather.cpp
+++ b/csrc/kernel/kernel_csr_gather.cpp
@@ -232,3 +232,24 @@ extern "C" __global__ AICORE void csr_gather_fp32(GM_ADDR values,
       (__gm__ float*)z, x_size, indices_size);
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_csr_gather_fp16(uint32_t blockDim, void* stream,
+                                           void* values, void* indices, void* x,
+                                           void* z, uint32_t x_size,
+                                           uint32_t indices_size) {
+  csr_gather_fp16<<<blockDim, nullptr, stream>>>(
+      (GM_ADDR)values, (GM_ADDR)indices, (GM_ADDR)x, (GM_ADDR)z, x_size,
+      indices_size);
+}
+
+extern "C" void pto_launch_csr_gather_fp32(uint32_t blockDim, void* stream,
+                                           void* values, void* indices, void* x,
+                                           void* z, uint32_t x_size,
+                                           uint32_t indices_size) {
+  csr_gather_fp32<<<blockDim, nullptr, stream>>>(
+      (GM_ADDR)values, (GM_ADDR)indices, (GM_ADDR)x, (GM_ADDR)z, x_size,
+      indices_size);
+}

--- a/csrc/kernel/kernel_gdn_chunk_cumsum.cpp
+++ b/csrc/kernel/kernel_gdn_chunk_cumsum.cpp
@@ -503,3 +503,14 @@ extern "C" __global__ AICORE void gdn_chunk_cumsum_fp32(
   }
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_gdn_chunk_cumsum_fp32(
+    uint32_t blockDim, void* stream, void* g_ptr, void* g_sum_ptr,
+    void* cu_seqlens, int64_t batch_size, int64_t seq_len) {
+  gdn_chunk_cumsum_fp32<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)g_ptr, (__gm__ uint8_t*)g_sum_ptr,
+      (__gm__ uint8_t*)cu_seqlens, batch_size, seq_len);
+}

--- a/csrc/kernel/kernel_gdn_chunk_h.cpp
+++ b/csrc/kernel/kernel_gdn_chunk_h.cpp
@@ -900,3 +900,18 @@ extern "C" __global__ AICORE void gdn_chunk_h(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_gdn_chunk_h(uint32_t blockDim, void* stream, void* K,
+                                       void* W, void* U, void* G, void* S,
+                                       void* V, void* FS, void* workspace,
+                                       void* cu_seqlens, int64_t batch_size,
+                                       int64_t seq_len, int64_t total_tokens) {
+  gdn_chunk_h<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)K, (__gm__ uint8_t*)W, (__gm__ uint8_t*)U,
+      (__gm__ uint8_t*)G, (__gm__ uint8_t*)S, (__gm__ uint8_t*)V,
+      (__gm__ uint8_t*)FS, (__gm__ uint8_t*)workspace,
+      (__gm__ uint8_t*)cu_seqlens, batch_size, seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_gdn_chunk_o.cpp
+++ b/csrc/kernel/kernel_gdn_chunk_o.cpp
@@ -1168,3 +1168,21 @@ extern "C" __global__ AICORE void gdn_chunk_o(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_gdn_chunk_o(
+    uint32_t blockDim, void* stream, void* Q_handle, void* K_handle,
+    void* V_handle, void* S_handle, void* G_handle, void* Msk_handle,
+    void* workspace_qk, void* workspace_qs_qkv, void* workspace_qk_gated,
+    void* O_handle, void* cu_seqlens, int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens) {
+  gdn_chunk_o<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)Q_handle, (__gm__ uint8_t*)K_handle,
+      (__gm__ uint8_t*)V_handle, (__gm__ uint8_t*)S_handle,
+      (__gm__ uint8_t*)G_handle, (__gm__ uint8_t*)Msk_handle,
+      (__gm__ uint8_t*)workspace_qk, (__gm__ uint8_t*)workspace_qs_qkv,
+      (__gm__ uint8_t*)workspace_qk_gated, (__gm__ uint8_t*)O_handle,
+      (__gm__ uint8_t*)cu_seqlens, batch_size, seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_gdn_scaled_dot_kkt.cpp
+++ b/csrc/kernel/kernel_gdn_scaled_dot_kkt.cpp
@@ -465,3 +465,18 @@ extern "C" __global__ AICORE void gdn_scaled_dot_kkt(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_gdn_scaled_dot_kkt(
+    uint32_t blockDim, void* stream, void* K_handle, void* Beta_handle,
+    void* G_handle, void* Msk_handle, void* workspace_handle, void* A_handle,
+    void* cu_seqlens, int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens) {
+  gdn_scaled_dot_kkt<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)K_handle, (__gm__ uint8_t*)Beta_handle,
+      (__gm__ uint8_t*)G_handle, (__gm__ uint8_t*)Msk_handle,
+      (__gm__ uint8_t*)workspace_handle, (__gm__ uint8_t*)A_handle,
+      (__gm__ uint8_t*)cu_seqlens, batch_size, seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_gdn_wy_fast.cpp
+++ b/csrc/kernel/kernel_gdn_wy_fast.cpp
@@ -882,3 +882,21 @@ extern "C" __global__ AICORE void gdn_wy_fast(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_gdn_wy_fast(
+    uint32_t blockDim, void* stream, void* K_handle, void* V_handle,
+    void* Beta_handle, void* G_handle, void* A_handle,
+    void* workspace_a1_handle, void* workspace_a2_handle, void* W_handle,
+    void* U_handle, void* cu_seqlens, int64_t batch_size, int64_t seq_len,
+    int64_t total_tokens) {
+  gdn_wy_fast<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)K_handle, (__gm__ uint8_t*)V_handle,
+      (__gm__ uint8_t*)Beta_handle, (__gm__ uint8_t*)G_handle,
+      (__gm__ uint8_t*)A_handle, (__gm__ uint8_t*)workspace_a1_handle,
+      (__gm__ uint8_t*)workspace_a2_handle, (__gm__ uint8_t*)W_handle,
+      (__gm__ uint8_t*)U_handle, (__gm__ uint8_t*)cu_seqlens, batch_size,
+      seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_kda_chunk_h.cpp
+++ b/csrc/kernel/kernel_kda_chunk_h.cpp
@@ -756,3 +756,18 @@ extern "C" __global__ AICORE void kda_chunk_h(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_kda_chunk_h(uint32_t blockDim, void* stream, void* K,
+                                       void* W, void* U, void* G, void* S,
+                                       void* V_corr, void* workspace,
+                                       void* cu_seqlens, int64_t batch_size,
+                                       int64_t seq_len, int64_t total_tokens) {
+  kda_chunk_h<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)K, (__gm__ uint8_t*)W, (__gm__ uint8_t*)U,
+      (__gm__ uint8_t*)G, (__gm__ uint8_t*)S, (__gm__ uint8_t*)V_corr,
+      (__gm__ uint8_t*)workspace, (__gm__ uint8_t*)cu_seqlens, batch_size,
+      seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_kda_chunk_o.cpp
+++ b/csrc/kernel/kernel_kda_chunk_o.cpp
@@ -729,3 +729,18 @@ extern "C" __global__ AICORE void kda_chunk_o(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_kda_chunk_o(uint32_t blockDim, void* stream, void* Q,
+                                       void* K, void* V_corr, void* S, void* G,
+                                       void* Mask, void* workspace, void* O,
+                                       void* cu_seqlens, int64_t batch_size,
+                                       int64_t seq_len, int64_t total_tokens) {
+  kda_chunk_o<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)Q, (__gm__ uint8_t*)K, (__gm__ uint8_t*)V_corr,
+      (__gm__ uint8_t*)S, (__gm__ uint8_t*)G, (__gm__ uint8_t*)Mask,
+      (__gm__ uint8_t*)workspace, (__gm__ uint8_t*)O,
+      (__gm__ uint8_t*)cu_seqlens, batch_size, seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_kda_gate_cumsum.cpp
+++ b/csrc/kernel/kernel_kda_gate_cumsum.cpp
@@ -319,3 +319,15 @@ extern "C" __global__ AICORE void kda_gate_cumsum(__gm__ uint8_t* g_ptr,
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len);
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_kda_gate_cumsum(uint32_t blockDim, void* stream,
+                                           void* g_ptr, void* g_sum_ptr,
+                                           void* cu_seqlens, int64_t batch_size,
+                                           int64_t seq_len) {
+  kda_gate_cumsum<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)g_ptr, (__gm__ uint8_t*)g_sum_ptr,
+      (__gm__ uint8_t*)cu_seqlens, batch_size, seq_len);
+}

--- a/csrc/kernel/kernel_kda_kkt.cpp
+++ b/csrc/kernel/kernel_kda_kkt.cpp
@@ -378,3 +378,18 @@ extern "C" __global__ AICORE void kda_kkt(
       total_tokens);
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_kda_kkt(uint32_t blockDim, void* stream, void* k_ptr,
+                                   void* g_cs_ptr, void* beta_ptr,
+                                   void* mask_ptr, void* L_out_ptr,
+                                   void* cu_seqlens, int64_t batch_size,
+                                   int64_t seq_len, int64_t total_tokens) {
+  kda_kkt<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)k_ptr, (__gm__ uint8_t*)g_cs_ptr,
+      (__gm__ uint8_t*)beta_ptr, (__gm__ uint8_t*)mask_ptr,
+      (__gm__ uint8_t*)L_out_ptr, (__gm__ uint8_t*)cu_seqlens, batch_size,
+      seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_kda_wy.cpp
+++ b/csrc/kernel/kernel_kda_wy.cpp
@@ -988,3 +988,23 @@ extern "C" __global__ AICORE void kda_wy(
       reinterpret_cast<__gm__ int32_t*>(cu_seqlens), batch_size, seq_len,
       total_tokens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_kda_wy(uint32_t blockDim, void* stream,
+                                  void* K_handle, void* V_handle,
+                                  void* Beta_handle, void* G_handle,
+                                  void* A_handle, void* workspace_a2_handle,
+                                  void* workspace_keff_handle, void* U_handle,
+                                  void* W_handle, void* cu_seqlens,
+                                  int64_t batch_size, int64_t seq_len,
+                                  int64_t total_tokens) {
+  kda_wy<<<blockDim, nullptr, stream>>>(
+      (__gm__ uint8_t*)K_handle, (__gm__ uint8_t*)V_handle,
+      (__gm__ uint8_t*)Beta_handle, (__gm__ uint8_t*)G_handle,
+      (__gm__ uint8_t*)A_handle, (__gm__ uint8_t*)workspace_a2_handle,
+      (__gm__ uint8_t*)workspace_keff_handle, (__gm__ uint8_t*)U_handle,
+      (__gm__ uint8_t*)W_handle, (__gm__ uint8_t*)cu_seqlens, batch_size,
+      seq_len, total_tokens);
+}

--- a/csrc/kernel/kernel_scan_ul1.cpp
+++ b/csrc/kernel/kernel_scan_ul1.cpp
@@ -231,3 +231,22 @@ extern "C" __global__ AICORE void scan_ul1_fp32(__gm__ void* x, __gm__ void* o,
   run_scan_ul1((__gm__ float*)x, (__gm__ float*)o, (__gm__ float*)u,
                (__gm__ float*)l, (__gm__ float*)s, matrix_size);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_scan_ul1_fp16(uint32_t blockDim, void* stream,
+                                         void* x, void* o, void* u, void* l,
+                                         void* s, uint32_t matrix_size) {
+  scan_ul1_fp16<<<blockDim, nullptr, stream>>>((__gm__ void*)x, (__gm__ void*)o,
+                                               (__gm__ void*)u, (__gm__ void*)l,
+                                               (__gm__ void*)s, matrix_size);
+}
+
+extern "C" void pto_launch_scan_ul1_fp32(uint32_t blockDim, void* stream,
+                                         void* x, void* o, void* u, void* l,
+                                         void* s, uint32_t matrix_size) {
+  scan_ul1_fp32<<<blockDim, nullptr, stream>>>((__gm__ void*)x, (__gm__ void*)o,
+                                               (__gm__ void*)u, (__gm__ void*)l,
+                                               (__gm__ void*)s, matrix_size);
+}

--- a/csrc/kernel/kernel_simple_matmul.cpp
+++ b/csrc/kernel/kernel_simple_matmul.cpp
@@ -154,3 +154,27 @@ extern "C" __global__ AICORE void simple_matmul_fp32(__gm__ void* a,
                            matrix_size);
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_simple_matmul_bf16(uint32_t blockDim, void* stream,
+                                              void* a, void* b, void* c,
+                                              uint32_t matrix_size) {
+  simple_matmul_bf16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)a, (__gm__ void*)b, (__gm__ void*)c, matrix_size);
+}
+
+extern "C" void pto_launch_simple_matmul_fp16(uint32_t blockDim, void* stream,
+                                              void* a, void* b, void* c,
+                                              uint32_t matrix_size) {
+  simple_matmul_fp16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)a, (__gm__ void*)b, (__gm__ void*)c, matrix_size);
+}
+
+extern "C" void pto_launch_simple_matmul_fp32(uint32_t blockDim, void* stream,
+                                              void* a, void* b, void* c,
+                                              uint32_t matrix_size) {
+  simple_matmul_fp32<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)a, (__gm__ void*)b, (__gm__ void*)c, matrix_size);
+}

--- a/csrc/kernel/kernel_swiglu.cpp
+++ b/csrc/kernel/kernel_swiglu.cpp
@@ -415,3 +415,13 @@ extern "C" void call_swiglu_kernel(uint32_t blockDim, void* stream, uint8_t* x,
                                    uint32_t input_n) {
   swiglu_fp16<<<blockDim * 2, nullptr, stream>>>(x, y, batch, input_n);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_swiglu_fp16(uint32_t blockDim, void* stream, void* x,
+                                       void* y, uint32_t batch,
+                                       uint32_t input_n) {
+  swiglu_fp16<<<blockDim, nullptr, stream>>>((GM_ADDR)x, (GM_ADDR)y, batch,
+                                             input_n);
+}

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -173,3 +173,22 @@ extern "C" __global__ AICORE void triv_inv_col_sweep_fp32(
   }
 #endif
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_triv_inv_col_sweep_fp16(uint32_t blockDim,
+                                                   void* stream, void* x,
+                                                   void* z, uint32_t in_length,
+                                                   uint32_t matrix_size) {
+  triv_inv_col_sweep_fp16<<<blockDim, nullptr, stream>>>(
+      (GM_ADDR)x, (GM_ADDR)z, in_length, matrix_size);
+}
+
+extern "C" void pto_launch_triv_inv_col_sweep_fp32(uint32_t blockDim,
+                                                   void* stream, void* x,
+                                                   void* z, uint32_t in_length,
+                                                   uint32_t matrix_size) {
+  triv_inv_col_sweep_fp32<<<blockDim, nullptr, stream>>>(
+      (GM_ADDR)x, (GM_ADDR)z, in_length, matrix_size);
+}

--- a/csrc/kernel/kernel_tri_inv_ns.cpp
+++ b/csrc/kernel/kernel_tri_inv_ns.cpp
@@ -407,3 +407,16 @@ extern "C" __global__ AICORE void tri_inv_ns_fp16(
                             num_iters, num_matrices);
   }
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_tri_inv_ns_fp16(
+    uint32_t blockDim, void* stream, void* tensor_out, void* tensor_in,
+    void* identity_neg_in, void* identity_over_n_in, uint32_t matrix_size,
+    uint32_t num_iters, uint32_t num_matrices) {
+  tri_inv_ns_fp16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)tensor_out, (__gm__ void*)tensor_in,
+      (__gm__ void*)identity_neg_in, (__gm__ void*)identity_over_n_in,
+      matrix_size, num_iters, num_matrices);
+}

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -843,3 +843,26 @@ extern "C" __global__ AICORE void tri_inv_rec_unroll_fp16(
       _tensor_out, _tensor_in, _minus_eye_in, matrix_size, num_matrices,
       num_bsnd_heads, is_lower, _cu_seqlens);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_tri_inv_rec_unroll_bf16(
+    uint32_t blockDim, void* stream, void* tensor_out, void* tensor_in,
+    void* minus_eye_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, uint32_t is_lower, void* cu_seqlens) {
+  tri_inv_rec_unroll_bf16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)tensor_out, (__gm__ void*)tensor_in,
+      (__gm__ void*)minus_eye_in, matrix_size, num_matrices, num_bsnd_heads,
+      is_lower, (__gm__ void*)cu_seqlens);
+}
+
+extern "C" void pto_launch_tri_inv_rec_unroll_fp16(
+    uint32_t blockDim, void* stream, void* tensor_out, void* tensor_in,
+    void* minus_eye_in, uint32_t matrix_size, uint32_t num_matrices,
+    uint32_t num_bsnd_heads, uint32_t is_lower, void* cu_seqlens) {
+  tri_inv_rec_unroll_fp16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)tensor_out, (__gm__ void*)tensor_in,
+      (__gm__ void*)minus_eye_in, matrix_size, num_matrices, num_bsnd_heads,
+      is_lower, (__gm__ void*)cu_seqlens);
+}

--- a/csrc/kernel/kernel_tri_inv_trick.cpp
+++ b/csrc/kernel/kernel_tri_inv_trick.cpp
@@ -210,3 +210,16 @@ extern "C" __global__ AICORE void tri_inv_trick_fp16(__gm__ void* tensor_out,
                           (__gm__ half*)identity_in, matrix_size,
                           max_block_size);
 }
+
+// Host-callable launch shims: the `<<<>>>` syntax is only
+// understood by the kernel compiler, so the launch lives here
+// rather than in the host wrappers under csrc/host/.
+extern "C" void pto_launch_tri_inv_trick_fp16(uint32_t blockDim, void* stream,
+                                              void* tensor_out, void* tensor_in,
+                                              void* identity_in,
+                                              uint32_t matrix_size,
+                                              uint32_t max_block_size) {
+  tri_inv_trick_fp16<<<blockDim, nullptr, stream>>>(
+      (__gm__ void*)tensor_out, (__gm__ void*)tensor_in,
+      (__gm__ void*)identity_in, matrix_size, max_block_size);
+}


### PR DESCRIPTION
This MR updates the Ascend CMake infrastructure to the new `9.0.0` version where `ASC` language feature is enabled.

In short, this remove the `aclrtXXX` obsolete calls with `kernel<<<block_dim,...,stream>` kernel invocation.

Tests pass on 910B4 and 910B2: `make wheel install test`