### PR TITLE
Use util for pipebarrier vec

### DIFF
--- a/csrc/kernel/kernel_csr_gather.cpp
+++ b/csrc/kernel/kernel_csr_gather.cpp
@@ -10,6 +10,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 constexpr uint32_t UB_USABLE_BYTES = 192 * 1024;
 constexpr uint32_t UB_ZERO_ADDR = 0;
@@ -147,7 +148,7 @@ AICORE void runTCsrGather(__gm__ T* values, __gm__ int32_t* indices,
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID7);
 
     // Wait for mul to be done (previous iteration's computation)
-    pipe_barrier(PIPE_V);
+    PipeBarrierVec();
 
     // Gather
     TGATHER(wTiles, xTiles, idxTiles, tmpTiles);
@@ -170,7 +171,7 @@ AICORE void runTCsrGather(__gm__ T* values, __gm__ int32_t* indices,
     wait_flag(PIPE_MTE3, PIPE_V, ev0);
 
     // Wait for gather to be done
-    pipe_barrier(PIPE_V);
+    PipeBarrierVec();
 
     // Mul
     TMUL(zTiles, valTiles, wTiles);

--- a/csrc/kernel/kernel_gdn_chunk_cumsum.cpp
+++ b/csrc/kernel/kernel_gdn_chunk_cumsum.cpp
@@ -61,6 +61,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 // GDN_H, GDN_C: Compile-time constants injected by the build system.
 //   GDN_H = number of attention heads (e.g., 16)
@@ -212,34 +213,34 @@ AICORE void cumsum_kernel_varlen(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
         UbND<float, 1, HTC> g_row_0;
         TASSIGN(g_row_0, GUbAddr);
         TMOV(acc_ub, g_row_0);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         UbND<float, 1, HTC> s_row_0;
         TASSIGN(s_row_0, SUbAddr);
         TMOV(s_row_0, acc_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         // acc += g[i]; g_sum[i] = acc
         for (int32_t i = 1; i < valid; ++i) {
           UbND<float, 1, HTC> g_row_i;
           TASSIGN(g_row_i, GUbAddr + i * RowBytes);
           TADD(acc_ub, acc_ub, g_row_i);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
 
           UbND<float, 1, HTC> s_row_i;
           TASSIGN(s_row_i, SUbAddr + i * RowBytes);
           TMOV(s_row_i, acc_ub);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         // Zero-fill padding rows
         TEXPANDS(acc_ub, 0.0f);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         for (int32_t i = valid; i < ChunkSize; ++i) {
           UbND<float, 1, HTC> s_row_i;
           TASSIGN(s_row_i, SUbAddr + i * RowBytes);
           TMOV(s_row_i, acc_ub);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         // Store g_sum to GM
@@ -414,12 +415,12 @@ AICORE void cumsum_kernel_static(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
     // are pipelined and may not finish in order. Think of it as a local
     // __syncthreads() for the Vec engine only. Much lighter than
     // set_flag/wait_flag (which sync across different hardware units).
-    pipe_barrier(PIPE_V);
+    PipeBarrierVec();
 
     UbND<float, 1, HTC> s_row_0;
     TASSIGN(s_row_0, SUbAddr);
     TMOV(s_row_0, acc_ub);
-    pipe_barrier(PIPE_V);
+    PipeBarrierVec();
 
     // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
     for (int32_t i = 1; i < valid; ++i) {
@@ -428,24 +429,24 @@ AICORE void cumsum_kernel_static(__gm__ float* g_ptr, __gm__ float* g_sum_ptr,
       // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
       // Operates on all HTC elements in parallel (SIMD).
       TADD(acc_ub, acc_ub, g_row_i);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       UbND<float, 1, HTC> s_row_i;
       TASSIGN(s_row_i, SUbAddr + i * RowBytes);
       TMOV(s_row_i, acc_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
     }
 
     // Zero-fill rows beyond valid (tail padding for downstream kernels)
     // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
     // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
     TEXPANDS(acc_ub, 0.0f);
-    pipe_barrier(PIPE_V);
+    PipeBarrierVec();
     for (int32_t i = valid; i < ChunkSize; ++i) {
       UbND<float, 1, HTC> s_row_i;
       TASSIGN(s_row_i, SUbAddr + i * RowBytes);
       TMOV(s_row_i, acc_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
     }
 
     // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────

--- a/csrc/kernel/kernel_gdn_chunk_h.cpp
+++ b/csrc/kernel/kernel_gdn_chunk_h.cpp
@@ -88,6 +88,7 @@
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 #ifdef __CCE_AICORE__
 
@@ -679,9 +680,9 @@ AICORE void chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
       // numerically local. Torch-like:
       //   coeff = exp(g_last - g_rows_owned_by_this_subblock)
       TADDS(coeff_ub, g_v_ub, -g_last);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TSUB(coeff_ub, zero_ub, coeff_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TEXP(coeff_ub, coeff_ub);
 
       TEXP(g_ub, g_ub);
@@ -697,10 +698,10 @@ AICORE void chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
       // Broadcast one decay scalar per token row across the D feature columns:
       //   coeff_2d[row, :] = coeff[row]
       TROWEXPAND(coeff_2d_ub, coeff_col_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       // `k_ub` now holds k_tilde = exp(g_last - g_i) * K_i.
       TMUL(k_ub, k_ub, coeff_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       wait_flag_dev(0);
       {

--- a/csrc/kernel/kernel_gdn_chunk_o.cpp
+++ b/csrc/kernel/kernel_gdn_chunk_o.cpp
@@ -69,6 +69,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 // ── Compile-time configuration (overridable at build time via -D flags) ──
 #ifndef GDN_H
@@ -766,13 +767,13 @@ static AICORE void chunk_o_kernel(
         TROWEXPAND(g_r_2d, g_v_col);
         TCOLEXPAND(coeff_ub, g_ub);
         TSUB(coeff_ub, g_r_2d, coeff_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMINS(coeff_ub, coeff_ub, 0.0f);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(coeff_ub, coeff_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMUL(coeff_ub, coeff_ub, msk_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(g_v_ub, g_v_ub);
       }
 
@@ -861,7 +862,7 @@ static AICORE void chunk_o_kernel(
       UbDN<float, HalfChunk, 1> g_v_col2;
       TASSIGN(g_v_col2, GvUbAddr);
       TROWEXPAND(g_exp_2d, g_v_col2);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TMUL(qs_ub, qs_ub, g_exp_2d);
 
       // ── Wait for Cube→Vec flag 2: QKV ready ─────────────────────────
@@ -979,13 +980,13 @@ static AICORE void chunk_o_kernel(
               TROWEXPAND(g_r_2d_v, g_v_col_v);
               TCOLEXPAND(coeff_ub, g_ub);
               TSUB(coeff_ub, g_r_2d_v, coeff_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMINS(coeff_ub, coeff_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TEXP(coeff_ub, coeff_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(coeff_ub, coeff_ub, msk_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TEXP(g_v_ub, g_v_ub);
             }
 
@@ -1076,7 +1077,7 @@ static AICORE void chunk_o_kernel(
               UbDN<float, HalfChunk, 1> g_v_col2_v;
               TASSIGN(g_v_col2_v, GvUbAddr);
               TROWEXPAND(g_exp_2d_v, g_v_col2_v);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(qs_ub, qs_ub, g_exp_2d_v);
 
               wait_flag_dev(2);

--- a/csrc/kernel/kernel_gdn_scaled_dot_kkt.cpp
+++ b/csrc/kernel/kernel_gdn_scaled_dot_kkt.cpp
@@ -39,6 +39,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 // ── Compile-time configuration (overridable at build time via -D flags) ──
 #ifndef GDN_H
@@ -368,25 +369,25 @@ AICORE void kkt_kernel(__gm__ half* K_handle, __gm__ half* Beta_handle,
         TASSIGN(g_ub_temp,
                 GUbAddr + row_offset * static_cast<int32_t>(sizeof(float)));
         TMOV(g_v_ub, g_ub_temp);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         TLOG(beta_ub, beta_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TADD(g_v_ub, g_v_ub, beta_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMOV(g_r_ub, g_v_ub);
         TMOV(g_c_ub, g_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         UbDN<float, HalfChunk, 1, HalfChunk, 1> g_r_ub_temp;
         TASSIGN(g_r_ub_temp, GRUbAddr);
         TROWEXPAND(g_r_2d_ub, g_r_ub_temp);
         TCOLEXPAND(g_c_2d_ub, g_c_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TSUB(coeff_ub, g_r_2d_ub, g_c_2d_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMINS(coeff_ub, coeff_ub, 0.0f);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(coeff_ub, coeff_ub);
 
         set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);

--- a/csrc/kernel/kernel_gdn_wy_fast.cpp
+++ b/csrc/kernel/kernel_gdn_wy_fast.cpp
@@ -38,6 +38,7 @@ for the full License text.
 
 #include "kernel_utils.h"
 using namespace pto;
+using namespace kernel_utils;
 
 // ── Compile-time configuration (overridable at build time via -D flags) ──
 #ifndef GDN_H
@@ -394,7 +395,7 @@ AICORE void wy_fast_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
             } else {
               // Empty lower-half tail: zero-fill so Cube sees valid padding
               TEXPANDS(a1_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -403,9 +404,9 @@ AICORE void wy_fast_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
 
             // A2 = A * beta_2d   (beta broadcast along columns)
             TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(beta_r_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(beta_2d_ub, beta_r_ub);
 
             TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
@@ -450,11 +451,11 @@ AICORE void wy_fast_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
 
             // A1 = A * (exp(g)*beta)_2d
             TEXP(g_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMUL(g_ub, g_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(g_r_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(g_2d_ub, g_r_ub);
             TMUL(a1_ub, a1_ub, g_2d_ub);
             TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
@@ -542,7 +543,7 @@ AICORE void wy_fast_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
               }
             } else {
               TEXPANDS(a1_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -551,9 +552,9 @@ AICORE void wy_fast_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
 
             // A2 = A * beta_2d
             TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(beta_r_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(beta_2d_ub, beta_r_ub);
 
             TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
@@ -597,11 +598,11 @@ AICORE void wy_fast_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
 
             // A1 = A * (exp(g)*beta)_2d
             TEXP(g_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMUL(g_ub, g_ub, beta_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMOV(g_r_ub, g_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TCOLEXPAND(g_2d_ub, g_r_ub);
             TMUL(a1_ub, a1_ub, g_2d_ub);
             TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);

--- a/csrc/kernel/kernel_kda_chunk_h.cpp
+++ b/csrc/kernel/kernel_kda_chunk_h.cpp
@@ -44,6 +44,7 @@
 
 #include "kernel_utils.h"
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_H
 #define GDN_H 16
@@ -534,7 +535,7 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
           TileUbDataND<half, HalfC, K_DIM, HalfC, K_DIM> k_stg_cvt;
           TASSIGN(k_stg_cvt, K_UB_HALF);
           TCVT(k_ub, k_stg_cvt, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
         {
           GmShape2D g_shape(valid_rows, K_DIM);
@@ -574,14 +575,14 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
 
       // ── 3. coeff_2d = exp(g_total - g_cs)  [HalfC, K] ───────────────────
       TCOLEXPAND(coeff_2d_ub, gtotal_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TSUB(coeff_2d_ub, coeff_2d_ub, gcs_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TEXP(coeff_2d_ub, coeff_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       TMUL(k_ub, k_ub, coeff_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TCVT(k_ub_half, k_ub, pto::RoundMode::CAST_NONE);
 
       // ── 4. Reuse GCS_UB region to load U (g_cs is now dead) ──────────────
@@ -611,7 +612,7 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
           TileUbDataND<half, HalfC, V_DIM, HalfC, V_DIM> u_stg_cvt;
           TASSIGN(u_stg_cvt, U_UB_HALF);
           TCVT(u_ub, u_stg_cvt, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
       } else {
         TEXPANDS(u_ub, 0.0f);
@@ -635,9 +636,9 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
       set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
       wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
       TCVT(ws_ub, u_ub_half, pto::RoundMode::CAST_NONE);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TSUB(u_ub, u_ub, ws_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TCVT(u_ub_half, u_ub, pto::RoundMode::CAST_NONE);
 
       // ── 6. Store V_corr (fp16 to output and workspace WS_V) ──────────────
@@ -680,7 +681,7 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
       set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
       wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
       TEXP(gtotal_ub, gtotal_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       {
         TileUbDataDN<float, HalfC, 1, HalfC, 1> exp_gt_col;
@@ -689,9 +690,9 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
                                 static_cast<int32_t>(sizeof(float)));
         TROWEXPAND(exp_gt_2d_ub, exp_gt_col);
       }
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TMUL(s_ub, s_ub, exp_gt_2d_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       // ── 8. Wait Cube KV ready, S += KV ───────────────────────────────────
       wait_flag_dev(2);
@@ -715,7 +716,7 @@ AICORE void kda_chunk_h_kernel(__gm__ half* K_handle, __gm__ half* W_handle,
         TASSIGN(kv_load_view, KV_LOAD_UB);
         TCVT(kv_ub, kv_load_view, pto::RoundMode::CAST_NONE);
       }
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TADD(s_ub, s_ub, kv_ub);
 
       // ── 9. Write fp16(S) to workspace WS_S for next chunk's W @ S ────────

--- a/csrc/kernel/kernel_kda_chunk_o.cpp
+++ b/csrc/kernel/kernel_kda_chunk_o.cpp
@@ -54,6 +54,7 @@
 
 #include "kernel_utils.h"
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_H
 #define GDN_H 16
@@ -408,7 +409,7 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
           TileUbDataND<half, HalfC, K_DIM, HalfC, K_DIM> q_stg_cvt;
           TASSIGN(q_stg_cvt, SLOT_D_ADDR);
           TCVT(q_ub, q_stg_cvt, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
         {
           GmShape2D g_shape(valid_rows, K_DIM);
@@ -434,9 +435,9 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
 
       // (A.2) q_eff = Q * exp(g_cs).
       TEXP(exp_ub, g_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
       TMUL(exp_ub, q_ub, exp_ub);
-      pipe_barrier(PIPE_V);
+      PipeBarrierVec();
 
       set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
       wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -465,7 +466,7 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
           TileUbDataND<float, HalfC, C, HalfC, C> zero_ub;
           TASSIGN(zero_ub, SLOT_C_ADDR);
           TEXPANDS(zero_ub, 0.0f);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
           wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
           GmShape2D z_shape(HalfC, C);
@@ -504,7 +505,7 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
             TileUbDataND<float, 1, K_DIM, 1, K_DIM> kc_f;
             TASSIGN(kc_f, AQK_KC);
             TCVT(kc_f, kc_h, pto::RoundMode::CAST_NONE);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
           }
           TileUbDataND<float, 1, K_DIM, 1, K_DIM> gc;
           TASSIGN(gc, AQK_GC);
@@ -518,17 +519,17 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
           TASSIGN(colsum, AQK_COL);
 
           TCOLEXPANDSUB(diff, g_ub, gc);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           TMINS(diff, diff, 0.0f);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           TEXP(diff, diff);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           TCOLEXPANDMUL(diff, diff, kc);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           TMUL(diff, diff, q_ub);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           TROWSUM(colsum, diff, tmp);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
           {
             TileUbDataND<float, HalfC, 16, HalfC, 1> mk;
             TASSIGN(mk, AQK_MSK);
@@ -541,7 +542,7 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             TMUL(colsum, colsum, mk);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
           }
           set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
           wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -590,10 +591,10 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
           set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
           wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
           TCVT(v_f_ub, vh_ub, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         } else {
           TEXPANDS(v_f_ub, 0.0f);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -633,7 +634,7 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
         TCVT(s_f_ub, sh_ub, pto::RoundMode::CAST_NONE);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -690,12 +691,12 @@ AICORE void kda_chunk_o_kernel(__gm__ half* Q_handle, __gm__ half* K_handle,
         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
         TADD(qs_ub, qs_ub, qkv_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         TileUbDataND<half, HalfC, V_DIM, HalfC, V_DIM> oh_ub;
         TASSIGN(oh_ub, SLOT_D_ADDR);
         TCVT(oh_ub, qs_ub, pto::RoundMode::CAST_NONE);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         int64_t o_offset = (chunk_start * H + head) * V_DIM +

--- a/csrc/kernel/kernel_kda_gate_cumsum.cpp
+++ b/csrc/kernel/kernel_kda_gate_cumsum.cpp
@@ -38,6 +38,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_H
 #define GDN_H 16
@@ -160,7 +161,7 @@ AICORE void kda_gate_cumsum_kernel(__gm__ half* g_ptr, __gm__ float* g_sum_ptr,
           UbND<float, ChunkSize, CTC> g_f;
           TASSIGN(g_f, GUbAddr);
           TCVT(g_f, g_h, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         // Vec: prefix sum (all ColTile cols in parallel).
@@ -168,24 +169,24 @@ AICORE void kda_gate_cumsum_kernel(__gm__ half* g_ptr, __gm__ float* g_sum_ptr,
         UbND<float, 1, CTC> g_row_0;
         TASSIGN(g_row_0, GUbAddr);
         TMOV(acc_ub, g_row_0);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         UbND<float, 1, CTC> s_row_0;
         TASSIGN(s_row_0, SUbAddr);
         TMOV(s_row_0, acc_ub);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         // Rows 1..valid-1: acc += g[i]; g_sum[i] = acc
         for (int32_t i = 1; i < valid; ++i) {
           UbND<float, 1, CTC> g_row_i;
           TASSIGN(g_row_i, GUbAddr + i * RowBytes);
           TADD(acc_ub, acc_ub, g_row_i);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
 
           UbND<float, 1, CTC> s_row_i;
           TASSIGN(s_row_i, SUbAddr + i * RowBytes);
           TMOV(s_row_i, acc_ub);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         // V → MTE2: prevent next iteration's TLOAD from clobbering UB before
@@ -255,29 +256,29 @@ AICORE void kda_gate_cumsum_kernel(__gm__ half* g_ptr, __gm__ float* g_sum_ptr,
               UbND<float, ChunkSize, CTC> g_f;
               TASSIGN(g_f, GUbAddr);
               TCVT(g_f, g_h, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
             }
 
             UbND<float, 1, CTC> g_row_0;
             TASSIGN(g_row_0, GUbAddr);
             TMOV(acc_ub, g_row_0);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
             UbND<float, 1, CTC> s_row_0;
             TASSIGN(s_row_0, SUbAddr);
             TMOV(s_row_0, acc_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
             for (int32_t i = 1; i < valid; ++i) {
               UbND<float, 1, CTC> g_row_i;
               TASSIGN(g_row_i, GUbAddr + i * RowBytes);
               TADD(acc_ub, acc_ub, g_row_i);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
 
               UbND<float, 1, CTC> s_row_i;
               TASSIGN(s_row_i, SUbAddr + i * RowBytes);
               TMOV(s_row_i, acc_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
             }
 
             set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);

--- a/csrc/kernel/kernel_kda_kkt.cpp
+++ b/csrc/kernel/kernel_kda_kkt.cpp
@@ -49,6 +49,7 @@
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef KDA_KKT_H
 #define KDA_KKT_H 4
@@ -219,7 +220,7 @@ AICORE inline void kda_kkt_kernel(__gm__ half* k_ptr, __gm__ float* g_cs_ptr,
         UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> k_f(my_rows, KDim);
         TASSIGN(k_f, MYK_ADDR);
         TCVT(k_f, k_h, pto::RoundMode::CAST_NONE);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
       }
       // ── Load my rows' beta (fp16 -> fp32) as a [1, my_rows] row, then
       //    re-view as a [my_rows, 1] column for the per-row scale. ───────
@@ -242,7 +243,7 @@ AICORE inline void kda_kkt_kernel(__gm__ half* k_ptr, __gm__ float* g_cs_ptr,
         UbND<float, 1, HalfChunk, DYNAMIC, DYNAMIC> b_f(1, my_rows);
         TASSIGN(b_f, BETA_ADDR);
         TCVT(b_f, b_h, pto::RoundMode::CAST_NONE);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
       }
 
       UbND<float, HalfChunk, KTC, DYNAMIC, DYNAMIC> myg(my_rows, KDim);
@@ -277,7 +278,7 @@ AICORE inline void kda_kkt_kernel(__gm__ half* k_ptr, __gm__ float* g_cs_ptr,
           UbND<float, 1, KTC, 1, KTC> kc_f;
           TASSIGN(kc_f, KC_ADDR);
           TCVT(kc_f, kc_h, pto::RoundMode::CAST_NONE);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         UbND<float, 1, KTC, 1, KTC> gc;
@@ -293,23 +294,23 @@ AICORE inline void kda_kkt_kernel(__gm__ half* k_ptr, __gm__ float* g_cs_ptr,
 
         // diff[r,d] = g_cs[my r, d] - g_cs[c, d]
         TCOLEXPANDSUB(diff, myg, gc);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         // clamp to <= 0 so exp(.) is finite for masked (r<c) entries too
         TMINS(diff, diff, 0.0f);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TEXP(diff, diff);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         // *= k[c,d]  (per-dim broadcast), then *= k[my r, d]
         TCOLEXPANDMUL(diff, diff, kc);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         TMUL(diff, diff, myk);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         // per-row beta scale (TMUL can't take a [R,1] column directly)
         TROWEXPANDMUL(diff, diff, beta_col);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         // colsum[r] = beta[r] * sum_d diff[r,d]   (unmasked)
         TROWSUM(colsum, diff, tmp);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         // Strict-lower mask: load mask[my_off+r, c] as a padded [my_rows,1]
         // strip (row-strided gather, innermost contiguous) and zero the
@@ -326,7 +327,7 @@ AICORE inline void kda_kkt_kernel(__gm__ half* k_ptr, __gm__ float* g_cs_ptr,
           set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
           wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
           TMUL(colsum, colsum, mk);
-          pipe_barrier(PIPE_V);
+          PipeBarrierVec();
         }
 
         // cvt colsum -> fp16 into a padded RowMajor [my_rows, 1] tile and
@@ -335,7 +336,7 @@ AICORE inline void kda_kkt_kernel(__gm__ half* k_ptr, __gm__ float* g_cs_ptr,
         UbND<half, HalfChunk, 16, DYNAMIC, DYNAMIC> col_h(my_rows, 1);
         TASSIGN(col_h, COLH_ADDR);
         TCVT(col_h, colsum, pto::RoundMode::CAST_NONE);
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/csrc/kernel/kernel_kda_wy.cpp
+++ b/csrc/kernel/kernel_kda_wy.cpp
@@ -65,6 +65,7 @@
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 #ifndef GDN_H
 #define GDN_H 16
@@ -441,7 +442,7 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
               // Fully empty lower-half stripe: emit zeros so the workspace tile
               // for this sub-block stays well-defined.
               TEXPANDS(a2_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -450,12 +451,12 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
 
             if (local_rows > 0) {
               TCVT(beta_r_ub, beta_ub, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TileUbDataND<half, HalfChunk, ChunkSize, HalfChunk, ChunkSize>
                   a_stg_cvt;
               TASSIGN(a_stg_cvt, A2HalfUbAddr);
               TCVT(inv_ub, a_stg_cvt, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               // Replicate beta_j across rows: beta_2d[i,j] = beta[j].
               TCOLEXPAND(beta_2d_ub, beta_r_ub);
               // A2 = INV * beta_2d (column-scale).
@@ -511,7 +512,7 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
                     k_stg_cvt;
                 TASSIGN(k_stg_cvt, KeffHalfUbAddr);
                 TCVT(k_ub, k_stg_cvt, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
               }
               {
                 GmShape2D g_shape(local_rows, HiddenSize);
@@ -534,13 +535,13 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
               wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
               // exp(g_cs) in-place over gcs_ub, then K_eff = k * exp(g_cs).
               TEXP(gcs_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(keff_ub, k_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             } else {
               TEXPANDS(keff_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -630,7 +631,7 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
               }
             } else {
               TEXPANDS(a2_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
             }
 
@@ -639,12 +640,12 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
 
             if (local_rows > 0) {
               TCVT(beta_r_ub, beta_ub, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TileUbDataND<half, HalfChunk, ChunkSize, HalfChunk, ChunkSize>
                   a_stg_cvt;
               TASSIGN(a_stg_cvt, A2HalfUbAddr);
               TCVT(inv_ub, a_stg_cvt, pto::RoundMode::CAST_NONE);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCOLEXPAND(beta_2d_ub, beta_r_ub);
               TMUL(a2_ub, inv_ub, beta_2d_ub);
               TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
@@ -696,7 +697,7 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
                     k_stg_cvt;
                 TASSIGN(k_stg_cvt, KeffHalfUbAddr);
                 TCVT(k_ub, k_stg_cvt, pto::RoundMode::CAST_NONE);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
               }
               {
                 GmShape2D g_shape(local_rows, HiddenSize);
@@ -718,13 +719,13 @@ AICORE void kda_wy_kernel(__gm__ half* K_handle, __gm__ half* V_handle,
               set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
               wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
               TEXP(gcs_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TMUL(keff_ub, k_ub, gcs_ub);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             } else {
               TEXPANDS(keff_ub, 0.0f);
-              pipe_barrier(PIPE_V);
+              PipeBarrierVec();
               TCVT(keff_ub_half, keff_ub, pto::RoundMode::CAST_NONE);
             }
 

--- a/csrc/kernel/kernel_swiglu.cpp
+++ b/csrc/kernel/kernel_swiglu.cpp
@@ -10,6 +10,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 #define DIV_ROUNDUP(x, y) (((x) + (y) - 1) / (y))
 #define ALIGN_UP(x, y) (DIV_ROUNDUP((x), (y)) * (y))
@@ -184,15 +185,15 @@ template <typename TileData, typename T>
 AICORE inline void computeSwiGLUTile(TileData& x0Tile, TileData& x1Tile,
                                      TileData& yTile) {
   TMULS(yTile, x0Tile, (T)-1);
-  pipe_barrier(PIPE_V);
+  PipeBarrierVec();
   TEXP(yTile, yTile);
-  pipe_barrier(PIPE_V);
+  PipeBarrierVec();
   TADDS(yTile, yTile, (T)1);
-  pipe_barrier(PIPE_V);
+  PipeBarrierVec();
   TDIV(yTile, x0Tile, yTile);
-  pipe_barrier(PIPE_V);
+  PipeBarrierVec();
   TMUL(yTile, yTile, x1Tile);
-  pipe_barrier(PIPE_V);
+  PipeBarrierVec();
 }
 
 // col_count is padded for UB tile sizing; col_count_store is the actual GM

--- a/csrc/kernel/kernel_tri_inv_col_sweep.cpp
+++ b/csrc/kernel/kernel_tri_inv_col_sweep.cpp
@@ -10,6 +10,7 @@ for the full License text.
 #include "kernel_utils.h"
 
 using namespace pto;
+using namespace kernel_utils;
 
 /**
  * @brief Runs triangular matrix inverse on input buffer.
@@ -116,7 +117,7 @@ AICORE void runTTriInv(__gm__ T* vec_in, __gm__ T* vec_out,
       for (int32_t k = j - 1; k >= 1; --k) {
         TASSIGN(A_k, k * S * sizeof(T));
 
-        pipe_barrier(PIPE_V);
+        PipeBarrierVec();
         set_flag(PIPE_S, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_S, PIPE_V, EVENT_ID0);
         TAXPY(b, A_k, static_cast<T>(-xk));

--- a/csrc/kernel/kernel_utils.h
+++ b/csrc/kernel/kernel_utils.h
@@ -165,4 +165,14 @@ constexpr pto::BLayout GetOuterLayout(bool is_left) {
 #endif
 }
 
+/**
+ * @brief Pipe in-core barrier for vector core.
+ *
+ */
+AICORE inline void PipeBarrierVec() {
+#if __CCE_AICORE__ == 220
+  pipe_barrier(PIPE_V);
+#endif
+}
+
 }  // namespace kernel_utils


### PR DESCRIPTION
Porting a helper function for `PipeBarrierVec()` to use for A5 transition.
To be used in #162 