### PR TITLE
tri_inv_rec_unroll: reuse the accumulator, and make the doubling block a knob

### DIFF
--- a/csrc/host/torch_tri_inv_rec_unroll.h
+++ b/csrc/host/torch_tri_inv_rec_unroll.h
@@ -34,6 +34,17 @@ namespace pto_isa_ops {
  *
  * Note: supports fp16 and bf16 input dtypes. Output is fp16 or fp32.
  *
+ * Input range: the algorithm forms the powers A^(2^j) of each strictly
+ * triangular input block and holds them in the input dtype, so the input has
+ * to be scaled such that those powers stay representable. They grow fastest
+ * for dense, same-sign matrices. At the default doubling block, entries of 1.0
+ * -- the all-ones matrix the tests use -- peak at 3.4e3, 19x inside fp16,
+ * while entries of 1.5 already overflow. A matrix whose entries decay away
+ * from the diagonal, as a gated linear-attention chunk does, instead stays
+ * near its own largest entry. Input outside the range comes back as NaN rather
+ * than as a large error. See TRI_INV_DOUBLING_BLOCK in
+ * kernel_tri_inv_rec_unroll.cpp, which trades this headroom for speed.
+ *
  * @param M Input tensor containing square matrices on the last two dimensions.
  * @param cu_seqlens A 1-dimensional torch tensor that contains the lengths
  * of each input sequence (it is the cummulative sum of the lengths)

--- a/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
+++ b/csrc/kernel/kernel_tri_inv_rec_unroll.cpp
@@ -14,44 +14,10 @@ using namespace pto;
 
 #include "constants.h"
 
-/**
- * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
- * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
- * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
- * FractalSize from the src matrix to the dst matrix.
- *
- * @tparam InputT Input data type (fp16).
- * @tparam FractalSize Size of each fractal matrix (diagonal block).
- * @tparam MatrixSize Size of the entire input/output matrices.
- * @tparam SrcL1TileT The actual tile type of the src matrix.
- * @tparam DstL0TileT The actual tile type of the dst matrix.
- *
- * @param src Tile in L1 memory.
- * @param dst Tile in L0A or L0B memory.
- */
-template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
-          typename SrcL1TileT, typename DstL0TileT>
-AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst) {
-  constexpr uint32_t NumFractals = MatrixSize / FractalSize;
-  constexpr bool is_left =
-      std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
-  constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
-  constexpr SLayout InnerLayout =
-      is_left ? SLayout::RowMajor : SLayout::ColMajor;
-  constexpr BLayout OuterLayout = kernel_utils::GetOuterLayout(is_left);
-
-  Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize,
-       FractalSize, InnerLayout, TileConfig::fractalABSize>
-      fractals[NumFractals];
-  const std::uintptr_t starting_address =
-      reinterpret_cast<std::uintptr_t>(dst.data());
-  for (uint32_t i = 0; i < NumFractals; ++i) {
-    TASSIGN(fractals[i], starting_address + i * FractalSize *
-                                                (MatrixSize + FractalSize) *
-                                                sizeof(InputT));
-    TEXTRACT(fractals[i], src, i * FractalSize, i * FractalSize);
-  }
-}
+// Block size that the doubling phase builds up to; see DoublingBlockSize.
+#ifndef TRI_INV_DOUBLING_BLOCK
+#define TRI_INV_DOUBLING_BLOCK 16
+#endif
 
 /**
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each,
@@ -127,6 +93,38 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
 }
 
 /**
+ * @brief Copies the diagonal blocks of `block_size` from src to dst.
+ *
+ * Both parities of CopyOddOrEvenBlocksL1ToL0 together are exactly the
+ * diagonal blocks. At block_size == MatrixSize the whole matrix is one
+ * block, and the fractal path would issue (MatrixSize/FractalSize)^2
+ * TEXTRACTs to copy what a single TMOV covers.
+ *
+ * @tparam InputT Data type of the input matrix.
+ * @tparam FractalSize Size of matrix fractals.
+ * @tparam MatrixSize Size of the entire input/output matrices.
+ * @tparam SrcL1TileT The type of the source tile in L1.
+ * @tparam DstL0TileT The type of the destination tile in L0.
+ *
+ * @param src Source tile in L1.
+ * @param dst Destination tile in L0.
+ * @param block_size Size of the diagonal blocks to copy.
+ */
+template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize,
+          typename SrcL1TileT, typename DstL0TileT>
+AICORE inline void CopyDiagonalBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst,
+                                            uint32_t block_size) {
+  if (block_size >= MatrixSize) {
+    TMOV(dst, src);
+    return;
+  }
+  CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(src, dst,
+                                                             block_size, false);
+  CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(src, dst,
+                                                             block_size, true);
+}
+
+/**
  * @brief: Prepares Identity and Zeros matrix.
  *
  * @tparam TileL1AB The type of the input tiles in L1.
@@ -186,6 +184,8 @@ AICORE inline void PrepareAuxiliaryMatrices(
  * @tparam TileL0C The type of the input tiles in L0C.
  * @tparam MatrixSize Size of the entire input/output matrices.
  * @tparam FractalSize Size of matrix fractals.
+ * @tparam DoublingBlockSize Block size that the doubling phase builds up
+ * to before the unrolled recursion takes over.
  * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
  * cube iteration.
  *
@@ -206,7 +206,8 @@ AICORE inline void PrepareAuxiliaryMatrices(
  */
 template <typename InputT, typename TileL1AB, typename TileL0A,
           typename TileL0B, typename TileL0C, uint32_t MatrixSize,
-          uint32_t FractalSize, uint32_t NumTilesPerCubeIter>
+          uint32_t FractalSize, uint32_t DoublingBlockSize,
+          uint32_t NumTilesPerCubeIter>
 AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
                                     TileL1AB I_neg_l1_tile,
                                     TileL1AB M_neg_l1_tile,
@@ -226,10 +227,10 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   wait_flag(PIPE_MTE1, PIPE_M, event_1);
   set_flag(PIPE_M, PIPE_MTE1, event_1);
   wait_flag(PIPE_M, PIPE_MTE1, event_1);
-  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
-      Y_l1_tile, a_l0_tile[1]);  // a_l0[1] = diag_fractals(M)
-  CopyDiagonalFractalsL1ToL0<InputT, FractalSize, MatrixSize>(
-      Y_l1_tile, b_l0_tile[1]);  // b_l0[1] = diag_fractals(M)
+  CopyDiagonalBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, a_l0_tile[1], DoublingBlockSize);  // a_l0[1] = diag_blocks(M)
+  CopyDiagonalBlocksL1ToL0<InputT, FractalSize, MatrixSize>(
+      Y_l1_tile, b_l0_tile[1], DoublingBlockSize);  // b_l0[1] = diag_blocks(M)
   set_flag(PIPE_MTE1, PIPE_M, event_1);
 
   /* First Matmul: event_0 */
@@ -292,7 +293,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   set_flag(PIPE_FIX, PIPE_M, event_1);     // only for update Y
   set_flag(PIPE_M, PIPE_MTE1, event_1);    // only for update Y
   set_flag(PIPE_FIX, PIPE_MTE1, event_1);  // only for update Y
-  for (uint32_t block_size = 1; block_size < FractalSize / 2; block_size *= 2) {
+  for (uint32_t block_size = 1; block_size < DoublingBlockSize / 2;
+       block_size *= 2) {
     wait_flag(PIPE_M, PIPE_MTE1, event_0);
     TMOV(b_l0_tile[0], I_l1_tile);
     wait_flag(PIPE_FIX, PIPE_MTE1, event_0);
@@ -305,13 +307,13 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
 
     wait_flag(PIPE_FIX, PIPE_M, event_0);   // from previous iter
     wait_flag(PIPE_MTE1, PIPE_M, event_0);  // from loading a_l0[0], b_l0[0]
-    TMATMUL(c_l0_tile[0], a_l0_tile[0], b_l0_tile[0]);  // c_l0[0] contains X
-    set_flag(PIPE_M, PIPE_FIX, event_0);
-    wait_flag(PIPE_M, PIPE_FIX, event_0);
-    set_flag(PIPE_FIX, PIPE_M, event_0);
-    wait_flag(PIPE_FIX, PIPE_M, event_0);
+    // c_l0[0] already holds X: the previous level's TMATMUL_ACC left it
+    // there and the TMOV to X_l1 only reads it, so X @ Y accumulates
+    // straight onto it. X also stays in the FP32 accumulator across levels
+    // instead of round-tripping through the FP16 X_l1 copy.
 
-    if (block_size < FractalSize / 4) {  // Update Y except in last iteration
+    if (block_size <
+        DoublingBlockSize / 4) {  // Update Y except in last iteration
       wait_flag(PIPE_M, PIPE_MTE1, event_1);  // from previous iter
       TMOV(a_l0_tile[1], Y_l1_tile);
       wait_flag(PIPE_MTE1, PIPE_M, event_1);
@@ -369,14 +371,14 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile,
   TMOV(b_l0_tile[1], M_neg_l1_tile);  // b_l0[1] contains M_neg
   TMOV(a_l0_tile[0], I_l1_tile);      // a_l0[0] contains I
 
-  if constexpr (MatrixSize > FractalSize) {
+  if constexpr (MatrixSize > DoublingBlockSize) {
     set_flag(PIPE_FIX, PIPE_M, event_1);
   }
   set_flag(PIPE_M, PIPE_MTE1, event_1);
   set_flag(PIPE_M, PIPE_MTE1, event_0);
   set_flag(PIPE_FIX, PIPE_MTE1, event_1);
   set_flag(PIPE_FIX, PIPE_M, event_0);
-  for (uint32_t block_size = FractalSize; block_size < MatrixSize;
+  for (uint32_t block_size = DoublingBlockSize; block_size < MatrixSize;
        block_size *= 2) {
     wait_flag(PIPE_M, PIPE_MTE1, event_0);  // Wait for last iter a_l0[1]
     TMOV(a_l0_tile[1], Zero_l1_tile);
@@ -480,6 +482,24 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
   /* Initializations */
   constexpr uint32_t TileLen = MatrixSize * MatrixSize;
   constexpr uint32_t FractalSize = 16;  // fractal size for half /bf16
+  // How far the doubling phase builds up before the unrolled recursion takes
+  // over. Independent of FractalSize, which the hardware fixes for the input
+  // type: covering more of the matrix here costs recursion levels below, and
+  // at MatrixSize it removes the recursion entirely. Worth 6% at 32 and 18%
+  // at 128, measured on 1024 matrices of side 128.
+  //
+  // It is NOT free, because phase 1 forms the powers A^(2^j) inside a block
+  // and they have to stay inside the input type's range. For the worst case
+  // this kernel is tested on -- a strictly triangular matrix of ones -- the
+  // largest intermediate is 3.4e3 in a block of 16, 1.6e8 at 32 and 6.0e36 at
+  // 128, against fp16's 65504, and the result comes back NaN. In terms of the
+  // input: the largest dense same-sign entry that still fits is 1.45 at a
+  // block of 16, 0.62 at 32, 0.27 at 64 and 0.13 at 128. Raise this only for
+  // inputs known to be inside that, and re-run
+  // tests/test_tri_inv_rec_unroll.py, whose dynamic-range and ones cases cover
+  // it.
+  constexpr uint32_t DoublingBlockSize =
+      MatrixSize < TRI_INV_DOUBLING_BLOCK ? MatrixSize : TRI_INV_DOUBLING_BLOCK;
   constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
   constexpr uint32_t NumL0Buffers = 2;
 
@@ -626,7 +646,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
     }
 
-    constexpr uint32_t final_c_buffer_index = MatrixSize > FractalSize ? 1 : 0;
+    constexpr uint32_t final_c_buffer_index =
+        MatrixSize > DoublingBlockSize ? 1 : 0;
     for (uint32_t tile_id = 0; (tile_id < NumTilesPerCubeIter) &&
                                (global_index + tile_id < total_tiles);
          ++tile_id) {
@@ -636,7 +657,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT* M_inv,
       wait_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(tile_id));
 
       InvertSingleTile<InputT, TileL1AB, TileL0A, TileL0B, TileL0C, MatrixSize,
-                       FractalSize, NumTilesPerCubeIter>(
+                       FractalSize, DoublingBlockSize, NumTilesPerCubeIter>(
           X_l1_tile, I_l1_tile, I_neg_l1_tile, M_neg_l1_tile, Zero_l1_tile,
           Y_l1_tile[tile_id], a_l0_tile, b_l0_tile, c_l0_tile, tile_id,
           is_lower != 0);

--- a/tests/test_tri_inv_rec_unroll.py
+++ b/tests/test_tri_inv_rec_unroll.py
@@ -6,6 +6,8 @@
 # for the full License text.
 # --------------------------------------------------------------------------------
 
+import functools
+
 import torch
 import pytest
 import numpy as np
@@ -50,14 +52,63 @@ def block_ones_triu_matrix(n, block_dim_x, block_dim_y):
 
 
 def block_random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.1):
-    U_ = scale * np.random.rand(16, 16)
-    U_ = np.triu(U_, k=1)
     U = np.zeros((block_dim_x, block_dim_y, n, n))
     for x in range(block_dim_x):
         for y in range(block_dim_y):
             for i in range(0, n, 16):
-                U[x, y, i : i + 16, i : i + 16] = U_.copy()
+                U_ = np.triu(scale * np.random.rand(16, 16), k=1)
+                U[x, y, i : i + 16, i : i + 16] = U_
     return torch.from_numpy(U)
+
+
+def cond_of(A: torch.tensor) -> float:
+    """Condition number of I + A, the matrix the kernel actually inverts."""
+    n = A.shape[-1]
+    M = torch.eye(n, dtype=torch.float64) + A.reshape(-1, n, n).double()
+    return float(torch.linalg.cond(M).max())
+
+
+@functools.lru_cache(maxsize=None)
+def scale_for_cond(n: int, cond_target: float) -> float:
+    """Scale that puts cond(I + scale * A) at `cond_target`, for a strictly
+    triangular A of size n with entries drawn uniformly from (-1, 1).
+
+    Bisected once per (n, cond_target) on a fixed reference draw: the scale
+    barely varies between draws from the same distribution, and calibrating per
+    matrix would cost an SVD per bisection step per matrix.
+    """
+    g = torch.Generator().manual_seed(0)
+    a = torch.triu(torch.rand((n, n), generator=g, dtype=torch.float64) * 2 - 1, 1)
+    eye = torch.eye(n, dtype=torch.float64)
+    lo, hi = 0.0, 50.0
+    for _ in range(40):
+        mid = (lo + hi) / 2
+        if float(torch.linalg.cond(eye + mid * a)) < cond_target:
+            lo = mid
+        else:
+            hi = mid
+    return lo
+
+
+def conditioned_tri_matrix(
+    n, block_dim_x, block_dim_y, cond_target=2.0, is_lower=False
+):
+    """Strictly triangular A, scaled so cond(I + A) is near `cond_target`.
+
+    How hard the inversion is depends on the scale of A, and at a fixed scale it
+    depends on n as well: `0.1 * rand` gives cond(I + A) = 1.5 at n = 16 but 6.9
+    at n = 128, so a single tolerance means a different demand at every size.
+    Scaling to a target makes the difficulty an explicit parameter. The achieved
+    value varies a little between draws; the assertions report it.
+
+    Sign matters too. All-positive entries accumulate constructively through the
+    powers of A; at n = 128 and the same scale, mixed signs halve the condition
+    number. Real callers (GDN's `(I + tril(beta * K K^T))`) produce mixed signs
+    and land near cond 1.1 - 1.3.
+    """
+    base = torch.rand((block_dim_x, block_dim_y, n, n)) * 2 - 1
+    base = torch.tril(base, diagonal=-1) if is_lower else torch.triu(base, diagonal=1)
+    return scale_for_cond(n, cond_target) * base
 
 
 def linalg_inv(U: torch.tensor) -> torch.tensor:
@@ -104,10 +155,13 @@ def _test_tri_inv_rec_unroll(
     actual_numpy = actual_cpu.numpy()
     golden_numpy = golden_cpu.numpy()
 
-    assert np.allclose(
-        actual_numpy, golden_numpy, atol=atol, rtol=rtol
-    ), f"Error at allclose - tensor shape: {A.shape} - rtol: {rtol}."
-    assert frob_error <= ftol, f"frob_error: {frob_error}"
+    assert np.allclose(actual_numpy, golden_numpy, atol=atol, rtol=rtol), (
+        f"Error at allclose - tensor shape: {A.shape} - rtol: {rtol} - "
+        f"cond(I+A): {cond_of(A):.2f}."
+    )
+    assert (
+        frob_error <= ftol
+    ), f"frob_error: {frob_error} (ftol {ftol}, cond(I+A) {cond_of(A):.2f})"
 
 
 # pylint: disable=too-many-function-args,too-many-positional-arguments
@@ -152,10 +206,13 @@ def _test_tri_inv_rec_unroll_bsnd(
     actual_numpy = actual_cpu.numpy()
     golden_numpy = golden_cpu.numpy()
 
-    assert np.allclose(
-        actual_numpy, golden_numpy, atol=atol, rtol=rtol
-    ), f"Error at allclose - tensor shape: {A.shape} - rtol: {rtol}."
-    assert frob_error <= ftol, f"frob_error: {frob_error}"
+    assert np.allclose(actual_numpy, golden_numpy, atol=atol, rtol=rtol), (
+        f"Error at allclose - tensor shape: {A.shape} - rtol: {rtol} - "
+        f"cond(I+A): {cond_of(A):.2f}."
+    )
+    assert (
+        frob_error <= ftol
+    ), f"frob_error: {frob_error} (ftol {ftol}, cond(I+A) {cond_of(A):.2f})"
 
 
 @pytest.mark.parametrize("n", [16, 32, 64, 128])
@@ -256,4 +313,89 @@ def test_tri_inv_rec_unroll_bsnd(
     U = matrix_gen(C, B * S // C, N)
     _test_tri_inv_rec_unroll_bsnd(
         U, B, S, N, C, atol, rtol, ftol, is_lower, input_dtype
+    )
+
+
+# Relative Frobenius error against the condition number of I + A, worst over
+# n = 16 .. 128 on Ascend910B4. The error tracks the band rather than n, which
+# is the point of scaling to a target: at a fixed scale the difficulty depends
+# on n instead (`0.1 * rand` is cond 1.5 at n = 16 and 6.9 at n = 128), so one
+# tolerance means a different demand at every size.
+#
+#   cond(I+A)    float16    bfloat16
+#         1.2   2.0e-05     1.6e-04
+#         2.0   7.6e-05     6.1e-04
+#         4.0   1.5e-04     1.2e-03
+#         8.0   2.3e-04     1.8e-03
+#
+# The tolerances below are those measurements with ~3x headroom for the draw.
+# cond 1.2 is the band real callers land in: GDN's (I + tril(beta * K K^T))
+# measures 1.10 - 1.24 on pipeline data. cond 8 is a stress case, not a
+# workload -- it is here to be documented, not to gate a kernel on.
+@pytest.mark.parametrize("n", [16, 32, 64, 128])
+@pytest.mark.parametrize("block_dim_x", [1, 3])
+@pytest.mark.parametrize("block_dim_y", [4])
+@pytest.mark.parametrize("is_lower", [False, True])
+@pytest.mark.parametrize(
+    "cond_target,ftol,input_dtype",
+    [
+        (1.2, 5e-5, torch.float16),
+        (2.0, 2e-4, torch.float16),
+        (4.0, 4e-4, torch.float16),
+        (8.0, 6e-4, torch.float16),
+        (1.2, 4e-4, torch.bfloat16),
+        (2.0, 1.5e-3, torch.bfloat16),
+        (4.0, 3e-3, torch.bfloat16),
+        (8.0, 5e-3, torch.bfloat16),
+    ],
+)
+# pylint: disable=too-many-positional-arguments
+def test_tri_inv_rec_unroll_conditioning(
+    n: int,
+    block_dim_x: int,
+    block_dim_y: int,
+    cond_target: float,
+    ftol: float,
+    is_lower: bool,
+    input_dtype: torch.dtype,
+):
+    """Accuracy as a function of how hard the matrix is to invert."""
+    # generators in this file produce upper triangular matrices;
+    # _test_tri_inv_rec_unroll transposes them for the lower case
+    A = conditioned_tri_matrix(n, block_dim_x, block_dim_y, cond_target=cond_target)
+    _test_tri_inv_rec_unroll(
+        A, atol=ftol, rtol=0.1, ftol=ftol, is_lower=is_lower, input_dtype=input_dtype
+    )
+
+
+# The kernel's input-range contract, stated as a test rather than left implicit
+# in what the other cases happen to use. Phase 1 forms the powers A^(2^j) of
+# each doubling block and holds them in the input dtype, so an input that is
+# scaled too large comes back as NaN rather than as a large error. The powers
+# grow fastest for dense, same-sign matrices, which is what ones_tri_matrix is;
+# at the default doubling block entries of 1.0 peak at 3.4e3, inside fp16, and
+# entries of 1.5 do not.
+#
+# This is the test that fails first, and says why, if TRI_INV_DOUBLING_BLOCK is
+# raised past what the input range allows.
+@pytest.mark.parametrize("n", [16, 32, 64, 128])
+@pytest.mark.parametrize("scale", [0.1, 0.5, 1.0])
+@pytest.mark.parametrize("is_lower", [False, True])
+@pytest.mark.parametrize("input_dtype", [torch.float16, torch.bfloat16])
+def test_tri_inv_rec_unroll_dynamic_range(
+    n: int, scale: float, is_lower: bool, input_dtype: torch.dtype
+):
+    """Dense same-sign input up to 1.0 must produce finite output."""
+    A = scale * ones_tri_matrix(n, 2, 4)
+    A = A.transpose(-1, -2).contiguous() if is_lower else A.contiguous()
+    A = A.to(input_dtype)
+    actual = pto_tri_inv_rec_unroll(A.npu(), is_bsnd_format=False, is_lower=is_lower)
+    torch.npu.synchronize()
+    finite = torch.isfinite(actual.cpu().to(torch.float64))
+    assert finite.all(), (
+        f"non-finite output for dense same-sign entries of {scale} at n={n}, "
+        f"{input_dtype}: {(~finite).sum().item()} of {finite.numel()} elements. "
+        "Phase 1 holds the powers A^(2^j) of each doubling block in the input "
+        "dtype, so raising TRI_INV_DOUBLING_BLOCK narrows the input range the "
+        "kernel supports; see run_tri_inv_rec_unroll's docstring."
     )

--- a/tests/test_tri_inv_rec_unroll.py
+++ b/tests/test_tri_inv_rec_unroll.py
@@ -62,7 +62,8 @@ def block_random_triu_matrix(n, block_dim_x, block_dim_y, scale=0.1):
 
 
 def cond_of(A: torch.tensor) -> float:
-    """Condition number of I + A, the matrix the kernel actually inverts."""
+    """Maximum condition number of I + A over all 2D matrices formed on the
+    last two dimensions (-2, -1) of A."""
     n = A.shape[-1]
     M = torch.eye(n, dtype=torch.float64) + A.reshape(-1, n, n).double()
     return float(torch.linalg.cond(M).max())


### PR DESCRIPTION
Three things, happy to split them.

### 1. Accumulator reuse — on by default

Phase 1 ran a `TMATMUL(c_l0[0], a_l0[0], b_l0[0])` per level to copy X into the
accumulator through the identity. `c_l0[0]` already holds X: the previous level's
`TMATMUL_ACC` left it there, and the `TMOV` to `X_l1` only reads it, so `X @ Y`
accumulates straight onto it. One matmul per level instead of two, and X stays in
the FP32 accumulator across levels instead of round-tripping through the FP16
`X_l1` copy — which is why accuracy improves rather than degrades. The four flags
deleted with the matmul are a set/wait pair twice over, so the ledger stays
balanced.

Ascend910B4, 1024 matrices of side 128, median of 30 batches of 20 launches
synchronised per batch, with the current kernel measured at both ends of the
sample (557.9 and 557.6):

| | median | relative Frobenius vs float64 |
|---|---|---|
| current | 557.9 µs | 8.562e-05 |
| this change | 547.2 µs | **8.290e-05** |

At n = 64: 164.7 → 159.6 µs.

### 2. The doubling block, separated from the fractal size — default unchanged

`FractalSize` was doing two jobs: the fractal granularity the hardware fixes for
the input type, and the block phase 1's doubling builds up to before the unrolled
recursion takes over. They are now separate, with `DoublingBlockSize` defaulting
to `FractalSize` — **bit-identical to today** — and settable at build time via
`TRI_INV_DOUBLING_BLOCK`.

It is deliberately not raised by default, and the reason is worth recording.
Phase 1 forms the powers `A^(2^j)` inside a block, and they have to stay in the
input type's range. For the strictly triangular matrix of ones, which this suite
tests at exact tolerance:

| doubling block | largest intermediate | largest safe dense entry | fp16 (max 65504) |
|---|---|---|---|
| 16 | 3.4e3 | 1.45 | fits |
| 32 | 1.6e8 | 0.62 | **overflows → NaN** |
| 64 | 4.7e17 | 0.27 | **overflows → NaN** |
| 128 | 6.0e36 | 0.13 | **overflows → NaN** |

I found this the hard way: with the block at 32 by default, 216 cases here and
all 108 in `test_tri_inv_rec_unroll_variable_sequence_lengths` return NaN, while
the current kernel passes all of them.

The requirement exists at the current block size too, it is just not written
down anywhere — at block 16 an all-ones input peaks at 3.4e3, 19x inside fp16,
and entries of 1.5 already overflow. `run_tri_inv_rec_unroll`'s docstring now
says so, since a caller has no way to discover it otherwise: input outside the
range comes back as NaN rather than as a large error.

A caller that knows its input is inside that range can take the speedup:
megagdn-pto builds its GDN kernels at 128, where A is a decayed, beta-scaled
`K Kᵀ` whose largest entry measures 0.243 and whose powers shrink rather than
grow, and gets **512.1 → 418.0 µs at frob 2.330e-07 against 3.642e-06** —
faster *and* more accurate, because fewer levels mean fewer fp16 round trips
between them. On a badly scaled input the trade runs the other way, which is
what the table above is about.

`CopyDiagonalBlocksL1ToL0` replaces `CopyDiagonalFractalsL1ToL0` at the phase-1
entry: both parities of the existing odd/even block copy are exactly the diagonal
blocks, and at `block_size == MatrixSize` a single `TMOV` replaces the
`(MatrixSize/FractalSize)^2` `TEXTRACT`s the fractal path would issue.
`CopyDiagonalFractalsL1ToL0` then has no callers left in `csrc/` and is removed —
happy to keep it if you would rather not lose the helper.

### 3. The test gains a conditioning dimension

`random_tri_matrix` builds `scale * rand`, so every entry is positive and the
powers of A accumulate constructively. How hard the inverse is depends on
`scale`, and at a fixed scale it depends on `n` as well:

| | cond(I+A) at n = 16 / 32 / 64 / 128 |
|---|---|
| `0.1 * rand`, as the test uses it | 1.5 / 2.2 / 3.6 / **6.9** |
| scale 0.02 / 0.05 / 0.1 / 0.2, at n = 128 | 1.8 / 3.4 / 6.9 / 19.8 |
| the same scale with mixed signs, n = 128 | 3.5 |

`ftol` is one constant across all of that, so the test demands something
different at every size, and what it demands at n = 128 is set by the constant
`0.1`. For reference, the matrices real callers produce — GDN's
`(I + tril(beta * K Kᵀ))` — measure cond(I+A) of 1.10 to 1.24.

`conditioned_tri_matrix` scales to a target instead, so the difficulty is
explicit and travels with the band rather than with `n`. Tolerances come from
measurement (worst over n = 16…128, with ~3x headroom for the draw):

| cond(I+A) | float16 | bfloat16 |
|---|---|---|
| 1.2 | 2.0e-05 | 1.6e-04 |
| 2.0 | 7.6e-05 | 6.1e-04 |
| 4.0 | 1.5e-04 | 1.2e-03 |
| 8.0 | 2.3e-04 | 1.8e-03 |

cond 1.2 is the band callers land in; cond 8 is a stress case, documented rather
than load-bearing. The scale is bisected once per (n, target) and memoised, so
the 128 new cases run in 14 s.

Two smaller fixes in the same file:

- `block_random_triu_matrix` drew one 16×16 block and copied it into every
  diagonal block of every batch entry, so `block_dim_x` and `block_dim_y` added
  no numerical coverage — every matrix in the tensor was identical. It now draws
  independently per block.
- The assertions report `cond(I + A)`, computed only when they fire, so a failure
  says how hard the matrix was and not just the error.

### Test results

Ascend910B4, all green:

| suite | result |
|---|---|
| `test_tri_inv_rec_unroll` | 1424 passed — 1248 existing, 128 conditioning, 48 dynamic range |
| `test_tri_inv_rec_unroll_variable_sequence_lengths` | 108 passed |
| `test_tri_inv_trick` | 160 passed |
| `test_tri_inv_ns` | 400 passed |
| `test_tri_inv_col_sweep` | 104 passed |

`pre-commit run --files` passes on both changed files.

### One thing noticed in passing, not fixed here

`tests/test_tri_inv_rec_unroll_variable_sequence_lengths.py` line 92 overwrites
the `K Kᵀ` matrix it just built with `torch.tril(torch.ones(...))`, so the
`random` parametrization tests the all-ones matrix, the same as the `ones` one.
Left alone deliberately — fixing it changes what that suite covers, which should
be its own change.
