### PR TITLE
examples: add mxfp4_matmul_a5

### DIFF
--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -55,42 +55,42 @@ of which took the median of up to 100 interleaved reps.
 
 | K=N | ours / vendor | ours wins | ours peak | vendor peak | ours as % of vendor peak |
 |---|--:|--:|--:|--:|--:|
-| 512 | **1.86x** | 16/16 | 378 TF/s | 274 TF/s | 138% |
-| 1024 | **1.81x** | 16/16 | 807 | 732 | 110% |
-| 2048 | **1.68x** | 14/16 | 1244 | 1332 | 93% |
-| 3072 | **1.46x** | 14/16 | 1399 | 1513 | 92% |
-| 4096 | **1.41x** | 13/16 | 1490 | 1590 | 94% |
-| 6144 | **1.18x** | 12/16 | 1536 | 1662 | 92% |
-| 8192 | **1.03x** | 12/16 | 1555 | 1686 | 92% |
-| 12288 | 0.88x | 1/16 | 1591 | 1698 | 94% |
-| 16384 | 0.79x | 1/16 | 1607 | 1712 | 94% |
+| 512 | **1.77x** | 16/16 | 378 TF/s | 280 TF/s | 135% |
+| 1024 | **1.71x** | 16/16 | 808 | 761 | 106% |
+| 2048 | **1.67x** | 14/16 | 1236 | 1316 | 94% |
+| 3072 | **1.48x** | 14/16 | 1399 | 1514 | 92% |
+| 4096 | **1.42x** | 13/16 | 1488 | 1590 | 94% |
+| 6144 | **1.19x** | 13/16 | 1536 | 1662 | 92% |
+| 8192 | **1.05x** | 12/16 | 1555 | 1685 | 92% |
+| 12288 | 0.89x | 1/16 | 1590 | 1698 | 94% |
+| 16384 | 0.80x | 1/16 | 1607 | 1712 | 94% |
 
-The shape of it is one mechanism. The vendor kernel reaches 1686–1712 TF/s,
+The shape of it is one mechanism. The vendor kernel reaches 1685–1712 TF/s,
 which is the MXFP4 cube ceiling (1692 TF/s from the L0 format ratio), so at
 large K=N there is nothing left to win and this kernel's 92–94% of that peak
 is the whole gap. At the other end the vendor is on a dispatch floor of about
-38 us — at K=N=512 it measures 38.0 us at M=1 and 39.6 us at M=1024, flat
+38 us — at K=N=512 it measures 39.3 us at M=1 and 37.7 us at M=1024, flat
 across three decades of work — and there it loses to a plain bf16 GEMM:
 
 | K=N | ours vs bf16 | vendor vs bf16 |
 |---|--:|--:|
-| 512 | 1.35x | 0.72x |
-| 1024 | 1.35x | 0.75x |
-| 2048 | 1.59x | 0.94x |
-| 4096 | 2.21x | 1.49x |
-| 8192 | 2.16x | 2.05x |
-| 16384 | 2.28x | 2.92x |
+| 512 | 1.29x | 0.71x |
+| 1024 | 1.30x | 0.75x |
+| 2048 | 1.58x | 0.94x |
+| 4096 | 2.19x | 1.47x |
+| 8192 | 2.15x | 2.02x |
+| 16384 | 2.28x | 2.90x |
 
 So this kernel beats bf16 at every width measured, and the vendor does not
 below K=N=3072.
 
 M matters as much as K=N, and in the same direction: more work per launch helps
-the vendor. At K=N=4096 this kernel runs 1.45x the vendor at M=16 and 0.94x at
+the vendor. At K=N=4096 this kernel runs 1.44x the vendor at M=16 and 0.94x at
 M=32768. The M at which it first falls behind drops sharply as K=N grows:
 
 | K=N | 512 | 1024 | 2048 | 3072 | 4096 | 6144 | 8192 | 12288 |
 |---|--:|--:|--:|--:|--:|--:|--:|--:|
-| first losing M | never | never | 16384 | 16384 | 8192 | 4096 | 4096 | 1 |
+| first losing M | never | never | 16384 | 16384 | 8192 | 8192 | 4096 | 1 |
 
 `ours_vs_vendor` for all 144 cells is in the CSV.
 

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -180,15 +180,19 @@ L1 is 512 KB, and that bounds the slab. Two `K_L1=512` sets fit in 272 KB; two
 
 ```
 error: static assertion failed due to requirement
-'L1_SETS * (a_l1_bytes + b_l1_bytes + BASE_M * SK_L1 + SK_L1 * BASE_N)
- <= 512U * 1024U': L1 sets must fit the 512 KB L1
+'L1_SETS * l1_set_bytes + scale_bytes <= 512U * 1024U': the data sets plus
+the whole-K scale pair must fit the 512 KB L1; reduce L1_SETS or K
 ```
+
+`-DMXMM_K_L1=1024 -DMXMM_L1_SETS=1` does build, at the cost of the load/extract
+overlap.
 
 Tunable through `-D`, each with a `static_assert` that fires per instantiation
 so an unsupported combination cannot be built: `MXMM_BASE_M`, `MXMM_BASE_N`,
-`MXMM_K_L1`, `MXMM_L1_SETS`, `MXMM_SWIZZLE`, `MXMM_TINY_M`, and the ablation
-switches `MXMM_NO_LOAD`, `MXMM_NO_EXTRACT`, `MXMM_NO_MATMUL`, `MXMM_NO_STORE`,
-`MXMM_NO_SYNC`.
+`MXMM_K_L1`, `MXMM_L1_SETS` (1 or 2), `MXMM_SWIZZLE`, `MXMM_TINY_M`, and the
+build shape `MXMM_TEST_K` / `MXMM_TEST_N`. Every one of them produces correct
+output; the timing-only ablation switches used to attribute the bottleneck have
+been removed.
 
 ## What would close the gap
 
@@ -233,8 +237,9 @@ remaining distance is known rather than mysterious:
   from 1.87x to 1.29x even at K=N=512, which points at the tile-selection rule
   rather than at the inner loop.
 
-A third L1 set is not one of them. `MXMM_L1_SETS=3` builds to a genuinely
-different object and measures 1.005x, 0.999x and 0.989x at (M=4096, K=N=4096),
-(4096, 8192) and (1024, 2048) — 1.00x against spreads of 2–23%. Deeper
-buffering cannot help a stage bound by per-descriptor issue cost rather than by
-bandwidth.
+A third L1 set is not one of them, and is no longer in the source. It built to
+a genuinely different object and measured 1.005x, 0.999x and 0.989x at
+(M=4096, K=N=4096), (4096, 8192) and (1024, 2048) — 1.00x against spreads of
+2–23%. Deeper buffering cannot help a stage bound by per-descriptor issue cost
+rather than by bandwidth, so the set was removed and `MXMM_L1_SETS` now accepts
+1 or 2.

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -213,9 +213,20 @@ remaining distance is known rather than mysterious:
   gain shows only at K=N=8192 and is 1.01x at 4096, so at 4096 the kernel is
   bound by something else.
 * **Double-buffering the accumulator**, so the cube does not idle while a tile
-  drains. One accumulator at the current tile is `BASE_M x BASE_N` fp32, which
-  is 128 KB exactly; a second doubles that, so this is bounded by L0C capacity
-  and may need a narrower N tile. Not measured here.
+  drains — available at the 128-row tile and impossible at the 256-row one.
+  A5 L0C is 256 KB (`PTO_L0C_SIZE_BYTES` under `PTO_NPU_ARCH_A5`), and PTO
+  enforces it directly:
+
+  ```
+  constexpr size_t accBytes = TileRes::Rows * TileRes::Cols * sizeof(CType);
+  static_assert(accBytes <= PTO_L0C_SIZE_BYTES,
+                "TMatmulMX:accumulator (Rows*Cols*sizeof(out)) exceeds L0C capacity.");
+  ```
+
+  The BIG tile's accumulator is 256x256 fp32 = 256 KB, which is the entire
+  L0C, so a second one cannot exist there. The SMALL tile's is 128x256 fp32 =
+  128 KB, where two fit exactly. An `Acc<float, 256, 512>` needs 512 KB and is
+  refused at compile time by that assert.
 * **The large-M column.** The ratio decays monotonically with M at every width,
   from 1.87x to 1.29x even at K=N=512, which points at the tile-selection rule
   rather than at the inner loop.

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -107,15 +107,17 @@ Two asymmetries, both stated rather than corrected:
   flat in size. At K=N=512 it is a few percent of the vendor arm and it
   flatters this kernel; there is no way to remove it through the public API.
 * Both arms have their dtype views and transposes hoisted out of the timed
-  region. Leaving the vendor's four `view`/`t`/`transpose` calls inside the
-  loop, which an earlier harness did, cost that arm 10–35% at small shapes and
-  moved `ours_vs_vendor` at M=16 K=N=1024 from 1.81x to 2.29x. Neither arm
-  should be charged for per-call metadata bookkeeping.
+  region. Leaving the vendor's six `view`/`t`/`transpose` calls inside the loop,
+  which an earlier harness did, costs that arm a flat **8.5–10.1 us per call**
+  — measured by A/B of the two constructions in one process, and flat across
+  shapes because it is host-side work. That is 10–35% at small shapes and moved
+  `ours_vs_vendor` at M=16 K=N=1024 from 1.81x to 2.29x. Neither arm should be
+  charged for per-call metadata bookkeeping.
 
-The same trap applies to this kernel's own wrapper: `load_matmul` re-derives
-the tile plan per call, which is three ctypes round-trips into the `.so` and
-measurable when the whole matmul is 20 us. Use `matmul.prepare(...)` for
-anything timed or hot, which is what `benchmark.py` does.
+This kernel's own wrapper has the identical trap in reverse: `load_matmul`
+re-derives the tile plan per call, three ctypes round-trips into the `.so`,
+which read 1.30x at that same shape. Use `matmul.prepare(...)` for anything
+timed or hot, as `benchmark.py` does.
 
 ### Method
 

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -180,19 +180,25 @@ L1 is 512 KB, and that bounds the slab. Two `K_L1=512` sets fit in 272 KB; two
 
 ```
 error: static assertion failed due to requirement
-'L1_SETS * l1_set_bytes + scale_bytes <= 512U * 1024U': the data sets plus
-the whole-K scale pair must fit the 512 KB L1; reduce L1_SETS or K
+'L1_SETS * kSlabBytes + kScaleBytes <= L1_BYTES': The data sets plus the
+whole-K scale pair must fit L1; reduce L1_SETS or K.
 ```
 
 `-DMXMM_K_L1=1024 -DMXMM_L1_SETS=1` does build, at the cost of the load/extract
 overlap.
 
-Tunable through `-D`, each with a `static_assert` that fires per instantiation
-so an unsupported combination cannot be built: `MXMM_BASE_M`, `MXMM_BASE_N`,
-`MXMM_K_L1`, `MXMM_L1_SETS` (1 or 2), `MXMM_SWIZZLE`, `MXMM_TINY_M`, and the
-build shape `MXMM_TEST_K` / `MXMM_TEST_N`. Every one of them produces correct
-output; the timing-only ablation switches used to attribute the bottleneck have
-been removed.
+Tunable through `-D`: `MXMM_BASE_M`, `MXMM_BASE_N`, `MXMM_K_L1`,
+`MXMM_L1_SETS` (1 or 2), `MXMM_SWIZZLE`, and the build shape `MXMM_TEST_K` /
+`MXMM_TEST_N`. Every one produces correct output; the timing-only ablation
+switches used to attribute the bottleneck have been removed.
+
+The derived sizes and their `static_assert`s live in one
+`TileShape<M_MAX, K, N, TILE_M, TILE_N>` struct, so an unsupported combination
+fails to instantiate rather than faulting on device. The launcher instantiates
+it three times, once per output tile.
+
+`MXMM_TINY_M` is gone. Its value was `M_ALIGN`, the 16-row floor TMATMUL_MX
+imposes, so it could not go lower and above it was simply another tile size.
 
 ## What would close the gap
 

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -1,8 +1,14 @@
 # mxfp4_matmul_a5 — MXFP4 x MXFP4 matmul on the A5 cube
 
-`y = A @ B` with **both** operands MXFP4 block-32, accumulated in fp32 and
-stored bf16, on the Ascend 950 / A5 (`dav-c310`) cube's native microscaled
-path. JIT-compiled with `bisheng` and driven through `ctypes`.
+A full `y = A @ B` over the whole `(M, K) x (K, N)`, with **both** operands
+MXFP4 -- E2M1 nibbles carrying one E8M0 scale per 32 elements along K --
+accumulated in fp32 and stored bf16, on the Ascend 950 / A5 (`dav-c310`)
+cube's native microscaled path. JIT-compiled with `bisheng` and driven
+through `ctypes`.
+
+The 32 is MXFP4's scale granularity and nothing else: the matmul itself is
+not blocked. Do not read it as the block-32 rotation that
+`fused_hadamard_quant_b32_a5` names.
 
 ```
 A: (M, K)  E2M1 nibbles, two per byte, + one E8M0 scale per 32 along K
@@ -11,7 +17,7 @@ y: (M, N)  bf16
 ```
 
 A5 has a microscaled matmul in hardware, `TMATMUL_MX`, whose semantics are
-MXFP4 block-32 exactly. From PTO's own CPU reference (`pto/cpu/TMatmul.hpp`):
+MXFP4's exactly. From PTO's own CPU reference (`pto/cpu/TMatmul.hpp`):
 
 ```
 acc += a(i, k) * b(k, j) * aScale(i, k / 32) * bScale(k / 32, j)

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -188,8 +188,9 @@ whole-K scale pair must fit L1; reduce L1_SETS or K.
 overlap.
 
 Tunable through `-D`: `MXMM_BASE_M`, `MXMM_BASE_N`, `MXMM_K_L1`,
-`MXMM_L1_SETS` (1 or 2), `MXMM_SWIZZLE`, and the build shape `MXMM_TEST_K` /
-`MXMM_TEST_N`. Every one produces correct output; the timing-only ablation
+`MXMM_L1_SETS` (1 or 2), `MXMM_SWIZZLE`, the build shape `MXMM_TEST_K` /
+`MXMM_TEST_N`, and `MXMM_TARGET_BLOCKS`, which `jit_util` sets from the
+device's `cube_core_num` and which is part of the build cache key. Every one produces correct output; the timing-only ablation
 switches used to attribute the bottleneck have been removed.
 
 The derived sizes and their `static_assert`s live in one
@@ -199,6 +200,30 @@ it three times, once per output tile.
 
 `MXMM_TINY_M` is gone. Its value was `M_ALIGN`, the 16-row floor TMATMUL_MX
 imposes, so it could not go lower and above it was simply another tile size.
+
+### One block per core, and a tile rule that knows it
+
+`cube_core_num` is **32** on an Ascend950PR_9589, and two constants assumed
+64: the launcher capped `block_dim` at 64, so every core ran two blocks, and
+`TARGET_BLOCKS` — the count `pickMTile` wants filled before it will use the
+256-row tile — was 64, so the tall tile was withheld from shapes that already
+filled the machine.
+
+Three arms, interleaved with a cold L2, medians of three processes:
+
+| K=N, M | 64 blocks, target 64 | 32 blocks, target 64 | 32 blocks, target 32 | tile, last arm |
+|---|--:|--:|--:|---|
+| 2048, 1024 | 1.00x | 1.03x | **1.11x** | 128x256 -> 256x256 |
+| 4096, 512 | 1.00x | 1.03x | **1.11x** | 128x256 -> 256x256 |
+| 8192, 256 | 1.00x | 1.01x | **1.06x** | 128x256 -> 256x256 |
+| 4096, 1024 | 1.00x | 1.05x | 1.05x | 256x256 throughout |
+| 8192, 512 | 1.00x | 1.03x | 1.03x | 256x256 throughout |
+| 8192, 8192 | 1.00x | 1.00x | 0.99x | 256x256 throughout |
+
+Oversubscribing by 2:1 cost 1-5%, and the tile threshold cost a further 5-6%
+in the band where it changed the branch. Both are fixed by reading the core
+count off the device. Note the large-M control is flat, so this is not the
+large-M decay below.
 
 ## What would close the gap
 

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -1,0 +1,227 @@
+# mxfp4_matmul_a5 — MXFP4 x MXFP4 matmul on the A5 cube
+
+`y = A @ B` with **both** operands MXFP4 block-32, accumulated in fp32 and
+stored bf16, on the Ascend 950 / A5 (`dav-c310`) cube's native microscaled
+path. JIT-compiled with `bisheng` and driven through `ctypes`.
+
+```
+A: (M, K)  E2M1 nibbles, two per byte, + one E8M0 scale per 32 along K
+B: (K, N)  the same, stored DN
+y: (M, N)  bf16
+```
+
+A5 has a microscaled matmul in hardware, `TMATMUL_MX`, whose semantics are
+MXFP4 block-32 exactly. From PTO's own CPU reference (`pto/cpu/TMatmul.hpp`):
+
+```
+acc += a(i, k) * b(k, j) * aScale(i, k / 32) * bScale(k / 32, j)
+```
+
+The scaling is in the datapath, so this is not a dequantize-and-matmul. And
+`aScale` is `(M, K/32)`, which is what `mxfp4_quant_a5` already writes, so the
+two kernels meet with no repacking.
+
+## Running it
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh   # 9.1.0 or newer
+python -m pytest test_mxfp4_matmul_a5.py -q          # 20 tests
+./run_benchmark.sh --out results.csv                 # the full grid, ~4 min
+./run_benchmark.sh --kn 4096 --m 16 1024 16384       # one column
+```
+
+K and N are compile-time template arguments, because the GM strides are
+per-layer constants and static addressing is what keeps the inner loop tight.
+One `.so` therefore serves one `(K, N)` pair and the build cache is keyed on
+both. M is a runtime argument.
+
+**K must be a whole L1 slab**, so a multiple of 512 at the default `MXMM_K_L1`,
+and N a multiple of 64 for fp4. The default build shape is 512x512 for that
+reason. `jit_util_mxfp4_matmul_a5.py` rejects anything else before launching,
+which matters more here than usual: the kernel cannot report an error from the
+device, so handed a shape it was not built for its launcher returns having
+written nothing and the caller gets an untouched buffer back.
+
+M is rounded **up** to whole tiles. The result is `m_round(m)` rows tall, not
+`m`, and rows past `m` hold whatever the padded operands produced. Read the
+height off the returned tensor.
+
+## Measured against torch_npu
+
+`torch_npu`'s `npu_quant_matmul` reaches the same hardware path, so it is the
+arm that matters. Ratios below are **ours / vendor**, above 1 meaning this
+kernel is faster. Each figure is the median of three separate processes, each
+of which took the median of up to 100 interleaved reps.
+
+| K=N | ours / vendor | ours wins | ours peak | vendor peak | ours as % of vendor peak |
+|---|--:|--:|--:|--:|--:|
+| 512 | **1.83x** | 16/16 | 357 TF/s | 282 TF/s | 127% |
+| 1024 | **1.75x** | 16/16 | 770 | 750 | 103% |
+| 2048 | **1.63x** | 14/16 | 1196 | 1314 | 91% |
+| 3072 | **1.45x** | 13/16 | 1369 | 1514 | 90% |
+| 4096 | **1.31x** | 12/16 | 1398 | 1591 | 88% |
+| 6144 | 1.06x | 9/16 | 1362 | 1666 | 82% |
+| 8192 | 0.99x | 6/16 | 1235 | 1687 | 73% |
+| 12288 | 0.74x | 0/16 | 1409 | 1699 | 83% |
+| 16384 | 0.75x | 0/16 | 1408 | 1713 | 82% |
+
+The shape of it is one mechanism. The vendor kernel reaches 1687–1713 TF/s,
+which is the MXFP4 cube ceiling (1692 TF/s from the L0 format ratio), so at
+large K=N there is nothing left to win and this kernel's 82–88% of that ceiling
+is the whole gap. At the other end the vendor is on a dispatch floor of about
+38 us — at K=N=512 it measures 38.1 us at M=1 and 38.4 us at M=1024, flat
+across three decades of work — and there it loses to a plain bf16 GEMM:
+
+| K=N | ours vs bf16 | vendor vs bf16 |
+|---|--:|--:|
+| 512 | 1.34x | 0.74x |
+| 1024 | 1.39x | 0.78x |
+| 2048 | 1.57x | 0.95x |
+| 4096 | 2.06x | 1.53x |
+| 8192 | 1.97x | 2.06x |
+| 16384 | 2.12x | 2.90x |
+
+So this kernel beats bf16 at every width measured, and the vendor does not
+below K=N=3072.
+
+M matters as much as K=N, and in the same direction: more work per launch helps
+the vendor. At K=N=4096 this kernel runs 1.37x the vendor at M=16 and 0.88x at
+M=32768. The M at which it first falls behind drops sharply as K=N grows:
+
+| K=N | 512 | 1024 | 2048 | 3072 | 4096 | 6144 | 8192 | 12288 |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|
+| first losing M | never | never | 16384 | 8192 | 4096 | 512 | 2 | 1 |
+
+`ours_vs_vendor` for all 144 cells is in the CSV.
+
+### What is not in these numbers
+
+Both MXFP4 arms are timed on **pre-quantized operands**. Quantization is a
+separate kernel (`mxfp4_quant_a5`) and is in neither figure, so this is matmul
+against matmul.
+
+Two asymmetries, both stated rather than corrected:
+
+* `npu_quant_matmul` has no `out=` and allocates its result on every call.
+  Measured separately, that allocation is 2.2 us against a caching allocator,
+  flat in size. At K=N=512 it is a few percent of the vendor arm and it
+  flatters this kernel; there is no way to remove it through the public API.
+* Both arms have their dtype views and transposes hoisted out of the timed
+  region. Leaving the vendor's four `view`/`t`/`transpose` calls inside the
+  loop, which an earlier harness did, cost that arm 10–35% at small shapes and
+  moved `ours_vs_vendor` at M=16 K=N=1024 from 1.81x to 2.29x. Neither arm
+  should be charged for per-call metadata bookkeeping.
+
+The same trap applies to this kernel's own wrapper: `load_matmul` re-derives
+the tile plan per call, which is three ctypes round-trips into the `.so` and
+measurable when the whole matmul is 20 us. Use `matmul.prepare(...)` for
+anything timed or hot, which is what `benchmark.py` does.
+
+### Method
+
+Every part of this is load-bearing on a shared box.
+
+* **L2 is evicted before every timed launch**, outside the timer, by copying a
+  buffer twice the size of L2. That models a forward pass, where a layer's
+  weights are touched once per token and the model dwarfs the 128 MB L2. A
+  back-to-back loop leaves the weights resident and favours whichever format is
+  smaller.
+* **Arms are interleaved in one measurement window**, order rotated per rep, so
+  a drift in machine load cannot land on one arm.
+* **Wall clock over a synchronised launch.** The NPU event timer has reported
+  82, 28, 7.6 and 24 us for one and the same launch.
+* **A device-to-device copy reference per run**, printed and stored in the CSV.
+  It held at 1414–1427 GB/s across the three runs behind the table above, which
+  is this part's normal figure; a collapse means another tenant and the ratios
+  from that run are not comparable.
+* **Three processes, not one.** The vendor op is bimodal per process — it picks
+  a kernel at process start — so a single process can settle a near-tie the
+  wrong way. Across the three, 4 of 144 shapes disagreed on the sign, all of
+  them in the 0.99–1.05 band, and the worst run-to-run disagreement was 11.7%.
+
+Absolute microseconds and TFLOP/s here are from one box, an `Ascend950PR_9589`
+whose HBM runs at about 1.6 TB/s. Ratios between arms measured in the same run
+carry over; absolute throughput does not, and a 950DT part will not match these
+figures.
+
+## Structure
+
+The layout is asymmetric and none of it is guessable from the type names.
+Getting any one of these wrong produces a plausible-looking wrong answer rather
+than a failure, which is why each is called out at its declaration in the
+source:
+
+| | data | scale |
+|---|---|---|
+| A | `Layout::ND`, row-major `(M, K)` | `MX_A_ND`, row-major `(M, K/32)` |
+| B | `Layout::DN`, **not** ND | `MX_B_DN`, **not** `MX_B_ND` |
+
+B being DN costs nothing, since weights are prepared offline. Three more traps
+in the same class: GM strides come from a `BaseShape2D` of the **whole matrix**,
+not of the tile; fp4 pointer arithmetic is in **bytes**, so a K-element step is
+`K >> 1`; and scale tensors are **paired** along K, which is the real reason K
+must be a multiple of 64 rather than 32. The scale tiles also bind by address —
+the hardware reads them at `GetScaleAddr(operand.data())`, a `>> 4` of the
+operand's L0 address — so `TASSIGN`ing them anywhere else compiles and
+multiplies by whatever happens to be there.
+
+The performance structure is the **L1 K slab held separate from the cube's
+`BASE_K`**. A GM->L1 copy of a `(BASE_M, K_L1)` fp4 tile moves `K_L1/2`
+contiguous bytes per row, so tying the slab to `BASE_K=256` made every row copy
+128 bytes, a quarter of a 512-byte line. Widening the slab to 512 while the
+cube still consumes 256 from an inner sub-tile loop moves identical bytes and
+was worth 1.35–1.57x.
+
+L1 is 512 KB, and that bounds the slab. Two `K_L1=512` sets fit in 272 KB; two
+`K_L1=1024` sets would need 544 KB, and `-DMXMM_K_L1=1024` is refused at
+**compile** time rather than faulting on device:
+
+```
+error: static assertion failed due to requirement
+'L1_SETS * (a_l1_bytes + b_l1_bytes + BASE_M * SK_L1 + SK_L1 * BASE_N)
+ <= 512U * 1024U': L1 sets must fit the 512 KB L1
+```
+
+Tunable through `-D`, each with a `static_assert` that fires per instantiation
+so an unsupported combination cannot be built: `MXMM_BASE_M`, `MXMM_BASE_N`,
+`MXMM_K_L1`, `MXMM_L1_SETS`, `MXMM_SWIZZLE`, `MXMM_TINY_M`, and the ablation
+switches `MXMM_NO_LOAD`, `MXMM_NO_EXTRACT`, `MXMM_NO_MATMUL`, `MXMM_NO_STORE`,
+`MXMM_NO_SYNC`.
+
+## What would close the gap
+
+This kernel is at 82–88% of the cube ceiling where the vendor is at it, and the
+remaining distance is known rather than mysterious:
+
+* **`K_L1=1024`, for full 512-byte bursts — measured, and it does not pay.**
+  The wider slab is real: inside a configuration narrow enough to hold it, it
+  is worth 1.25x at K=N=8192 (555.9 us against 693.5). But two `K_L1=1024`
+  sets at the 256x256 output tile need 544 KB against a 512 KB L1, so
+  something has to give, and everything that gives costs more than 1.25x.
+  Dropping the 256-wide N tile costs 1.35x on its own, which nets out below
+  the default at every shape tried:
+
+  | M, K=N | default, `K_L1`=512 N=256 | `K_L1`=1024 N=128 | `K_L1`=512 N=128 |
+  |---|--:|--:|--:|
+  | 4096, 4096 | 122.8 us | 164.2 (0.75x) | 166.1 (0.74x) |
+  | 4096, 8192 | 477.3 us | 555.9 (0.86x) | 693.5 (0.69x) |
+  | 16384, 8192 | 1781.7 us | 2127.3 (0.84x) | 2623.0 (0.68x) |
+
+  So the lever is not the slab width itself but **L1 capacity**: reach
+  `K_L1=1024` while keeping a 256x256 tile, by single-buffering one operand or
+  otherwise cutting a set, and the 1.25x is available. Note also that the slab
+  gain shows only at K=N=8192 and is 1.01x at 4096, so at 4096 the kernel is
+  bound by something else.
+* **Double-buffering the accumulator**, so the cube does not idle while a tile
+  drains. One accumulator at the current tile is `BASE_M x BASE_N` fp32, which
+  is 128 KB exactly; a second doubles that, so this is bounded by L0C capacity
+  and may need a narrower N tile. Not measured here.
+* **The large-M column.** The ratio decays monotonically with M at every width,
+  from 1.87x to 1.29x even at K=N=512, which points at the tile-selection rule
+  rather than at the inner loop.
+
+A third L1 set is not one of them. `MXMM_L1_SETS=3` builds to a genuinely
+different object and measures 1.005x, 0.999x and 0.989x at (M=4096, K=N=4096),
+(4096, 8192) and (1024, 2048) — 1.00x against spreads of 2–23%. Deeper
+buffering cannot help a stage bound by per-descriptor issue cost rather than by
+bandwidth.

--- a/examples/jit_cpp/mxfp4_matmul_a5/README.md
+++ b/examples/jit_cpp/mxfp4_matmul_a5/README.md
@@ -55,42 +55,42 @@ of which took the median of up to 100 interleaved reps.
 
 | K=N | ours / vendor | ours wins | ours peak | vendor peak | ours as % of vendor peak |
 |---|--:|--:|--:|--:|--:|
-| 512 | **1.83x** | 16/16 | 357 TF/s | 282 TF/s | 127% |
-| 1024 | **1.75x** | 16/16 | 770 | 750 | 103% |
-| 2048 | **1.63x** | 14/16 | 1196 | 1314 | 91% |
-| 3072 | **1.45x** | 13/16 | 1369 | 1514 | 90% |
-| 4096 | **1.31x** | 12/16 | 1398 | 1591 | 88% |
-| 6144 | 1.06x | 9/16 | 1362 | 1666 | 82% |
-| 8192 | 0.99x | 6/16 | 1235 | 1687 | 73% |
-| 12288 | 0.74x | 0/16 | 1409 | 1699 | 83% |
-| 16384 | 0.75x | 0/16 | 1408 | 1713 | 82% |
+| 512 | **1.86x** | 16/16 | 378 TF/s | 274 TF/s | 138% |
+| 1024 | **1.81x** | 16/16 | 807 | 732 | 110% |
+| 2048 | **1.68x** | 14/16 | 1244 | 1332 | 93% |
+| 3072 | **1.46x** | 14/16 | 1399 | 1513 | 92% |
+| 4096 | **1.41x** | 13/16 | 1490 | 1590 | 94% |
+| 6144 | **1.18x** | 12/16 | 1536 | 1662 | 92% |
+| 8192 | **1.03x** | 12/16 | 1555 | 1686 | 92% |
+| 12288 | 0.88x | 1/16 | 1591 | 1698 | 94% |
+| 16384 | 0.79x | 1/16 | 1607 | 1712 | 94% |
 
-The shape of it is one mechanism. The vendor kernel reaches 1687–1713 TF/s,
+The shape of it is one mechanism. The vendor kernel reaches 1686–1712 TF/s,
 which is the MXFP4 cube ceiling (1692 TF/s from the L0 format ratio), so at
-large K=N there is nothing left to win and this kernel's 82–88% of that ceiling
+large K=N there is nothing left to win and this kernel's 92–94% of that peak
 is the whole gap. At the other end the vendor is on a dispatch floor of about
-38 us — at K=N=512 it measures 38.1 us at M=1 and 38.4 us at M=1024, flat
+38 us — at K=N=512 it measures 38.0 us at M=1 and 39.6 us at M=1024, flat
 across three decades of work — and there it loses to a plain bf16 GEMM:
 
 | K=N | ours vs bf16 | vendor vs bf16 |
 |---|--:|--:|
-| 512 | 1.34x | 0.74x |
-| 1024 | 1.39x | 0.78x |
-| 2048 | 1.57x | 0.95x |
-| 4096 | 2.06x | 1.53x |
-| 8192 | 1.97x | 2.06x |
-| 16384 | 2.12x | 2.90x |
+| 512 | 1.35x | 0.72x |
+| 1024 | 1.35x | 0.75x |
+| 2048 | 1.59x | 0.94x |
+| 4096 | 2.21x | 1.49x |
+| 8192 | 2.16x | 2.05x |
+| 16384 | 2.28x | 2.92x |
 
 So this kernel beats bf16 at every width measured, and the vendor does not
 below K=N=3072.
 
 M matters as much as K=N, and in the same direction: more work per launch helps
-the vendor. At K=N=4096 this kernel runs 1.37x the vendor at M=16 and 0.88x at
+the vendor. At K=N=4096 this kernel runs 1.45x the vendor at M=16 and 0.94x at
 M=32768. The M at which it first falls behind drops sharply as K=N grows:
 
 | K=N | 512 | 1024 | 2048 | 3072 | 4096 | 6144 | 8192 | 12288 |
 |---|--:|--:|--:|--:|--:|--:|--:|--:|
-| first losing M | never | never | 16384 | 8192 | 4096 | 512 | 2 | 1 |
+| first losing M | never | never | 16384 | 16384 | 8192 | 4096 | 4096 | 1 |
 
 `ours_vs_vendor` for all 144 cells is in the CSV.
 
@@ -227,7 +227,7 @@ large-M decay below.
 
 ## What would close the gap
 
-This kernel is at 82–88% of the cube ceiling where the vendor is at it, and the
+This kernel is at 88–95% of the cube ceiling where the vendor is at it, and the
 remaining distance is known rather than mysterious:
 
 * **`K_L1=1024`, for full 512-byte bursts — measured, and it does not pay.**

--- a/examples/jit_cpp/mxfp4_matmul_a5/benchmark.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/benchmark.py
@@ -1,0 +1,299 @@
+"""Three arms over an (M, K=N) grid: bf16 matmul, the vendor MXFP4 matmul, ours.
+
+Method, and every part of it is load-bearing on a shared box:
+
+* **L2 is evicted before every timed launch**, outside the timer, by copying a
+  buffer twice the size of L2. That models a forward pass, where a layer's
+  weights are touched once per token and the model dwarfs the 128 MB L2. A
+  back-to-back loop instead leaves the weights resident and quietly favours
+  whichever format is smaller.
+* **Arms are interleaved inside one measurement window**, order rotated per
+  rep. Measuring them in sequential blocks lets a drift in machine load land
+  entirely on one arm; a 9% drift once faked a 4% difference that was really
+  8%.
+* **The wall clock over a synchronised launch**, not the NPU event timer, which
+  has reported 82, 28, 7.6 and 24 us for one and the same launch.
+* **Medians over enough reps to resolve**, with the observed spread printed
+  next to every row. Believe a difference only once it is larger than that
+  spread, and confirm it by running this more than once -- the vendor kernel is
+  chosen per process, so a single process can settle a near-tie the wrong way.
+* **A device-to-device copy reference per run.** If it collapses, another
+  tenant is on the device and the ratios in that run are not comparable.
+
+Both MXFP4 arms are timed on **pre-quantized operands**, so what is compared is
+matmul against matmul. Quantization is a separate kernel and is not in either
+number.
+"""
+
+import argparse
+import csv
+import gc
+import statistics
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import torch  # noqa: E402
+import torch_npu  # noqa: E402
+
+from jit_util_mxfp4_matmul_a5 import (  # noqa: E402
+    MX_BLOCK,
+    compile_kernel,
+    load_matmul,
+    tile_plan,
+)
+
+L2_BYTES = 128 << 20  # A5 L2; the eviction buffer is twice this in bf16 halves
+WARMUP = 20
+TARGET_WINDOW_US = 200_000.0  # per arm, per shape
+CUBE_PEAK_TFS = 1692.0  # MXFP4 cube ceiling, for the reps estimate only
+FIELDS = [
+    "m",
+    "m_run",
+    "kn",
+    "bf16_us",
+    "vendor_us",
+    "ours_us",
+    "ours_vs_bf16",
+    "vendor_vs_bf16",
+    "ours_vs_vendor",
+    "bf16_tfs",
+    "vendor_tfs",
+    "ours_tfs",
+    "padded",
+    "reps",
+    "spread_pct",
+    "copy_gbs",
+]
+
+MS = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+KNS = [512, 1024, 2048, 3072, 4096, 6144, 8192, 12288, 16384]
+
+
+def host(array):
+    """Operands are generated on the host and moved, never with device RNG."""
+    return torch.from_numpy(np.ascontiguousarray(array)).npu()
+
+
+def copy_reference(source, destination) -> float:
+    """GB/s of a plain device-to-device copy, as this run's contention check."""
+    for _ in range(5):
+        destination.copy_(source)
+    torch.npu.synchronize()
+    start = time.perf_counter()
+    for _ in range(20):
+        destination.copy_(source)
+    torch.npu.synchronize()
+    seconds = (time.perf_counter() - start) / 20
+    return 2 * source.numel() * source.element_size() / seconds / 1e9
+
+
+def timed_medians(arms, reps, source, destination):
+    """Interleaved, order-rotated, L2 cold before each timed launch."""
+    for arm in arms.values():
+        for _ in range(WARMUP):
+            arm()
+    torch.npu.synchronize()
+    observed = {name: [] for name in arms}
+    names = list(arms)
+    for rep in range(reps):
+        offset = rep % len(names)
+        for name in names[offset:] + names[:offset]:
+            destination.copy_(source)  # evict, untimed
+            torch.npu.synchronize()
+            start = time.perf_counter()
+            arms[name]()
+            torch.npu.synchronize()
+            observed[name].append((time.perf_counter() - start) * 1e6)
+    return {
+        name: (
+            statistics.median(samples),
+            100 * (max(samples) - min(samples)) / statistics.median(samples),
+        )
+        for name, samples in observed.items()
+    }
+
+
+def vendor_arm(activations, weights):
+    """torch_npu's MXFP4 matmul, with the operands quantized up front.
+
+    The scales are (rows, K/64, 2) pairs of E8M0 and any 2D scale is refused;
+    ``group_sizes=[1, 1, 32]`` is mandatory; and the weight and its scale must
+    share transpose state.
+    """
+    a_packed, a_scale = torch_npu.npu_dynamic_mx_quant(activations)
+    b_packed, b_scale = torch_npu.npu_dynamic_mx_quant(weights.t().contiguous())
+    fp4, e8m0 = torch.float4_e2m1fn_x2, torch.float8_e8m0fnu
+    view = (
+        a_packed.view(fp4),
+        b_packed.view(fp4).t(),
+        b_scale.view(e8m0).transpose(0, 1),
+        a_scale.view(e8m0),
+    )
+
+    def run():
+        return torch_npu.npu_quant_matmul(
+            view[0],
+            view[1],
+            view[2],
+            pertoken_scale=view[3],
+            output_dtype=torch.bfloat16,
+            group_sizes=[1, 1, 32],
+        )
+
+    return run
+
+
+def our_arm(matmul, m_run, k, n, rng):
+    """Ours, on pre-packed nibbles, with the shape bound once.
+
+    ``matmul.prepare`` validates and derives the tile plan up front and hands
+    back a launcher that only launches. Timing the validating entry point
+    instead charges this arm three ctypes round-trips per call, which at
+    M=16 K=N=1024 read as 1.30x against the vendor where the kernel itself is
+    2.3x -- the wrapper, not the kernel.
+    """
+    packed = (
+        host(rng.integers(0, 255, (m_run, k // 2), dtype=np.uint8)),
+        host(rng.integers(120, 136, (m_run, k // MX_BLOCK)).astype(np.uint8)),
+        host(rng.integers(0, 255, (n, k // 2), dtype=np.uint8)),
+        host(rng.integers(120, 136, (n, k // MX_BLOCK)).astype(np.uint8)),
+    )
+    launch, out = matmul.prepare(*packed, m=m_run)
+    torch.npu.synchronize()
+    return launch, packed, out
+
+
+def measure(matmul, m, m_run, kn, source, destination, max_reps):
+    """One grid point, three arms. Returns the CSV row.
+
+    The operands live in this frame and nowhere else, so they are released when
+    it returns -- rather than by a ``del`` at the end of a loop body, which the
+    arm closures above would then be holding stale names for.
+    """
+    rng = np.random.default_rng(137)
+    activations = host(
+        np.asarray(rng.normal(0, 1, (m, kn)), dtype=np.float32)
+    ).bfloat16()
+    weights = host(
+        np.asarray(rng.normal(0, 0.05, (kn, kn)), dtype=np.float32)
+    ).bfloat16()
+    bf16_out = torch.empty((m, kn), dtype=torch.bfloat16, device="npu")
+    ours, _packed, _our_out = our_arm(matmul, m_run, kn, kn, rng)
+
+    flop = 2.0 * m * kn * kn
+    floor_us = max(6.0, flop / (CUBE_PEAK_TFS * 1e12) * 1e6)
+    reps = int(min(max_reps, max(5, round(TARGET_WINDOW_US / floor_us))))
+    result = timed_medians(
+        {
+            "bf16": lambda: torch.matmul(activations, weights, out=bf16_out),
+            "vendor": vendor_arm(activations, weights),
+            "ours": ours,
+        },
+        reps,
+        source,
+        destination,
+    )
+    bf16_us, bf16_spread = result["bf16"]
+    vendor_us, vendor_spread = result["vendor"]
+    ours_us, ours_spread = result["ours"]
+    return {
+        "m": m,
+        "m_run": m_run,
+        "kn": kn,
+        "bf16_us": round(bf16_us, 3),
+        "vendor_us": round(vendor_us, 3),
+        "ours_us": round(ours_us, 3),
+        "ours_vs_bf16": round(bf16_us / ours_us, 3),
+        "vendor_vs_bf16": round(bf16_us / vendor_us, 3),
+        "ours_vs_vendor": round(vendor_us / ours_us, 3),
+        "bf16_tfs": round(flop / bf16_us / 1e6),
+        "vendor_tfs": round(flop / vendor_us / 1e6),
+        "ours_tfs": round(flop / ours_us / 1e6),
+        "padded": int(m_run != m),
+        "reps": reps,
+        "spread_pct": round(max(bf16_spread, vendor_spread, ours_spread), 1),
+    }
+
+
+def already_done(path):
+    try:
+        with open(path, newline="", encoding="utf-8") as handle:
+            rows = {(int(r["m"]), int(r["kn"])) for r in csv.DictReader(handle)}
+        if rows:
+            print(f"  resuming: {len(rows)} rows already present")
+        return rows, True
+    except FileNotFoundError:
+        return set(), False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--out", default="mxfp4_matmul_a5.csv")
+    parser.add_argument("--kn", type=int, nargs="*", default=KNS)
+    parser.add_argument("--m", type=int, nargs="*", default=MS)
+    parser.add_argument("--max-reps", type=int, default=100)
+    args = parser.parse_args()
+
+    torch.npu.set_device(0)
+    source = torch.ones(L2_BYTES, dtype=torch.bfloat16, device="npu")
+    destination = torch.empty_like(source)
+    copy_gbs = copy_reference(source, destination)
+    print(f"\n  device-to-device copy reference: {copy_gbs:.0f} GB/s")
+    print(f"  {torch.npu.get_device_name(0)}\n")
+
+    done, had_rows = already_done(args.out)
+    output = open(args.out, "a", newline="", encoding="utf-8")
+    writer = csv.DictWriter(output, fieldnames=FIELDS)
+    if not had_rows:
+        writer.writeheader()
+        output.flush()
+
+    header = (
+        f"  {'M':>6} {'run':>6} {'K=N':>6} {'bf16':>9} {'vendor':>9} "
+        f"{'ours':>9} {'o/v':>6} {'o/bf16':>7} {'reps':>5} {'spread':>7}"
+    )
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+
+    added = 0
+    for kn in args.kn:
+        so = compile_kernel(kn, kn, verbose=False)
+        matmul = load_matmul(so, kn, kn)
+        plan = tile_plan(so)
+        for m in args.m:
+            if (m, kn) in done:
+                continue
+            m_run = plan(m)[0]
+            try:
+                row = measure(matmul, m, m_run, kn, source, destination, args.max_reps)
+            except (RuntimeError, ValueError) as error:
+                first = str(error).splitlines()[0][:60]
+                print(f"  {m:>6} {m_run:>6} {kn:>6}  skipped: {first}", flush=True)
+            else:
+                print(
+                    f"  {m:>6} {m_run:>6} {kn:>6} {row['bf16_us']:>9.2f} "
+                    f"{row['vendor_us']:>9.2f} {row['ours_us']:>9.2f} "
+                    f"{row['ours_vs_vendor']:>6.2f} {row['ours_vs_bf16']:>7.2f} "
+                    f"{row['reps']:>5} {row['spread_pct']:>6.1f}%",
+                    flush=True,
+                )
+                writer.writerow({**row, "copy_gbs": round(copy_gbs)})
+                output.flush()
+                added += 1
+            # The operands are held only by measure()'s frame, so returning
+            # drops them; at M=32768 K=N=16384 that matters within one sweep.
+            gc.collect()
+            torch.npu.empty_cache()
+    output.close()
+    total = len(done) + added
+    print(f"\n  +{added}, {total} of {len(args.m) * len(args.kn)} in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/jit_cpp/mxfp4_matmul_a5/benchmark.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/benchmark.py
@@ -37,10 +37,10 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-import torch  # noqa: E402
-import torch_npu  # noqa: E402
+import torch  # noqa
+import torch_npu  # noqa
 
-from jit_util_mxfp4_matmul_a5 import (  # noqa: E402
+from jit_util_mxfp4_matmul_a5 import (  # noqa
     MX_BLOCK,
     compile_kernel,
     load_matmul,
@@ -247,49 +247,50 @@ def main() -> int:
     print(f"  {torch.npu.get_device_name(0)}\n")
 
     done, had_rows = already_done(args.out)
-    output = open(args.out, "a", newline="", encoding="utf-8")
-    writer = csv.DictWriter(output, fieldnames=FIELDS)
-    if not had_rows:
-        writer.writeheader()
-        output.flush()
+    with open(args.out, "a", newline="", encoding="utf-8") as output:
+        writer = csv.DictWriter(output, fieldnames=FIELDS)
+        if not had_rows:
+            writer.writeheader()
+            output.flush()
 
-    header = (
-        f"  {'M':>6} {'run':>6} {'K=N':>6} {'bf16':>9} {'vendor':>9} "
-        f"{'ours':>9} {'o/v':>6} {'o/bf16':>7} {'reps':>5} {'spread':>7}"
-    )
-    print(header)
-    print("  " + "-" * (len(header) - 2))
+        header = (
+            f"  {'M':>6} {'run':>6} {'K=N':>6} {'bf16':>9} {'vendor':>9} "
+            f"{'ours':>9} {'o/v':>6} {'o/bf16':>7} {'reps':>5} {'spread':>7}"
+        )
+        print(header)
+        print("  " + "-" * (len(header) - 2))
 
-    added = 0
-    for kn in args.kn:
-        so = compile_kernel(kn, kn, verbose=False)
-        matmul = load_matmul(so, kn, kn)
-        plan = tile_plan(so)
-        for m in args.m:
-            if (m, kn) in done:
-                continue
-            m_run = plan(m)[0]
-            try:
-                row = measure(matmul, m, m_run, kn, source, destination, args.max_reps)
-            except (RuntimeError, ValueError) as error:
-                first = str(error).splitlines()[0][:60]
-                print(f"  {m:>6} {m_run:>6} {kn:>6}  skipped: {first}", flush=True)
-            else:
-                print(
-                    f"  {m:>6} {m_run:>6} {kn:>6} {row['bf16_us']:>9.2f} "
-                    f"{row['vendor_us']:>9.2f} {row['ours_us']:>9.2f} "
-                    f"{row['ours_vs_vendor']:>6.2f} {row['ours_vs_bf16']:>7.2f} "
-                    f"{row['reps']:>5} {row['spread_pct']:>6.1f}%",
-                    flush=True,
-                )
-                writer.writerow({**row, "copy_gbs": round(copy_gbs)})
-                output.flush()
-                added += 1
-            # The operands are held only by measure()'s frame, so returning
-            # drops them; at M=32768 K=N=16384 that matters within one sweep.
-            gc.collect()
-            torch.npu.empty_cache()
-    output.close()
+        added = 0
+        for kn in args.kn:
+            so = compile_kernel(kn, kn, verbose=False)
+            matmul = load_matmul(so, kn, kn)
+            plan = tile_plan(so)
+            for m in args.m:
+                if (m, kn) in done:
+                    continue
+                m_run = plan(m)[0]
+                try:
+                    row = measure(
+                        matmul, m, m_run, kn, source, destination, args.max_reps
+                    )
+                except (RuntimeError, ValueError) as error:
+                    first = str(error).splitlines()[0][:60]
+                    print(f"  {m:>6} {m_run:>6} {kn:>6}  skipped: {first}", flush=True)
+                else:
+                    print(
+                        f"  {m:>6} {m_run:>6} {kn:>6} {row['bf16_us']:>9.2f} "
+                        f"{row['vendor_us']:>9.2f} {row['ours_us']:>9.2f} "
+                        f"{row['ours_vs_vendor']:>6.2f} {row['ours_vs_bf16']:>7.2f} "
+                        f"{row['reps']:>5} {row['spread_pct']:>6.1f}%",
+                        flush=True,
+                    )
+                    writer.writerow({**row, "copy_gbs": round(copy_gbs)})
+                    output.flush()
+                    added += 1
+                # The operands are held only by measure()'s frame, so returning
+                # drops them; at M=32768 K=N=16384 that matters within one sweep.
+                gc.collect()
+                torch.npu.empty_cache()
     total = len(done) + added
     print(f"\n  +{added}, {total} of {len(args.m) * len(args.kn)} in {args.out}")
     return 0

--- a/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
@@ -44,9 +44,6 @@ KERNEL_ARGS = [
     ctypes.c_uint32,
     ctypes.c_uint32,
 ]
-# call_mxfp4_matmul_grouped and _repeat take one leading count.
-COUNTED_KERNEL_ARGS = [ctypes.c_uint32] + KERNEL_ARGS
-
 # Flags that never vary; one string so black leaves the wrapping alone.
 FIXED_FLAGS = (
     "-O2 -std=c++17 -fPIC -Wno-ignored-attributes -Wno-macro-redefined "

--- a/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
@@ -1,0 +1,305 @@
+"""Build and load the A5 MXFP4 matmul kernel.
+
+``y = A @ B`` with both operands MXFP4 block-32, accumulated in fp32 and stored
+bf16, on the cube's native microscaled path.
+
+K and N are compile-time template arguments, because the GM strides are
+per-layer constants and static addressing is what keeps the inner loop tight.
+One built ``.so`` therefore serves exactly one (K, N) pair and the build cache
+is keyed on both. M is a runtime argument: ``block_dim`` is
+``m_tiles * n_tiles``, so a compile-time M would cap parallelism at
+``N / n_tile`` -- four cores at N=1024.
+
+The kernel cannot report an error from the device. Handed a shape it was not
+built for, its launcher returns having written nothing, and the caller gets an
+untouched output buffer back rather than a failure. Every argument is checked
+here instead. Use :func:`load_matmul`, which validates and then launches.
+"""
+
+import ctypes
+import os
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SRC = HERE / "mxfp4_matmul_a5.cpp"
+
+MX_BLOCK = 32  # elements per E8M0 scale
+BASE_K = 256  # the cube's K tile; must match BASE_K in the kernel
+K_L1 = 512  # default L1 slab width; must match MXMM_K_L1
+N_ALIGN = 64  # TMATMUL_MX needs N 64-aligned for fp4
+M_ALIGN = 16  # and M 16-aligned
+MAX_BLOCK_DIM = 64  # cube blocks a launch may ask for on an A5
+
+# (block_dim, stream, a, a_scale, b, b_scale, out, m, k, n)
+KERNEL_ARGS = [
+    ctypes.c_uint32,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_uint32,
+    ctypes.c_uint32,
+    ctypes.c_uint32,
+]
+# call_mxfp4_matmul_grouped and _repeat take one leading count.
+COUNTED_KERNEL_ARGS = [ctypes.c_uint32] + KERNEL_ARGS
+
+# Flags that never vary; one string so black leaves the wrapping alone.
+FIXED_FLAGS = (
+    "-O2 -std=c++17 -fPIC -Wno-ignored-attributes -Wno-macro-redefined "
+    "-mllvm -cce-aicore-stack-size=0x8000 "
+    "-mllvm -cce-aicore-function-stack-size=0x8000 "
+    "-mllvm -cce-aicore-addr-transform "
+    "-mllvm -cce-aicore-dcci-insert-for-scalar=false "
+    "-Xhost-start -Xhost-end"
+).split()
+
+
+def ascend_home() -> str:
+    for key in ("ASCEND_HOME_PATH", "ASCEND_TOOLKIT_HOME"):
+        if os.environ.get(key):
+            return os.environ[key]
+    raise RuntimeError("set ASCEND_HOME_PATH or ASCEND_TOOLKIT_HOME")
+
+
+def check_shape(k: int, n: int, k_l1: int = K_L1) -> None:
+    """Validate (K, N) before any arithmetic that could fail on a bad value."""
+    if k <= 0 or n <= 0:
+        raise ValueError(f"k and n must be positive, got k={k}, n={n}")
+    if k % k_l1:
+        raise ValueError(
+            f"k must be whole L1 slabs of {k_l1} elements, got k={k}. "
+            f"Build with -DMXMM_K_L1 to change the slab width."
+        )
+    if n % N_ALIGN:
+        raise ValueError(f"n must be a multiple of {N_ALIGN} for fp4, got n={n}")
+
+
+def check_rows(m: int, m_max: int, m_tile: int) -> None:
+    """Validate M against what this build accepts."""
+    if m <= 0:
+        raise ValueError(f"m must be positive, got m={m}")
+    if m % m_tile:
+        raise ValueError(f"m must be a multiple of {m_tile}, got m={m}")
+    if m > m_max:
+        raise ValueError(f"m must be at most {m_max}, got m={m}")
+
+
+def compile_kernel(
+    k: int,
+    n: int,
+    extra_defs=(),
+    force: bool = False,
+    verbose: bool = True,
+) -> Path:
+    """Compile and link to a device ``.so``, reusing an up-to-date one.
+
+    K and N are compile-time, so they go in the name. Without that the first
+    shape built wins the cache and every later caller is silently handed a
+    binary for the wrong dimensions -- and the kernel's launcher answers a
+    mismatched shape by doing nothing at all.
+    """
+    check_shape(k, n)
+    out_dir = HERE / "build"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"mxfp4_matmul_a5_k{k}_n{n}"
+    if extra_defs:
+        tag = "_".join(sorted(d.lstrip("-D").replace("=", "") for d in extra_defs))
+        stem = f"{stem}_{tag}"
+    obj, so = out_dir / f"{stem}.o", out_dir / f"{stem}.so"
+    if not force and so.exists() and so.stat().st_mtime >= SRC.stat().st_mtime:
+        if verbose:
+            print(f"[compile] up-to-date, reusing {so.name}")
+        return so
+    home = ascend_home()
+    bisheng = f"{home}/bin/bisheng"
+    arch = ["--cce-aicore-arch=dav-c310", "-DREGISTER_BASE"]
+    inc = [f"-I{home}/aarch64-linux/include", f"-I{home}/include"]
+    shape = [f"-DMXMM_TEST_K={k}", f"-DMXMM_TEST_N={n}"]
+    cmd = [bisheng, "-xcce", *arch, *FIXED_FLAGS, *inc, *shape, *extra_defs]
+    subprocess.run([*cmd, "-c", str(SRC), "-o", str(obj)], check=True)
+    link = f"-fPIC -shared --cce-fatobj-link -Wl,-soname,{so.name}".split()
+    subprocess.run([bisheng, *link, str(obj), "-o", str(so)], check=True)
+    return so
+
+
+def bind_launcher(so_path, name: str, argtypes=None):
+    """ctypes-load ``so_path`` and bind the launcher ``name``."""
+    fn = getattr(ctypes.CDLL(str(so_path)), name)
+    fn.argtypes = list(KERNEL_ARGS if argtypes is None else argtypes)
+    fn.restype = None
+    return fn
+
+
+def current_stream_ptr():
+    """Raw pointer for the ACTIVE stream, resolved per launch.
+
+    Never cached: a cached pointer sends later launches to whichever stream was
+    current first -- a race, not an error. The raw accessor is used instead of
+    current_stream() because it is far cheaper and follows a
+    `with torch.npu.stream(...)` block identically.
+    """
+    import torch
+    import torch_npu
+
+    # pylint: disable=protected-access  # the public accessor costs 8.9 us
+    raw = getattr(torch_npu._C, "_npu_getCurrentRawStream", None)
+    if raw is not None:
+        return ctypes.c_void_p(raw(torch.npu.current_device()))
+    handle = getattr(torch.npu.current_stream(), "npu_stream", None)
+    if handle is None:
+        raise RuntimeError("could not resolve the NPU stream pointer")
+    return ctypes.c_void_p(int(handle))
+
+
+def kernel_shape(so_path):
+    """What this build was compiled for, read back from the binary itself.
+
+    Cheaper than trusting the filename, and the only way to catch a stale
+    ``.so`` whose name says one shape while its template arguments say another.
+    """
+    lib = ctypes.CDLL(str(so_path))
+    out = {}
+    for name in ("m_tile", "m_max", "k", "n"):
+        fn = getattr(lib, f"mxfp4_matmul_{name}")
+        fn.argtypes = []
+        fn.restype = ctypes.c_uint32
+        out[name] = int(fn())
+    return out
+
+
+def tile_plan(so_path):
+    """The kernel's own M-rounding and tile choice, as plain callables.
+
+    The tile is picked from M so that ``m_tiles * n_tiles`` fills the device;
+    a caller that guesses a multiple of its own instead can land on a launch
+    the kernel silently declines.
+    """
+    lib = ctypes.CDLL(str(so_path))
+    fns = {}
+    for name in ("m_round", "m_tile_for", "n_tile_for"):
+        fn = getattr(lib, f"mxfp4_matmul_{name}")
+        fn.argtypes = [ctypes.c_uint32]
+        fn.restype = ctypes.c_uint32
+        fns[name] = fn
+
+    def plan(m: int):
+        if m <= 0:
+            raise ValueError(f"m must be positive, got m={m}")
+        m_run = int(fns["m_round"](m))
+        m_tile = int(fns["m_tile_for"](m_run))
+        n_tile = int(fns["n_tile_for"](m_run))
+        if 0 in (m_run, m_tile, n_tile):
+            raise ValueError(f"kernel has no tile plan for m={m}")
+        return m_run, m_tile, n_tile
+
+    return plan
+
+
+def load_matmul(so_path, k: int, n: int):
+    """Return a validated callable for one built (K, N).
+
+    The returned function takes the packed operands and writes into ``out``:
+    ``a`` and ``b`` are E2M1 nibbles two per byte, ``b`` stored DN -- that is,
+    (N, K) row-major -- and the scales are E8M0 bytes, ``a_scale`` (M, K/32)
+    row-major and ``b_scale`` (N, K/32), matching B's transpose.
+
+    M is rounded UP to whole tiles, because the kernel launches on whole tiles.
+    So the operands and the result are ``m_round(m)`` rows tall, not ``m``, and
+    the rows past ``m`` hold whatever the padded operands produced. Read the
+    height off the returned tensor rather than assuming it; a caller that
+    supplies ``out`` at the unrounded height is refused rather than having the
+    extra rows written past the end of it.
+    """
+    import torch
+
+    check_shape(k, n)
+    built = kernel_shape(so_path)
+    if (built["k"], built["n"]) != (k, n):
+        raise ValueError(
+            f"{Path(so_path).name} was built for k={built['k']} n={built['n']}, "
+            f"asked for k={k} n={n}"
+        )
+    plan = tile_plan(so_path)
+    kernel = bind_launcher(so_path, "call_mxfp4_matmul")
+
+    def run(a, a_scale, b, b_scale, out=None, m=None, stream_ptr=None):
+        rows = int(a.shape[0]) if m is None else int(m)
+        m_run, m_tile, n_tile = plan(rows)
+        check_rows(m_run, built["m_max"], built["m_tile"])
+        # The kernel reads each buffer as one flat contiguous run and can
+        # report neither a wrong dtype nor a strided view: a wider dtype is
+        # reinterpreted and a non-contiguous tensor is read as if packed.
+        for name, buf, shape in (
+            ("a", a, (m_run, k // 2)),
+            ("a_scale", a_scale, (m_run, k // MX_BLOCK)),
+            ("b", b, (n, k // 2)),
+            ("b_scale", b_scale, (n, k // MX_BLOCK)),
+        ):
+            if buf.dtype != torch.uint8:
+                raise TypeError(f"{name} must be uint8, got {buf.dtype}")
+            if not buf.is_contiguous():
+                raise ValueError(f"{name} must be contiguous; call .contiguous()")
+            if tuple(buf.shape) != shape:
+                raise ValueError(f"{name} must be {shape}, got {tuple(buf.shape)}")
+        if out is None:
+            out = torch.empty((m_run, n), dtype=torch.bfloat16, device=a.device)
+        elif out.dtype != torch.bfloat16 or tuple(out.shape) != (m_run, n):
+            raise ValueError(
+                f"out must be bfloat16 {(m_run, n)}, got "
+                f"{out.dtype} {tuple(out.shape)}"
+            )
+        blocks = (m_run // m_tile) * (n // n_tile)
+        kernel(
+            min(MAX_BLOCK_DIM, max(1, blocks)),
+            current_stream_ptr() if stream_ptr is None else stream_ptr,
+            ctypes.c_void_p(a.data_ptr()),
+            ctypes.c_void_p(a_scale.data_ptr()),
+            ctypes.c_void_p(b.data_ptr()),
+            ctypes.c_void_p(b_scale.data_ptr()),
+            ctypes.c_void_p(out.data_ptr()),
+            m_run,
+            k,
+            n,
+        )
+        return out
+
+    def prepare(a, a_scale, b, b_scale, out=None, m=None, stream_ptr=None):
+        """Validate once, then return a launcher that only launches.
+
+        ``run`` re-derives the tile plan on every call, and the plan costs
+        three ctypes round-trips into the ``.so``. At M=16 K=N=1024 the whole
+        matmul is about 30 us, so that bookkeeping is a measurable part of it
+        and timing ``run`` in a loop reports the wrapper as much as the kernel.
+        Anything measuring this kernel, or calling it at a fixed shape in a
+        hot loop, should bind the shape once through here.
+
+        Two consequences of binding. The stream pointer is resolved now, not
+        per launch, which is the one thing ``current_stream_ptr`` warns against
+        -- so a launcher prepared outside a ``with torch.npu.stream(...)``
+        block keeps firing at the stream that was current when it was
+        prepared. Re-prepare inside the block instead. And preparing runs the
+        validating path once, so ``out`` has already been written when this
+        returns.
+        """
+        rows = int(a.shape[0]) if m is None else int(m)
+        m_run, m_tile, n_tile = plan(rows)
+        prepared_out = run(a, a_scale, b, b_scale, out=out, m=rows)
+        blocks = min(MAX_BLOCK_DIM, max(1, (m_run // m_tile) * (n // n_tile)))
+        stream = current_stream_ptr() if stream_ptr is None else stream_ptr
+        pointers = tuple(
+            ctypes.c_void_p(buf.data_ptr())
+            for buf in (a, a_scale, b, b_scale, prepared_out)
+        )
+
+        def launch():
+            kernel(blocks, stream, *pointers, m_run, k, n)
+            return prepared_out
+
+        return launch, prepared_out
+
+    run.prepare = prepare
+    return run

--- a/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
@@ -17,6 +17,7 @@ here instead. Use :func:`load_matmul`, which validates and then launches.
 """
 
 import ctypes
+import functools
 import os
 import subprocess
 from pathlib import Path
@@ -29,7 +30,29 @@ BASE_K = 256  # the cube's K tile; must match BASE_K in the kernel
 K_L1 = 512  # default L1 slab width; must match MXMM_K_L1
 N_ALIGN = 64  # TMATMUL_MX needs N 64-aligned for fp4
 M_ALIGN = 16  # and M 16-aligned
-MAX_BLOCK_DIM = 64  # cube blocks a launch may ask for on an A5
+DEFAULT_CUBE_CORES = 32  # what an A5 reports, and the fallback
+
+
+@functools.lru_cache(maxsize=1)
+def cube_core_count() -> int:
+    """Blocks a launch should ask for: one per cube core.
+
+    Read from the device rather than assumed. Asking for more than the device
+    has still computes the right answer -- the kernel's work loop strides by
+    the block count -- but it measured 1.00-1.05x slower than one block per
+    core, and the tile picker uses the same number to decide when a shape
+    fills the machine. Cached, because a property query per launch is the
+    per-call cost ``current_stream_ptr`` warns about.
+    """
+    import torch
+
+    try:
+        properties = torch.npu.get_device_properties(torch.npu.current_device())
+    except (AttributeError, RuntimeError):
+        return DEFAULT_CUBE_CORES
+    cores = int(getattr(properties, "cube_core_num", DEFAULT_CUBE_CORES))
+    return cores if cores >= 1 else DEFAULT_CUBE_CORES
+
 
 # (block_dim, stream, a, a_scale, b, b_scale, out, m, k, n)
 KERNEL_ARGS = [
@@ -102,7 +125,8 @@ def compile_kernel(
     check_shape(k, n)
     out_dir = HERE / "build"
     out_dir.mkdir(parents=True, exist_ok=True)
-    stem = f"mxfp4_matmul_a5_k{k}_n{n}"
+    cores = cube_core_count()
+    stem = f"mxfp4_matmul_a5_k{k}_n{n}_tb{cores}"
     if extra_defs:
         tag = "_".join(sorted(d.lstrip("-D").replace("=", "") for d in extra_defs))
         stem = f"{stem}_{tag}"
@@ -115,7 +139,11 @@ def compile_kernel(
     bisheng = f"{home}/bin/bisheng"
     arch = ["--cce-aicore-arch=dav-c310", "-DREGISTER_BASE"]
     inc = [f"-I{home}/aarch64-linux/include", f"-I{home}/include"]
-    shape = [f"-DMXMM_TEST_K={k}", f"-DMXMM_TEST_N={n}"]
+    shape = [
+        f"-DMXMM_TEST_K={k}",
+        f"-DMXMM_TEST_N={n}",
+        f"-DMXMM_TARGET_BLOCKS={cores}",
+    ]
     cmd = [bisheng, "-xcce", *arch, *FIXED_FLAGS, *inc, *shape, *extra_defs]
     subprocess.run([*cmd, "-c", str(SRC), "-o", str(obj)], check=True)
     link = f"-fPIC -shared --cce-fatobj-link -Wl,-soname,{so.name}".split()
@@ -251,7 +279,7 @@ def load_matmul(so_path, k: int, n: int):
             )
         blocks = (m_run // m_tile) * (n // n_tile)
         kernel(
-            min(MAX_BLOCK_DIM, max(1, blocks)),
+            min(cube_core_count(), max(1, blocks)),
             current_stream_ptr() if stream_ptr is None else stream_ptr,
             ctypes.c_void_p(a.data_ptr()),
             ctypes.c_void_p(a_scale.data_ptr()),
@@ -285,7 +313,7 @@ def load_matmul(so_path, k: int, n: int):
         rows = int(a.shape[0]) if m is None else int(m)
         m_run, m_tile, n_tile = plan(rows)
         prepared_out = run(a, a_scale, b, b_scale, out=out, m=rows)
-        blocks = min(MAX_BLOCK_DIM, max(1, (m_run // m_tile) * (n // n_tile)))
+        blocks = min(cube_core_count(), max(1, (m_run // m_tile) * (n // n_tile)))
         stream = current_stream_ptr() if stream_ptr is None else stream_ptr
         pointers = tuple(
             ctypes.c_void_p(buf.data_ptr())

--- a/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
@@ -1,7 +1,9 @@
 """Build and load the A5 MXFP4 matmul kernel.
 
-``y = A @ B`` with both operands MXFP4 block-32, accumulated in fp32 and stored
-bf16, on the cube's native microscaled path.
+A full ``y = A @ B`` with both operands MXFP4 -- E2M1 nibbles carrying one
+E8M0 scale per 32 elements along K -- accumulated in fp32 and stored bf16, on
+the cube's native microscaled path. The 32 is the scale granularity; the
+matmul is not blocked.
 
 K and N are compile-time template arguments, because the GM strides are
 per-layer constants and static addressing is what keeps the inner loop tight.

--- a/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/jit_util_mxfp4_matmul_a5.py
@@ -295,9 +295,17 @@ def load_matmul(so_path, k: int, n: int):
             for buf in (a, a_scale, b, b_scale, prepared_out)
         )
 
+        # The launcher holds the operand TENSORS, not only their addresses.
+        # Without this the caller's tensors can fall out of scope while the
+        # launcher lives on, the caching allocator hands that memory to
+        # whatever allocates next, and the kernel silently reads it -- which is
+        # a wrong answer with no error, and it cost a bitwise A/B a false
+        # mismatch before the cause was found.
+        held = (a, a_scale, b, b_scale, prepared_out)
+
         def launch():
             kernel(blocks, stream, *pointers, m_run, k, n)
-            return prepared_out
+            return held[-1]
 
         return launch, prepared_out
 

--- a/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
+++ b/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
@@ -1,253 +1,236 @@
-// MXFP4 matmul on A5: y = A @ B with BOTH operands MXFP4, on the cube's
-// native microscaled path, TMATMUL_MX.
+// MXFP4 x MXFP4 matmul on the A5 cube's microscaled path, TMATMUL_MX.
 //
 //   A: (M, K) E2M1 nibbles, two per byte, + one E8M0 scale per 32 along K
-//   B: (K, N) the same, stored DN -- see LAYOUTS
+//   B: (K, N) the same, stored DN
 //   y: (M, N) bf16, accumulated in fp32
 //
-// The scaling is in the datapath, so this is not a dequantize-and-matmul.
-// From PTO's CPU reference (pto/cpu/TMatmul.hpp:44-67):
+// Layouts are asymmetric and not implied by the type names. Feeding
+// row-major B compiles and computes something else.
+//   A data   Layout::ND       A scale  Layout::MX_A_ND
+//   B data   Layout::DN       B scale  Layout::MX_B_DN
 //
-//     acc += a(i, k) * b(k, j) * aScale(i, k / 32) * bScale(k / 32, j)
+// Scale tiles bind by ADDRESS, not by argument: TMATMUL_MX takes them for the
+// type check but never forwards them to the mad_mx builtin
+// (a5/TMatmul.hpp:259-271). The hardware reads them at
+// GetScaleAddr(operand.data()), a >> 4 of the operand's L0 address
+// (a5/utils.hpp:82-87). TASSIGNing them anywhere else compiles and multiplies
+// by whatever is there.
 //
-// LAYOUTS -- asymmetric, and not implied by the type names:
-//   A data   Layout::ND       row-major (M, K)
-//   A scale  Layout::MX_A_ND  row-major (M, K/32)
-//   B data   Layout::DN       NOT ND
-//   B scale  Layout::MX_B_DN  NOT MX_B_ND
-// Feeding row-major B compiles and computes something else.
+// CheckMadMxValid asserts K a multiple of 64 elements, N a multiple of 64,
+// M a multiple of 16, and an fp32 accumulator.
 //
-// FP4 POINTER ARITHMETIC IS IN BYTES. sizeof(float4_e2m1x2_t) is 1 and it
-// holds two elements, so a K-element step is (K >> 1) bytes and a scale step
-// is (K >> 5).
-//
-// SCALE TILES BIND BY ADDRESS. TMATMUL_MX takes them for the type check but
-// never forwards them to the mad_mx builtin (a5/TMatmul.hpp:259-271). The
-// hardware reads them at GetScaleAddr(operand.data()), a >> 4 of the
-// operand's L0 address (a5/utils.hpp:82-87): the MX scale store is a 1/16
-// shadow of L0A/L0B. TASSIGNing them anywhere else compiles and multiplies
-// by whatever happens to be there.
-//
-// Alignment, all asserted by CheckMadMxValid: K a multiple of 64 ELEMENTS,
-// N a multiple of 64 for fp4, M a multiple of 16, accumulator fp32.
-//
-// Arch: cube plus a store, so dav-c310. No MIX, no cross-core sync.
-//
-// Measured throughput, the sweeps behind the defaults, and the approaches
-// tried and rejected are in README.md.
+// Measurements and the sweeps behind the defaults are in README.md.
 #include <pto/common/constants.hpp>
 #include <pto/common/pto_tile.hpp>
 #include <pto/pto-inst.hpp>
 
 using namespace pto;
 
-constexpr uint32_t SCALE_FACTOR = 32;       // elements per E8M0 scale
-constexpr uint32_t SHIFT_SCALE_FACTOR = 5;  // log2(SCALE_FACTOR)
-constexpr uint32_t SHIFT_FP4 = 1;           // two nibbles per byte
+// Hardware limits. Each is named once and every static_assert below refers to
+// the name, so a port states its constraints rather than repeating literals.
+constexpr unsigned M_ALIGN = 16;  // TMATMUL_MX's row alignment
+constexpr unsigned N_ALIGN = 64;  // fp4 column alignment
+constexpr unsigned K_ALIGN = 64;  // scales pair along K, so K/32 must be even
+constexpr uint32_t L1_BYTES = 512u * 1024u;
+constexpr uint32_t L0A_BYTES = 64u * 1024u;
+constexpr uint32_t L0B_BYTES = 64u * 1024u;
+constexpr unsigned MAT_FRACTAL_BYTES = 512;
+constexpr unsigned SCALE_FRACTAL_BYTES = 32;
 
-// Output-tile shape. The L1 fill for the whole matmul is
-// M*N*K*bytes_per_elem * (1/BASE_M + 1/BASE_N), and L0C, which holds one
-// output tile as fp32, is what bounds both dimensions.
+constexpr uint32_t SCALE_FACTOR = 32;
+constexpr uint32_t SHIFT_SCALE_FACTOR = 5;
+constexpr uint32_t SHIFT_FP4 = 1;
+constexpr unsigned BASE_K = 256;
+
+// Three output-tile row counts against one shared N. The launcher picks by M:
+// a taller tile re-fetches less L1 but halves the block count, and M_ALIGN is
+// the floor the hardware imposes.
 #ifndef MXMM_BASE_M
 #define MXMM_BASE_M 128
 #endif
 #ifndef MXMM_BASE_N
 #define MXMM_BASE_N 256
 #endif
-constexpr unsigned SMALL_M = MXMM_BASE_M;  // 16-aligned
-constexpr unsigned SMALL_N = MXMM_BASE_N;  // 64-aligned for fp4
+constexpr unsigned TILE_N = MXMM_BASE_N;
+constexpr unsigned TILE_M = MXMM_BASE_M;
+constexpr unsigned TILE_M_BIG = 2u * TILE_M;
+constexpr unsigned TILE_M_MIN = M_ALIGN;
 
-// A taller tile for large M: less L1 re-fetch, half the block count.
-constexpr unsigned BIG_M = 2u * SMALL_M;
-constexpr unsigned BIG_N = SMALL_N;
-
-// A 16-row tile for small M, so a caller with M below SMALL_M is not padded
-// up to it. 16 is the alignment floor TMATMUL_MX imposes.
-#ifndef MXMM_TINY_M
-#define MXMM_TINY_M 16
-#endif
-constexpr unsigned TINY_M = MXMM_TINY_M;
-constexpr unsigned TINY_N = SMALL_N;
-constexpr unsigned BASE_K = 256;  // the cube's K tile, a multiple of 64
-
-// The L1 slab's K extent, independent of the cube's BASE_K. A GM->L1 copy of
-// a (BASE_M, K_L1) fp4 tile moves K_L1/2 contiguous bytes per row, and the
-// cube still consumes BASE_K at a time from a K_SUB-step inner loop.
+// The L1 slab's K extent, independent of the cube's BASE_K: the cube consumes
+// BASE_K at a time from a sub-tile loop inside the slab.
 #ifndef MXMM_K_L1
 #define MXMM_K_L1 512
 #endif
 constexpr unsigned K_L1 = MXMM_K_L1;
-constexpr unsigned K_SUB = K_L1 / BASE_K;
-static_assert(K_L1 % BASE_K == 0, "the slab must be whole cube K tiles");
-static_assert(K_SUB >= 1u, "at least one sub-tile per slab");
 
-// How many L1 sets, and so how far ahead the GM->L1 load runs: a slab is
-// extracted LOOKAHEAD passes after it is loaded. With one set the slab is
-// loaded at the top of its own iteration and extracted immediately after, so
-// the load no longer overlaps the extract and multiply, and half the L1 is
-// free for a wider slab.
+// How far ahead the GM->L1 load runs. One set means no overlap and half the
+// L1 free for a wider slab.
 #ifndef MXMM_L1_SETS
 #define MXMM_L1_SETS 2
 #endif
 constexpr uint32_t L1_SETS = (uint32_t)(MXMM_L1_SETS);
 constexpr uint32_t LOOKAHEAD = L1_SETS - 1u;
-static_assert(L1_SETS >= 1u && L1_SETS <= 2u, "one or two L1 sets");
+static_assert(L1_SETS >= 1u && L1_SETS <= 2u, "One or two L1 sets.");
 
-// Output tiles are walked SWIZZLE_GROUP rows down before stepping across, so
-// the blocks resident at one time form a square-ish patch of the output
-// rather than a full-width strip. 1 restores the plain row-major walk. The
-// default is chosen per instantiation from n_tiles; -DMXMM_SWIZZLE overrides
-// it.
+// Output tiles are walked kSwizzleGroup rows down before stepping across.
+// 1 restores the plain row-major walk; -DMXMM_SWIZZLE overrides the default.
 constexpr uint32_t SWIZZLE_WIDE_TILES = 48u;
 constexpr uint32_t SWIZZLE_WIDE = 2u;
 constexpr uint32_t SWIZZLE_NARROW = 8u;
-constexpr unsigned BASE_SK = BASE_K / SCALE_FACTOR;
 
-static_assert(SMALL_M % 16 == 0 && BIG_M % 16 == 0, "M must be 16-aligned");
-static_assert(TINY_M % 16 == 0, "M must be 16-aligned");
-static_assert(SMALL_M % TINY_M == 0, "the coarser tiles are multiples of it");
-static_assert(SMALL_N % 64 == 0 && BIG_N % 64 == 0, "fp4 needs N 64-aligned");
-static_assert(BIG_M % SMALL_M == 0,
-              "the big tile's M must be a multiple of the small one's, so "
-              "one admissibility check covers both");
-static_assert(BASE_K % 64 == 0, "TMATMUL_MX needs K a multiple of 64");
+// The shape this translation unit is built for.
+#ifndef MXMM_TEST_K
+#define MXMM_TEST_K 512
+#endif
+#ifndef MXMM_TEST_N
+#define MXMM_TEST_N 512
+#endif
+constexpr unsigned TEST_M_MAX = 65536;
+constexpr unsigned TEST_K = MXMM_TEST_K, TEST_N = MXMM_TEST_N;
+constexpr uint32_t TARGET_BLOCKS = 64u;
 
-// K and N are template parameters so the GM strides stay static; they are
-// per-layer constants. M is RUNTIME, because block_dim is m_tiles * n_tiles
-// and a compile-time M would cap parallelism at N/BASE_N.
-//
-// M_MAX only sizes the BaseShape2D extents. Every GM offset here is computed
-// explicitly from BASE_M/BASE_N/BASE_K, so addressing does not depend on it;
-// it has to be an upper bound on the real M, which the host checks.
-template <unsigned M_MAX, unsigned K, unsigned N, unsigned BM, unsigned BN>
-__global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
-                                    __gm__ void *b_gm, __gm__ void *b_scale_gm,
-                                    __gm__ void *out_gm, uint32_t m_total,
-                                    uint32_t core_count) {
-  // The body reads BASE_M/BASE_N throughout, so binding them here makes the
-  // tile shape a template parameter without touching an offset or Shape type.
-  constexpr unsigned BASE_M = BM;
-  constexpr unsigned BASE_N = BN;
+namespace {
+
+// Every size the kernel derives from one output-tile choice, with the
+// static_asserts that make an unsupported combination fail to instantiate
+// rather than fault on device.
+template <unsigned kMMax, unsigned kMatK, unsigned kMatN, unsigned kTileM,
+          unsigned kTileN>
+struct TileShape {
+  static constexpr unsigned kRows = kTileM;
+  static constexpr unsigned kCols = kTileN;
+  static constexpr unsigned kMax = kMMax;
+  static constexpr unsigned kK = kMatK;
+  static constexpr unsigned kN = kMatN;
+
+  static constexpr unsigned kScaleK = kMatK / SCALE_FACTOR;
+  static constexpr unsigned kTileScaleK = BASE_K / SCALE_FACTOR;
+  static constexpr uint32_t kNTiles = kMatN / kTileN;
+  static constexpr uint32_t kCubeTiles = kMatK / BASE_K;
+  static constexpr uint32_t kSlabs = kMatK / K_L1;
+  static constexpr uint32_t kSubTiles = K_L1 / BASE_K;
+
+  static constexpr uint32_t kSlabABytes = (kTileM * K_L1) >> SHIFT_FP4;
+  static constexpr uint32_t kSlabBBytes = (K_L1 * kTileN) >> SHIFT_FP4;
+  static constexpr uint32_t kSlabBytes = kSlabABytes + kSlabBBytes;
+  static constexpr uint32_t kScaleBytes = kTileM * kScaleK + kScaleK * kTileN;
+  static constexpr uint32_t kL0ABytes = (kTileM * BASE_K) >> SHIFT_FP4;
+  static constexpr uint32_t kL0BBytes = (BASE_K * kTileN) >> SHIFT_FP4;
+
+#ifdef MXMM_SWIZZLE
+  static constexpr uint32_t kSwizzleGroup = (uint32_t)(MXMM_SWIZZLE);
+#else
+  static constexpr uint32_t kSwizzleGroup =
+      kNTiles >= SWIZZLE_WIDE_TILES ? SWIZZLE_WIDE : SWIZZLE_NARROW;
+#endif
+
+  static_assert(kTileM % M_ALIGN == 0, "TMATMUL_MX needs M M_ALIGN-aligned.");
+  static_assert(kTileN % N_ALIGN == 0, "fp4 needs N N_ALIGN-aligned.");
+  static_assert(BASE_K % K_ALIGN == 0, "The cube K tile must be K_ALIGN.");
+  static_assert(K_L1 % BASE_K == 0, "The slab must be whole cube K tiles.");
+  static_assert(kSubTiles >= 1u, "At least one sub-tile per slab.");
+  static_assert(kMatK % K_L1 == 0u, "K must be whole L1 slabs.");
+  static_assert(kMatN % kTileN == 0u, "N must be whole output tiles.");
+  static_assert(kSwizzleGroup >= 1u, "A group spans at least one tile row.");
+  // Holding the scales for the whole K costs 16*K bytes, so past a width they
+  // no longer fit beside the data sets.
+  static_assert(L1_SETS * kSlabBytes + kScaleBytes <= L1_BYTES,
+                "The data sets plus the whole-K scale pair must fit L1; "
+                "reduce L1_SETS or K.");
+  static_assert(2u * kL0ABytes <= L0A_BYTES, "Two A tiles must fit L0A.");
+  static_assert(2u * kL0BBytes <= L0B_BYTES, "Two B tiles must fit L0B.");
+};
+
 #if defined(__DAV_CUBE__)
+template <typename Shape>
+AICORE void runMxfp4Matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
+                           __gm__ void *b_gm, __gm__ void *b_scale_gm,
+                           __gm__ void *out_gm, uint32_t m_total,
+                           uint32_t core_count) {
   using Fp4 = float4_e2m1x2_t;
   using E8m0 = float8_e8m0_t;
-  constexpr unsigned SK = K / SCALE_FACTOR;
 
-  // DYNAMIC shape, whole-matrix stride. Pairing a static tile shape with a
-  // full-matrix BaseShape2D reads A's first 8 rows as zero. It is also why
-  // the scale assert accepts these: staticShape[4] == 2 OR -1
-  // (a5/TLoad.hpp:85).
+  // A static tile shape against a full-matrix BaseShape2D reads A's first 8
+  // rows as zero. Scale shapes must come from TileShape2D besides: TLoad
+  // asserts staticShape[4] == 2 or -1 for MX_*_ND/DN (a5/TLoad.hpp:85),
+  // because scales are paired along K -- which is also why K must be a
+  // multiple of 64 rather than of 32.
   using DynShape = pto::Shape<1, 1, 1, -1, -1>;
-  using GmA = GlobalTensor<Fp4, DynShape,
-                           BaseShape2D<Fp4, M_MAX, K, Layout::ND>, Layout::ND>;
-  using GmB = GlobalTensor<Fp4, DynShape, BaseShape2D<Fp4, K, N, Layout::DN>,
-                           Layout::DN>;
-  // The scale tensors' SHAPE must come from TileShape2D, not a hand-written
-  // pto::Shape: TLoad asserts staticShape[4] == 2 for every MX_*_ND/DN layout
-  // (a5/TLoad.hpp:85), because scales are grouped in pairs along K. That
-  // pairing is why K must be a multiple of 64 and not merely of 32.
-  using GmAS = GlobalTensor<E8m0, DynShape,
-                            BaseShape2D<E8m0, M_MAX, SK, Layout::MX_A_ND>,
-                            Layout::MX_A_ND>;
-  using GmBS =
-      GlobalTensor<E8m0, DynShape, BaseShape2D<E8m0, SK, N, Layout::MX_B_DN>,
-                   Layout::MX_B_DN>;
-  using GmOut =
-      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, BASE_M, BASE_N>,
-                   BaseShape2D<bfloat16_t, M_MAX, N, Layout::ND>, Layout::ND>;
+  using AGlobal =
+      GlobalTensor<Fp4, DynShape,
+                   BaseShape2D<Fp4, Shape::kMax, Shape::kK, Layout::ND>,
+                   Layout::ND>;
+  using BGlobal =
+      GlobalTensor<Fp4, DynShape,
+                   BaseShape2D<Fp4, Shape::kK, Shape::kN, Layout::DN>,
+                   Layout::DN>;
+  using AScaleGlobal = GlobalTensor<
+      E8m0, DynShape,
+      BaseShape2D<E8m0, Shape::kMax, Shape::kScaleK, Layout::MX_A_ND>,
+      Layout::MX_A_ND>;
+  using BScaleGlobal = GlobalTensor<
+      E8m0, DynShape,
+      BaseShape2D<E8m0, Shape::kScaleK, Shape::kN, Layout::MX_B_DN>,
+      Layout::MX_B_DN>;
+  using OutGlobal =
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, Shape::kRows, Shape::kCols>,
+                   BaseShape2D<bfloat16_t, Shape::kMax, Shape::kN, Layout::ND>,
+                   Layout::ND>;
 
-  // L1. A is ColMajor with a RowMajor fractal, B RowMajor with a ColMajor
-  // one; CheckMadMxValid asserts that asymmetry on the L0 tiles downstream.
   // The 512-byte fractal has to be explicit: omitting it reads A's first 8
   // rows as zero.
-  //
-  // L1 holds a K_L1-wide slab; L0 below holds BASE_K, and the extract picks
-  // sub-tile j out of the slab at column offset j*BASE_K.
-  using MatA = Tile<TileType::Mat, Fp4, BASE_M, K_L1, BLayout::ColMajor, BASE_M,
-                    K_L1, SLayout::RowMajor, 512>;
-  using MatB = Tile<TileType::Mat, Fp4, K_L1, BASE_N, BLayout::RowMajor, K_L1,
-                    BASE_N, SLayout::ColMajor, 512>;
-  // The scales are held for the WHOLE K of an output tile, not per slab: one
-  // pair of loads covers every slab, so the burst is longer and the
-  // descriptor count per output tile falls from 4*k_slabs to 2*k_slabs + 2.
-  using MatAS = Tile<TileType::Mat, E8m0, BASE_M, SK, BLayout::RowMajor, BASE_M,
-                     SK, SLayout::RowMajor, 32>;
-  using MatBS = Tile<TileType::Mat, E8m0, SK, BASE_N, BLayout::ColMajor, SK,
-                     BASE_N, SLayout::ColMajor, 32>;
+  using ATile = Tile<TileType::Mat, Fp4, Shape::kRows, K_L1, BLayout::ColMajor,
+                     Shape::kRows, K_L1, SLayout::RowMajor, MAT_FRACTAL_BYTES>;
+  using BTile = Tile<TileType::Mat, Fp4, K_L1, Shape::kCols, BLayout::RowMajor,
+                     K_L1, Shape::kCols, SLayout::ColMajor, MAT_FRACTAL_BYTES>;
+  using AScaleTile = Tile<TileType::Mat, E8m0, Shape::kRows, Shape::kScaleK,
+                          BLayout::RowMajor, Shape::kRows, Shape::kScaleK,
+                          SLayout::RowMajor, SCALE_FRACTAL_BYTES>;
+  using BScaleTile = Tile<TileType::Mat, E8m0, Shape::kScaleK, Shape::kCols,
+                          BLayout::ColMajor, Shape::kScaleK, Shape::kCols,
+                          SLayout::ColMajor, SCALE_FRACTAL_BYTES>;
 
-  // L0, using the Compact variants the tuned reference uses.
-  using Left = TileLeft<Fp4, BASE_M, BASE_K, BASE_M, BASE_K>;
-  using Right = TileRight<Fp4, BASE_K, BASE_N, BASE_K, BASE_N>;
-  using LeftS = TileLeftScale<E8m0, BASE_M, BASE_SK, BASE_M, BASE_SK>;
-  using RightS = TileRightScale<E8m0, BASE_SK, BASE_N, BASE_SK, BASE_N>;
-  using Acc = TileAcc<float, BASE_M, BASE_N, BASE_M, BASE_N>;
+  using LeftTile = TileLeft<Fp4, Shape::kRows, BASE_K, Shape::kRows, BASE_K>;
+  using RightTile = TileRight<Fp4, BASE_K, Shape::kCols, BASE_K, Shape::kCols>;
+  using LeftScaleTile = TileLeftScale<E8m0, Shape::kRows, Shape::kTileScaleK,
+                                      Shape::kRows, Shape::kTileScaleK>;
+  using RightScaleTile = TileRightScale<E8m0, Shape::kTileScaleK, Shape::kCols,
+                                        Shape::kTileScaleK, Shape::kCols>;
+  using AccTile =
+      TileAcc<float, Shape::kRows, Shape::kCols, Shape::kRows, Shape::kCols>;
 
-  // L1 is double buffered so the K loop can overlap its GM->L1 load with its
-  // extract and multiply. One set is 96 KB at the default slab and tile.
-  MatA a_l1, a_l1b;
-  MatB b_l1, b_l1b;
-  // One scale pair, not one per set: it is loaded once per output tile and
-  // read by every extract, so it does not ping-pong with the data slabs.
-  MatAS as_l1;
-  MatBS bs_l1;
-  // L0 is double buffered too. One fp4 operand tile is 32 KB and L0A and L0B
-  // are 64 KB each, so two sets fit exactly, which is what holds BASE_K at
-  // 256.
-  Left a_l0, a_l0b;
-  Right b_l0, b_l0b;
-  LeftS as_l0, as_l0b;
-  RightS bs_l0, bs_l0b;
-  Acc c_l0;
+  ATile aL1, aL1b;
+  BTile bL1, bL1b;
+  AScaleTile aScaleL1;
+  BScaleTile bScaleL1;
+  LeftTile aL0, aL0b;
+  RightTile bL0, bL0b;
+  LeftScaleTile aScaleL0, aScaleL0b;
+  RightScaleTile bScaleL0, bScaleL0b;
+  AccTile accL0;
 
-  constexpr uint32_t a_l1_bytes = (BASE_M * K_L1) >> SHIFT_FP4;
-  constexpr uint32_t b_l1_bytes = (K_L1 * BASE_N) >> SHIFT_FP4;
-  // Data slabs first, L1_SETS of them, then the single whole-K scale pair.
-  constexpr uint32_t l1_set_bytes = a_l1_bytes + b_l1_bytes;
-  constexpr uint32_t scale_bytes = BASE_M * SK + SK * BASE_N;
-  TASSIGN(a_l1, 0x0);
-  TASSIGN(b_l1, a_l1_bytes);
-  TASSIGN(a_l1b, l1_set_bytes);
-  TASSIGN(b_l1b, l1_set_bytes + a_l1_bytes);
-  TASSIGN(as_l1, L1_SETS * l1_set_bytes);
-  TASSIGN(bs_l1, L1_SETS * l1_set_bytes + BASE_M * SK);
-  // L1 is 512 KB on this part. Holding the scales for the whole K costs 16*K
-  // bytes, so past K=16384 they no longer fit beside two data sets -- and
-  // this refuses to build rather than faulting on device with 507015.
-  static_assert(L1_SETS * l1_set_bytes + scale_bytes <= 512u * 1024u,
-                "the data sets plus the whole-K scale pair must fit the 512 KB "
-                "L1; reduce L1_SETS or K");
-  constexpr uint32_t a_l0_bytes = (BASE_M * BASE_K) >> SHIFT_FP4;
-  constexpr uint32_t b_l0_bytes = (BASE_K * BASE_N) >> SHIFT_FP4;
-  static_assert(2u * a_l0_bytes <= 64u * 1024u, "two A tiles must fit L0A");
-  static_assert(2u * b_l0_bytes <= 64u * 1024u, "two B tiles must fit L0B");
-  TASSIGN(a_l0, 0x0);
-  TASSIGN(b_l0, 0x0);
-  TASSIGN(a_l0b, a_l0_bytes);
-  TASSIGN(b_l0b, b_l0_bytes);
-  TASSIGN(c_l0, 0x0);
-  TASSIGN(as_l0, GetScaleAddr(a_l0.data()));
-  TASSIGN(bs_l0, GetScaleAddr(b_l0.data()));
-  TASSIGN(as_l0b, GetScaleAddr(a_l0b.data()));
-  TASSIGN(bs_l0b, GetScaleAddr(b_l0b.data()));
+  TASSIGN(aL1, 0x0);
+  TASSIGN(bL1, Shape::kSlabABytes);
+  TASSIGN(aL1b, Shape::kSlabBytes);
+  TASSIGN(bL1b, Shape::kSlabBytes + Shape::kSlabABytes);
+  TASSIGN(aScaleL1, L1_SETS * Shape::kSlabBytes);
+  TASSIGN(bScaleL1,
+          L1_SETS * Shape::kSlabBytes + Shape::kRows * Shape::kScaleK);
+  TASSIGN(aL0, 0x0);
+  TASSIGN(bL0, 0x0);
+  TASSIGN(aL0b, Shape::kL0ABytes);
+  TASSIGN(bL0b, Shape::kL0BBytes);
+  TASSIGN(accL0, 0x0);
+  TASSIGN(aScaleL0, GetScaleAddr(aL0.data()));
+  TASSIGN(bScaleL0, GetScaleAddr(bL0.data()));
+  TASSIGN(aScaleL0b, GetScaleAddr(aL0b.data()));
+  TASSIGN(bScaleL0b, GetScaleAddr(bL0b.data()));
 
-  const uint32_t m_tiles = m_total / BASE_M;
-  constexpr uint32_t n_tiles = N / BASE_N;
-#ifdef MXMM_SWIZZLE
-  constexpr uint32_t SWIZZLE_GROUP = (uint32_t)(MXMM_SWIZZLE);
-#else
-  constexpr uint32_t SWIZZLE_GROUP =
-      n_tiles >= SWIZZLE_WIDE_TILES ? SWIZZLE_WIDE : SWIZZLE_NARROW;
-#endif
-  static_assert(SWIZZLE_GROUP >= 1u, "a group spans at least one tile row");
-  constexpr uint32_t k_tiles = K / BASE_K;
-  constexpr uint32_t k_slabs = K / K_L1;
-  static_assert(K % K_L1 == 0u, "K must be whole L1 slabs");
-  const uint32_t out_tiles = m_tiles * n_tiles;
-  const uint32_t per_group = SWIZZLE_GROUP * n_tiles;
+  const uint32_t m_tiles = m_total / Shape::kRows;
+  const uint32_t out_tiles = m_tiles * Shape::kNTiles;
+  const uint32_t per_group = Shape::kSwizzleGroup * Shape::kNTiles;
 
-  // Pipeline flags. Every pipe is in order, so one counter per direction is
-  // enough: a wait releases the oldest outstanding token, which is the tile
-  // whose turn it is.
+  // Every pipe is in order, so one counter per direction suffices.
   //
   //   MTE2 -> MTE1  ID0  a data slab has landed in L1
   //                 ID1  the whole-K scale pair has landed
@@ -258,93 +241,87 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   //   M    -> FIX   ID0  the accumulator is complete
   //   FIX  -> M     ID6  the store has read the accumulator
   //
-  // MTE2 runs ahead of MTE1 by design, so the scale buffer needs the same
-  // release handshake the data sets get: without ID3 a tile's scale load can
-  // land on top of scales the previous tile is still extracting.
+  // MTE2 runs ahead of MTE1, so without ID3 a tile's scale load lands on top
+  // of scales the previous tile is still extracting.
   bool scales_held = false;
   for (uint32_t t = get_block_idx(); t < out_tiles; t += core_count) {
     const uint32_t in_group = t % per_group;
-    const uint32_t first_mt = (t / per_group) * SWIZZLE_GROUP;
-    const uint32_t group_mts =
-        m_tiles - first_mt < SWIZZLE_GROUP ? m_tiles - first_mt : SWIZZLE_GROUP;
+    const uint32_t first_mt = (t / per_group) * Shape::kSwizzleGroup;
+    const uint32_t group_mts = m_tiles - first_mt < Shape::kSwizzleGroup
+                                   ? m_tiles - first_mt
+                                   : Shape::kSwizzleGroup;
     const uint32_t mt = first_mt + in_group % group_mts;
     const uint32_t nt = in_group / group_mts;
 
-#define MXMM_TILE_GM(kk)                                                   \
-  GmA a_g((__gm__ Fp4 *)a_gm +                                             \
-              (((uint64_t)mt * BASE_M * K + (uint64_t)(kk)) >> SHIFT_FP4), \
-          DynShape(BASE_M, K_L1));                                         \
-  GmB b_g((__gm__ Fp4 *)b_gm +                                             \
-              (((uint64_t)nt * BASE_N * K + (uint64_t)(kk)) >> SHIFT_FP4), \
-          DynShape(K_L1, BASE_N));                                         \
+#define MXMM_TILE_GM(kk)                                                 \
+  AGlobal aGlobal(                                                       \
+      (__gm__ Fp4 *)a_gm +                                               \
+          (((uint64_t)mt * Shape::kRows * Shape::kK + (uint64_t)(kk)) >> \
+           SHIFT_FP4),                                                   \
+      DynShape(Shape::kRows, K_L1));                                     \
+  BGlobal bGlobal(                                                       \
+      (__gm__ Fp4 *)b_gm +                                               \
+          (((uint64_t)nt * Shape::kCols * Shape::kK + (uint64_t)(kk)) >> \
+           SHIFT_FP4),                                                   \
+      DynShape(K_L1, Shape::kCols));                                     \
   (void)0
 
-// The scale tensors are indexed by the output tile alone, not by the slab:
-// A's scales by its row panel and B's by its column panel, spanning all of K.
-#define MXMM_FILL_SCALES()                                             \
-  do {                                                                 \
-    GmAS as_g((__gm__ E8m0 *)a_scale_gm +                              \
-                  (((uint64_t)mt * BASE_M * K) >> SHIFT_SCALE_FACTOR), \
-              DynShape(BASE_M, SK));                                   \
-    GmBS bs_g((__gm__ E8m0 *)b_scale_gm +                              \
-                  (((uint64_t)nt * BASE_N * K) >> SHIFT_SCALE_FACTOR), \
-              DynShape(SK, BASE_N));                                   \
-    TLOAD<MatAS, GmAS>(as_l1, as_g);                                   \
-    TLOAD<MatBS, GmBS>(bs_l1, bs_g);                                   \
+#define MXMM_FILL_SCALES()                                                     \
+  do {                                                                         \
+    AScaleGlobal aScaleGlobal(                                                 \
+        (__gm__ E8m0 *)a_scale_gm +                                            \
+            (((uint64_t)mt * Shape::kRows * Shape::kK) >> SHIFT_SCALE_FACTOR), \
+        DynShape(Shape::kRows, Shape::kScaleK));                               \
+    BScaleGlobal bScaleGlobal(                                                 \
+        (__gm__ E8m0 *)b_scale_gm +                                            \
+            (((uint64_t)nt * Shape::kCols * Shape::kK) >> SHIFT_SCALE_FACTOR), \
+        DynShape(Shape::kScaleK, Shape::kCols));                               \
+    TLOAD<AScaleTile, AScaleGlobal>(aScaleL1, aScaleGlobal);                   \
+    TLOAD<BScaleTile, BScaleGlobal>(bScaleL1, bScaleGlobal);                   \
   } while (0)
 
-// sub is the tile's index within the slab and tile its index within the whole
-// K. A holds K along its columns and B along its rows, so the offset goes in
-// a different argument for each. The data offset is per slab; the scale
-// offset is per output tile, because one scale buffer spans all of K.
-#define MXMM_DRAIN_TO_L0(a1, b1, a0, b0, as0, bs0, sub, tile) \
-  do {                                                        \
-    const uint16_t koff_ = (uint16_t)((sub) * BASE_K);        \
-    const uint16_t soff_ = (uint16_t)((tile) * BASE_SK);      \
-    TEXTRACT(a0, a1, 0, koff_);                               \
-    TEXTRACT(b0, b1, koff_, 0);                               \
-    TEXTRACT(as0, as_l1, 0, soff_);                           \
-    TEXTRACT(bs0, bs_l1, soff_, 0);                           \
+#define MXMM_DRAIN_TO_L0(a1, b1, a0, b0, as0, bs0, sub, tile)       \
+  do {                                                              \
+    const uint16_t koff_ = (uint16_t)((sub) * BASE_K);              \
+    const uint16_t soff_ = (uint16_t)((tile) * Shape::kTileScaleK); \
+    TEXTRACT(a0, a1, 0, koff_);                                     \
+    TEXTRACT(b0, b1, koff_, 0);                                     \
+    TEXTRACT(as0, aScaleL1, 0, soff_);                              \
+    TEXTRACT(bs0, bScaleL1, soff_, 0);                              \
   } while (0)
 
-// One GM->L1 copy per slab into the set its index selects.
 #define MXMM_LOAD(sl, sel)                     \
   do {                                         \
     MXMM_TILE_GM((uint64_t)(sl) * K_L1);       \
     if ((sel) == 0u) {                         \
-      TLOAD(a_l1, a_g);                        \
-      TLOAD(b_l1, b_g);                        \
+      TLOAD(aL1, aGlobal);                     \
+      TLOAD(bL1, bGlobal);                     \
     } else {                                   \
-      TLOAD(a_l1b, a_g);                       \
-      TLOAD(b_l1b, b_g);                       \
+      TLOAD(aL1b, aGlobal);                    \
+      TLOAD(bL1b, bGlobal);                    \
     }                                          \
     set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0); \
   } while (0)
 
-// e is the global K-tile index. A slab's load is waited for once, before its
-// first sub-tile, and the set released once, after its last -- so ID0 and ID2
-// count slabs while ID4 and ID5 count cube tiles.
-#define MXMM_EXTRACT(e, a0, b0, as0, bs0)                         \
-  do {                                                            \
-    const uint32_t e_ = (e);                                      \
-    const uint32_t slab_ = e_ / K_SUB;                            \
-    const uint32_t sub_ = e_ % K_SUB;                             \
-    if (sub_ == 0u) {                                             \
-      wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);                 \
-    }                                                             \
-    if (slab_ % L1_SETS == 0u) {                                  \
-      MXMM_DRAIN_TO_L0(a_l1, b_l1, a0, b0, as0, bs0, sub_, e_);   \
-    } else {                                                      \
-      MXMM_DRAIN_TO_L0(a_l1b, b_l1b, a0, b0, as0, bs0, sub_, e_); \
-    }                                                             \
-    if (sub_ + 1u == K_SUB) {                                     \
-      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);                  \
-    }                                                             \
-    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);                       \
+#define MXMM_EXTRACT(e, a0, b0, as0, bs0)                       \
+  do {                                                          \
+    const uint32_t e_ = (e);                                    \
+    const uint32_t slab_ = e_ / Shape::kSubTiles;               \
+    const uint32_t sub_ = e_ % Shape::kSubTiles;                \
+    if (sub_ == 0u) {                                           \
+      wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);               \
+    }                                                           \
+    if (slab_ % L1_SETS == 0u) {                                \
+      MXMM_DRAIN_TO_L0(aL1, bL1, a0, b0, as0, bs0, sub_, e_);   \
+    } else {                                                    \
+      MXMM_DRAIN_TO_L0(aL1b, bL1b, a0, b0, as0, bs0, sub_, e_); \
+    }                                                           \
+    if (sub_ + 1u == Shape::kSubTiles) {                        \
+      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);                \
+    }                                                           \
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);                     \
   } while (0)
 
-    // One pair of scale loads for the whole output tile, before the data
-    // prologue so it is the first thing MTE2 has queued.
     if (scales_held) {
       wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
     }
@@ -352,70 +329,50 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
     scales_held = true;
 
-    // Prologue: LOOKAHEAD slabs are in flight before the first multiply, so a
-    // tile's extract waits on a load issued LOOKAHEAD passes earlier instead
-    // of one it started itself.
-    for (uint32_t j = 0u; j < LOOKAHEAD && j < k_slabs; ++j) {
+    for (uint32_t j = 0u; j < LOOKAHEAD && j < Shape::kSlabs; ++j) {
       MXMM_LOAD(j, j % L1_SETS);
     }
-    // MTE1 blocks here until the scales are in L1; the prologue's data loads
-    // are already issued on MTE2, so this costs them nothing.
     wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
-    for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+    for (uint32_t kt = 0; kt < Shape::kCubeTiles; ++kt) {
       const bool odd = (kt & 1u) != 0u;
-      // One GM->L1 copy per slab, issued when the slab's first cube tile
-      // comes up rather than once per cube tile.
-      if (kt % K_SUB == 0u) {
-        const uint32_t slab_ahead = kt / K_SUB + LOOKAHEAD;
-        if (slab_ahead < k_slabs) {
-          if (slab_ahead >= L1_SETS) {  // that set must be fully extracted
+      if (kt % Shape::kSubTiles == 0u) {
+        const uint32_t slab_ahead = kt / Shape::kSubTiles + LOOKAHEAD;
+        if (slab_ahead < Shape::kSlabs) {
+          if (slab_ahead >= L1_SETS) {
             wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
           }
           MXMM_LOAD(slab_ahead, slab_ahead % L1_SETS);
         }
       }
-      // Tile kt was extracted on the previous pass, so this pass extracts
-      // kt+1 into the OTHER L0 set and the cube's multiply of kt runs beside
-      // it. wait_flag stalls its target pipe, not the scalar unit, so the
-      // multiply still issues to M while MTE1 sits in the extract.
       if (kt == 0u) {
-        MXMM_EXTRACT(0u, a_l0, b_l0, as_l0, bs_l0);
+        MXMM_EXTRACT(0u, aL0, bL0, aScaleL0, bScaleL0);
       }
-      if (kt + 1u < k_tiles) {
+      if (kt + 1u < Shape::kCubeTiles) {
         if (kt >= 1u) {
-          // tile kt-1 has released that L0 set
           wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
         }
-        if (odd) {  // kt+1 has the opposite parity, so the other L0 set
-          MXMM_EXTRACT(kt + 1u, a_l0, b_l0, as_l0, bs_l0);
+        if (odd) {
+          MXMM_EXTRACT(kt + 1u, aL0, bL0, aScaleL0, bScaleL0);
         } else {
-          MXMM_EXTRACT(kt + 1u, a_l0b, b_l0b, as_l0b, bs_l0b);
+          MXMM_EXTRACT(kt + 1u, aL0b, bL0b, aScaleL0b, bScaleL0b);
         }
       }
       wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
-      if (odd) {  // kt == 0 is even, so an odd tile always accumulates
-        TMATMUL_MX(c_l0, c_l0, a_l0b, as_l0b, b_l0b, bs_l0b);
+      if (odd) {
+        TMATMUL_MX(accL0, accL0, aL0b, aScaleL0b, bL0b, bScaleL0b);
       } else if (kt == 0u) {
-        TMATMUL_MX(c_l0, a_l0, as_l0, b_l0, bs_l0);
+        TMATMUL_MX(accL0, aL0, aScaleL0, bL0, bScaleL0);
       } else {
-        TMATMUL_MX(c_l0, c_l0, a_l0, as_l0, b_l0, bs_l0);
+        TMATMUL_MX(accL0, accL0, aL0, aScaleL0, bL0, bScaleL0);
       }
       set_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
     }
-    // ID2 carries min(k_slabs, L1_SETS) tokens out of the loop: every slab's
-    // last extract posts one and only the loads far enough ahead consume one.
-    // Draining keeps a count from carrying into the next output tile, where a
-    // later wait would return early.
-    for (uint32_t d = 0u; d < L1_SETS && d < k_slabs; ++d) {
+    for (uint32_t d = 0u; d < L1_SETS && d < Shape::kSlabs; ++d) {
       wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
     }
-    // Every extract above read the scale buffer, and MTE1 is in order, so one
-    // post here releases it for the next output tile.
     set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
-    // Every multiply posts on ID5 and only the extracts of tile 2 and later
-    // consume one, so min(k_tiles, 2) tokens are outstanding here.
     wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
-    if constexpr (k_tiles > 1u) {
+    if constexpr (Shape::kCubeTiles > 1u) {
       wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
     }
 #undef MXMM_TILE_GM
@@ -425,122 +382,104 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 #undef MXMM_EXTRACT
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-    GmOut out_g((__gm__ bfloat16_t *)out_gm +
-                ((uint64_t)mt * BASE_M * N + (uint64_t)nt * BASE_N));
-    TSTORE(out_g, c_l0);
-    // The next output tile's first multiply is non-accumulating and
-    // overwrites c_l0, so it waits for the store; its loads and extracts do
-    // not.
+    OutGlobal outGlobal((__gm__ bfloat16_t *)out_gm +
+                        ((uint64_t)mt * Shape::kRows * Shape::kN +
+                         (uint64_t)nt * Shape::kCols));
+    TSTORE(outGlobal, accL0);
     set_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
     wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
   }
 
-  // One ID3 post is outstanding: every tile posts and every tile but the
-  // first consumed one. Drain it so a later launch's first wait cannot return
-  // early.
   if (scales_held) {
     wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
   }
+}
+#endif
+
+inline uint32_t pickMTile(uint32_t m) {
+  if (m % TILE_M_BIG == 0u &&
+      (m / TILE_M_BIG) * (TEST_N / TILE_N) >= TARGET_BLOCKS) {
+    return TILE_M_BIG;
+  }
+  if (m % TILE_M == 0u) {
+    return TILE_M;
+  }
+  return TILE_M_MIN;
+}
+
+inline uint32_t pickMRound(uint32_t m) {
+  if (m == 0u) return TILE_M_MIN;
+  if (m <= TILE_M_MIN) return TILE_M_MIN;
+  return ((m + TILE_M - 1u) / TILE_M) * TILE_M;
+}
+
+}  // namespace
+
+template <unsigned kMMax, unsigned kK, unsigned kN, unsigned kBaseM,
+          unsigned kBaseN>
+__global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
+                                    __gm__ void *b_gm, __gm__ void *b_scale_gm,
+                                    __gm__ void *out_gm, uint32_t m_total,
+                                    uint32_t core_count) {
+#if defined(__DAV_CUBE__)
+  runMxfp4Matmul<TileShape<kMMax, kK, kN, kBaseM, kBaseN>>(
+      a_gm, a_scale_gm, b_gm, b_scale_gm, out_gm, m_total, core_count);
 #else
   (void)a_gm;
   (void)a_scale_gm;
   (void)b_gm;
   (void)b_scale_gm;
   (void)out_gm;
+  (void)m_total;
   (void)core_count;
 #endif
 }
 
-// The shape this translation unit is built for. K must be a multiple of K_L1,
-// so it cannot be under one L1 slab; 512 is the narrowest that builds at the
-// default slab width.
-#ifndef MXMM_TEST_K
-#define MXMM_TEST_K 512
-#endif
-#ifndef MXMM_TEST_N
-#define MXMM_TEST_N 512
-#endif
-constexpr unsigned TEST_M_MAX = 65536;  // an upper bound, not the shape
-constexpr unsigned M_TILE_ROWS = TINY_M;
-constexpr unsigned TEST_K = MXMM_TEST_K, TEST_N = MXMM_TEST_N;
+namespace {
 
-// Which output tile suits this M. The big one moves less data but halves the
-// block count, so it only pays where the shape still fills the cores; the
-// threshold is the launcher's own block cap.
-constexpr uint32_t TARGET_BLOCKS = 64u;
-inline uint32_t mxfp4_matmul_pick_m_tile(uint32_t m) {
-  if (m % BIG_M == 0u && (m / BIG_M) * (TEST_N / BIG_N) >= TARGET_BLOCKS) {
-    return BIG_M;
-  }
-  if (m % SMALL_M == 0u) {
-    return SMALL_M;
-  }
-  return TINY_M;
-}
-
-// What a caller with an awkward M should round up to. The tiny tile is only
-// right up to its own height: each output tile streams a whole B column
-// panel, so M=64 as four 16-row tiles reads B four times where one padded
-// 128-row tile reads it once.
-inline uint32_t mxfp4_matmul_pick_m_round(uint32_t m) {
-  if (m == 0u) return TINY_M;
-  if (m <= TINY_M) return TINY_M;
-  return ((m + SMALL_M - 1u) / SMALL_M) * SMALL_M;
-}
-
-static inline void mxfp4_matmul_launch(uint32_t block_dim, void *stream,
-                                       uint8_t *a_gm, uint8_t *a_scale_gm,
-                                       uint8_t *b_gm, uint8_t *b_scale_gm,
-                                       uint8_t *out_gm, uint32_t m, uint32_t k,
-                                       uint32_t n) {
-  // The host rejects what has no instantiation: a launcher that returns
-  // quietly hands the caller an untouched output buffer back.
-  if (block_dim == 0u) return;
+inline void launchMatmul(uint32_t blockDim, void *stream, uint8_t *a_gm,
+                         uint8_t *a_scale_gm, uint8_t *b_gm,
+                         uint8_t *b_scale_gm, uint8_t *out_gm, uint32_t m,
+                         uint32_t k, uint32_t n) {
+  // The host must reject what has no instantiation: returning quietly hands
+  // the caller an untouched output buffer back.
+  if (blockDim == 0u) return;
   if (k != TEST_K || n != TEST_N) return;
-  // M is runtime, but still has to be whole tiles and within the declared
-  // maximum.
-  if (m == 0u || m % M_TILE_ROWS != 0u || m > TEST_M_MAX) return;
+  if (m == 0u || m % TILE_M_MIN != 0u || m > TEST_M_MAX) return;
   // NEVER guard this launch with a device-pass macro.
-  const uint32_t tile = mxfp4_matmul_pick_m_tile(m);
-  if (tile == BIG_M) {
-    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, BIG_M, BIG_N>
-        <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
-                                         out_gm, m, block_dim);
-  } else if (tile == SMALL_M) {
-    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, SMALL_M, SMALL_N>
-        <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
-                                         out_gm, m, block_dim);
+  const uint32_t tile = pickMTile(m);
+  if (tile == TILE_M_BIG) {
+    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, TILE_M_BIG, TILE_N>
+        <<<blockDim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
+                                        out_gm, m, blockDim);
+  } else if (tile == TILE_M) {
+    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, TILE_M, TILE_N>
+        <<<blockDim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
+                                        out_gm, m, blockDim);
   } else {
-    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, TINY_M, TINY_N>
-        <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
-                                         out_gm, m, block_dim);
+    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, TILE_M_MIN, TILE_N>
+        <<<blockDim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
+                                        out_gm, m, blockDim);
   }
 }
 
-extern "C" void call_mxfp4_matmul(uint32_t block_dim, void *stream,
+}  // namespace
+
+extern "C" void call_mxfp4_matmul(uint32_t blockDim, void *stream,
                                   uint8_t *a_gm, uint8_t *a_scale_gm,
                                   uint8_t *b_gm, uint8_t *b_scale_gm,
                                   uint8_t *out_gm, uint32_t m, uint32_t k,
                                   uint32_t n) {
-  mxfp4_matmul_launch(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
-                      out_gm, m, k, n);
+  launchMatmul(blockDim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm, out_gm, m,
+               k, n);
 }
 
-extern "C" uint32_t mxfp4_matmul_m_tile() { return M_TILE_ROWS; }
-// Callers should pass mxfp4_matmul_m_round(m) as the launch M, with an output
-// buffer of that many rows, rather than picking a multiple themselves.
-extern "C" uint32_t mxfp4_matmul_m_round(uint32_t m) {
-  return mxfp4_matmul_pick_m_round(m);
-}
-extern "C" uint32_t mxfp4_matmul_m_tile_for(uint32_t m) {
-  return mxfp4_matmul_pick_m_tile(m);
-}
-// the N extent that goes with it, so a caller can size its grid as
-// (m / m_tile_for) * (N / n_tile_for) without knowing the rule
+extern "C" uint32_t mxfp4_matmul_m_tile() { return TILE_M_MIN; }
+extern "C" uint32_t mxfp4_matmul_m_round(uint32_t m) { return pickMRound(m); }
+extern "C" uint32_t mxfp4_matmul_m_tile_for(uint32_t m) { return pickMTile(m); }
 extern "C" uint32_t mxfp4_matmul_n_tile_for(uint32_t m) {
-  const uint32_t tile = mxfp4_matmul_pick_m_tile(m);
-  if (tile == BIG_M) return BIG_N;
-  return tile == SMALL_M ? SMALL_N : TINY_N;
+  (void)m;  // all three tiles share one N
+  return TILE_N;
 }
 extern "C" uint32_t mxfp4_matmul_m_max() { return TEST_M_MAX; }
 extern "C" uint32_t mxfp4_matmul_k() { return TEST_K; }

--- a/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
+++ b/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
@@ -1,0 +1,729 @@
+// MXFP4 matmul on A5: y = A @ B with BOTH operands MXFP4, on the cube's
+// native microscaled path.
+//
+//   A: (M, K) E2M1 nibbles, two per byte, + one E8M0 scale per 32 along K
+//   B: (K, N) the same, stored DN -- see LAYOUTS
+//   y: (M, N) bf16, accumulated in fp32
+//
+// A5 has a microscaled matmul in hardware, TMATMUL_MX, whose semantics are
+// MXFP4 block-32 exactly. From PTO's own CPU reference
+// (pto/cpu/TMatmul.hpp:44-67):
+//
+//     acc += a(i, k) * b(k, j) * aScale(i, k / 32) * bScale(k / 32, j)
+//
+// So the scaling is in the datapath; this is not a dequantize-and-matmul. And
+// aScale is (M, K/32), exactly what our activation kernel writes, so the two
+// halves of the chain meet with no repacking.
+//
+// STRUCTURE follows the vendor's tuned reference at pto-isa/kernels/manual/a5/
+// matmul_mxfp4_performance/mxmatmul_performance_kernel.cpp, because a first
+// version written from the header signatures alone got FOUR separate things
+// wrong and produced plausible-looking garbage (rel 1.5, not noise). Each is
+// called out below so the reasoning survives.
+//
+// LAYOUTS -- asymmetric, and not guessable from the type names
+//   A data   Layout::ND       plain row-major (M, K)
+//   A scale  Layout::MX_A_ND  plain row-major (M, K/32)
+//   B data   Layout::DN       NOT ND
+//   B scale  Layout::MX_B_DN  NOT MX_B_ND
+// B being DN costs nothing, since weights are prepared offline, but feeding
+// row-major B silently computes something else.
+//
+// STRIDES come from a BaseShape2D of the WHOLE matrix, not of the tile.
+// Deriving them from the tile width makes every row after the first read from
+// the wrong place, which was most of what went wrong the first time.
+//
+// FP4 POINTER ARITHMETIC IS IN BYTES. sizeof(float4_e2m1x2_t) is 1 and it holds
+// two elements, so a K-element step is (K >> 1) bytes and a scale step is
+// (K >> 5). Advancing by element counts double-steps.
+//
+// SCALE TILES BIND BY ADDRESS. TMATMUL_MX takes them, but TMATMUL_MX_IMPL never
+// forwards them to the mad_mx builtin (a5/TMatmul.hpp:259-271) -- they exist
+// for the type check. The hardware reads them at GetScaleAddr(operand.data()),
+// a
+// >> 4 of the operand's L0 address (a5/utils.hpp:82-87): the MX scale store is
+// a 1/16 shadow of L0A/L0B. TASSIGNing them anywhere else compiles and
+// multiplies by whatever happens to be there.
+//
+// Alignment, all asserted by CheckMadMxValid: K a multiple of 64 ELEMENTS (from
+// BASEK, and because the scale count K/32 must be even), N a multiple of 64 for
+// fp4, M a multiple of 16, accumulator fp32.
+//
+// Arch: cube plus a store, so dav-c310. No MIX, no cross-core sync.
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+constexpr uint32_t SCALE_FACTOR = 32;       // elements per E8M0 scale
+constexpr uint32_t SHIFT_SCALE_FACTOR = 5;  // log2(SCALE_FACTOR)
+constexpr uint32_t SHIFT_FP4 = 1;           // two nibbles per byte
+
+// Output-tile shape. The L1 fill for the whole matmul is
+// M*N*K*bytes_per_elem * (1/BASE_M + 1/BASE_N), so both dimensions cut
+// re-fetch and L0C, which holds one output tile as fp32, is what bounds
+// them. Overridable so the tradeoff can be swept.
+#ifndef MXMM_BASE_M
+#define MXMM_BASE_M 128
+#endif
+#ifndef MXMM_BASE_N
+#define MXMM_BASE_N 256
+#endif
+// Two output-tile shapes, chosen at launch. The big one cuts L1 re-fetch by
+// (1/BASE_M + 1/BASE_N) and measured 1.49x at M=4096 K=N=8192, but it also
+// halves the block count, and at M=256 that starved the 32 cube cores and
+// measured 0.65x. So the launcher picks per M rather than one being right.
+constexpr unsigned SMALL_M = MXMM_BASE_M;  // 16-aligned
+constexpr unsigned SMALL_N = MXMM_BASE_N;  // 64-aligned for fp4
+// A K_L1=1024 slab needs 544 KB for two L1 sets at a (256,256) output tile,
+// over the 512 KB L1, so testing it requires holding the tile at (128,256) --
+// which costs 1.5x the fill per output element, (1/128 + 1/256) against
+// (1/256 + 1/256). Defining this collapses the big tile onto the small one so
+// only one shape is instantiated and the assert has a chance of passing.
+#ifdef MXMM_NO_BIG_TILE
+constexpr unsigned BIG_M = SMALL_M;
+#else
+constexpr unsigned BIG_M = 2u * SMALL_M;
+#endif
+constexpr unsigned BIG_N = SMALL_N;
+
+// A third, 16-row output tile for small M. Below M=128 the launcher had to pad
+// up to the 128-row tile, which does 128 rows of arithmetic for a caller that
+// wants one -- and at K=N=2048 to 4096 that padding cost more than the format
+// saved, leaving those shapes at 0.91-0.98x of bf16. Sixteen is the alignment
+// floor TMATMUL_MX imposes, so it is the finest tile available.
+//
+// The extra fill this costs is real, (1/16 + 1/256) against (1/128 + 1/256)
+// per output element, but at small M the traffic is dominated by streaming B
+// regardless, and B's share does not change with the M tile.
+#ifndef MXMM_TINY_M
+#define MXMM_TINY_M 16
+#endif
+constexpr unsigned TINY_M = MXMM_TINY_M;
+constexpr unsigned TINY_N = SMALL_N;
+constexpr unsigned BASE_K = 256;  // multiple of 64
+
+// How many L1 sets, and so how far ahead the GM->L1 load runs: a tile is
+// extracted LOOKAHEAD passes after it is loaded.
+//
+// Two, not three. Three measured 1.00x at every shape from K=N=4096 to 8192,
+// because the loads are already at the memory system's limit rather than
+// waiting on latency: with the extract and the multiply both switched off the
+// kernel still takes 687 of its 687 us at K=N=8192, moving 1.14 GB at
+// 1660 GB/s against a 1600 GB/s peak. A deeper prefetch hides latency, and
+// there is none here to hide. The third set stays wired up behind the knob
+// because it costs 68 KB of L1 to enable and the balance is proven.
+// The L1 slab's K extent, independent of the cube's BASE_K. A GM->L1 copy of
+// a (BASE_M, K_L1) fp4 tile moves K_L1/2 contiguous bytes per row, so at the
+// default 256 that is 128 B -- a quarter of a 512-byte line. Widening it
+// lengthens every DMA burst without changing the byte count, and the cube
+// still consumes BASE_K at a time from a K_SUB-step inner loop. The vendor's
+// kernel_qbmm_mx does exactly this, sizing its kL1 against half of L1.
+// 512, not 256. Measured 1.35x at K=N=4096 and 1.57x at 8192, and the
+// loads-only arm moves the same bytes 1.60x faster, so the limit was
+// per-descriptor issue cost rather than bandwidth. 1024 would give full
+// 512-byte bursts but needs 544 KB for two sets against a 512 KB L1.
+#ifndef MXMM_K_L1
+#define MXMM_K_L1 512
+#endif
+constexpr unsigned K_L1 = MXMM_K_L1;
+constexpr unsigned K_SUB = K_L1 / BASE_K;
+static_assert(K_L1 % BASE_K == 0, "the slab must be whole cube K tiles");
+static_assert(K_SUB >= 1u, "at least one sub-tile per slab");
+
+#ifndef MXMM_L1_SETS
+#define MXMM_L1_SETS 2
+#endif
+constexpr uint32_t L1_SETS = (uint32_t)(MXMM_L1_SETS);
+constexpr uint32_t LOOKAHEAD = L1_SETS - 1u;
+// One set is allowed. With LOOKAHEAD 0 the slab is loaded at the top of its
+// own iteration and extracted immediately after, so the load no longer
+// overlaps the extract and multiply -- which costs little when the load is
+// already 97% of the runtime, and buys a 1024-wide slab at the wide output
+// tile: 272 KB for one set against 544 for two.
+static_assert(L1_SETS >= 1u, "at least one L1 set");
+static_assert(L1_SETS <= 3u, "only two and three sets are wired up");
+
+// Output tiles are walked SWIZZLE_GROUP rows down before stepping across, so
+// the blocks resident at one time form a square-ish patch of the output rather
+// than a full-width strip. 1 restores the plain row-major walk.
+#ifndef MXMM_SWIZZLE
+#define MXMM_SWIZZLE 8
+#endif
+constexpr uint32_t SWIZZLE_GROUP = (uint32_t)(MXMM_SWIZZLE);
+static_assert(SWIZZLE_GROUP >= 1u, "a group spans at least one tile row");
+constexpr unsigned BASE_SK = BASE_K / SCALE_FACTOR;
+
+static_assert(SMALL_M % 16 == 0 && BIG_M % 16 == 0, "M must be 16-aligned");
+static_assert(TINY_M % 16 == 0, "M must be 16-aligned");
+static_assert(SMALL_M % TINY_M == 0, "the coarser tiles are multiples of it");
+static_assert(SMALL_N % 64 == 0 && BIG_N % 64 == 0, "fp4 needs N 64-aligned");
+static_assert(BIG_M % SMALL_M == 0,
+              "the big tile's M must be a multiple of the small one's, so "
+              "one admissibility check covers both");
+static_assert(BASE_K % 64 == 0, "TMATMUL_MX needs K a multiple of 64");
+
+// K and N are template parameters so the GM strides stay static -- they are
+// per-layer constants. M is RUNTIME, which is the whole point: block_dim is
+// m_tiles * n_tiles, so a compile-time M of 128 capped parallelism at N/256,
+// i.e. four cores at N=1024. M is the token count of the batch, and letting it
+// grow is what fills the machine.
+//
+// M_MAX only sizes the BaseShape2D extents. Every GM offset here is computed
+// explicitly from BASE_M/BASE_N/BASE_K, so addressing does not depend on it; it
+// has to be an upper bound on the real M, which the host checks.
+template <unsigned M_MAX, unsigned K, unsigned N, unsigned BM, unsigned BN>
+// groups: how many independent problems of this same shape sit back to back
+// in memory. One launch covers all of them, because the host can only issue a
+// kernel every 5 us or so, and at K=N=512 that is 94% of a matmul's cost.
+// groups == 1 is the ordinary path and compiles to the same work list.
+__global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
+                                    __gm__ void *b_gm, __gm__ void *b_scale_gm,
+                                    __gm__ void *out_gm, uint32_t m_total,
+                                    uint32_t core_count, uint32_t groups) {
+  // The body reads BASE_M/BASE_N throughout; binding them here means the
+  // tile shape becomes a template parameter without touching a single
+  // offset, Shape type or TASSIGN below.
+  constexpr unsigned BASE_M = BM;
+  constexpr unsigned BASE_N = BN;
+#if defined(__DAV_CUBE__)
+  using Fp4 = float4_e2m1x2_t;
+  using E8m0 = float8_e8m0_t;
+  constexpr unsigned SK = K / SCALE_FACTOR;
+
+  // DYNAMIC shape, whole-matrix stride -- exactly what both reference sources
+  // do. Pairing a STATIC tile shape with a full-matrix BaseShape2D left A's
+  // first 8 rows reading as zero; the dynamic form passes the real extents at
+  // construction instead of encoding them in the type. It is also why the scale
+  // assert accepts these: staticShape[4] == 2 OR -1 (a5/TLoad.hpp:85).
+  using DynShape = pto::Shape<1, 1, 1, -1, -1>;
+  using GmA = GlobalTensor<Fp4, DynShape,
+                           BaseShape2D<Fp4, M_MAX, K, Layout::ND>, Layout::ND>;
+  using GmB = GlobalTensor<Fp4, DynShape, BaseShape2D<Fp4, K, N, Layout::DN>,
+                           Layout::DN>;
+  // The scale tensors' SHAPE must come from TileShape2D, not a hand-written
+  // pto::Shape: TLoad asserts staticShape[4] == 2 for every MX_*_ND/DN layout
+  // (a5/TLoad.hpp:85), because scales are grouped in pairs along K. That
+  // pairing is also why K/32 has to be even, i.e. why K must be a multiple of
+  // 64 and not merely of 32.
+  using GmAS = GlobalTensor<E8m0, DynShape,
+                            BaseShape2D<E8m0, M_MAX, SK, Layout::MX_A_ND>,
+                            Layout::MX_A_ND>;
+  using GmBS =
+      GlobalTensor<E8m0, DynShape, BaseShape2D<E8m0, SK, N, Layout::MX_B_DN>,
+                   Layout::MX_B_DN>;
+  using GmOut =
+      GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, BASE_M, BASE_N>,
+                   BaseShape2D<bfloat16_t, M_MAX, N, Layout::ND>, Layout::ND>;
+
+  // L1. A is ColMajor with a RowMajor fractal, B RowMajor with a ColMajor one;
+  // the asymmetry is what CheckMadMxValid asserts on the L0 tiles downstream.
+  // The explicit 512-byte fractal matters. Omitting it, as the vendor's tuned
+  // reference does, left A's FIRST 8 ROWS reading as zero -- output rows 0..7
+  // came back written-but-zero at every probe shift while rows 8+ were exactly
+  // right, so the K pairing was already identity and only A's row placement was
+  // wrong. The conformance test passes 512 explicitly; the vendor relies on a
+  // default that evidently is not the same here.
+  // L1 holds a K_L1-wide slab; L0 below still holds BASE_K, and the extract
+  // picks sub-tile j out of the slab at column offset j*BASE_K.
+  constexpr unsigned SK_L1 = K_L1 / SCALE_FACTOR;
+  using MatA = Tile<TileType::Mat, Fp4, BASE_M, K_L1, BLayout::ColMajor, BASE_M,
+                    K_L1, SLayout::RowMajor, 512>;
+  using MatB = Tile<TileType::Mat, Fp4, K_L1, BASE_N, BLayout::RowMajor, K_L1,
+                    BASE_N, SLayout::ColMajor, 512>;
+  using MatAS = Tile<TileType::Mat, E8m0, BASE_M, SK_L1, BLayout::RowMajor,
+                     BASE_M, SK_L1, SLayout::RowMajor, 32>;
+  using MatBS = Tile<TileType::Mat, E8m0, SK_L1, BASE_N, BLayout::ColMajor,
+                     SK_L1, BASE_N, SLayout::ColMajor, 32>;
+
+  // L0, using the Compact variants the tuned reference uses.
+  using Left = TileLeft<Fp4, BASE_M, BASE_K, BASE_M, BASE_K>;
+  using Right = TileRight<Fp4, BASE_K, BASE_N, BASE_K, BASE_N>;
+  using LeftS = TileLeftScale<E8m0, BASE_M, BASE_SK, BASE_M, BASE_SK>;
+  using RightS = TileRightScale<E8m0, BASE_SK, BASE_N, BASE_SK, BASE_N>;
+  using Acc = TileAcc<float, BASE_M, BASE_N, BASE_M, BASE_N>;
+
+  // L1 is double buffered so the K loop can overlap its GM->L1 load with
+  // its extract and multiply. One set is 51 KB.
+  MatA a_l1, a_l1b, a_l1c;
+  MatB b_l1, b_l1b, b_l1c;
+  MatAS as_l1, as_l1b, as_l1c;
+  MatBS bs_l1, bs_l1b, bs_l1c;
+  // L0 is double buffered too. One fp4 operand tile is 32 KB and L0A and L0B
+  // are 64 KB each, so two sets fit exactly, which is why BASE_K stays 256:
+  // (256,512,256) measures 1692 TF/s on the cube against 1653 here, but needs
+  // all 64 KB per side and leaves no room for the second set.
+  Left a_l0, a_l0b;
+  Right b_l0, b_l0b;
+  LeftS as_l0, as_l0b;
+  RightS bs_l0, bs_l0b;
+  Acc c_l0;
+
+  constexpr uint32_t a_l1_bytes = (BASE_M * K_L1) >> SHIFT_FP4;
+  constexpr uint32_t b_l1_bytes = (K_L1 * BASE_N) >> SHIFT_FP4;
+  TASSIGN(a_l1, 0x0);
+  TASSIGN(b_l1, a_l1_bytes);
+  TASSIGN(as_l1, a_l1_bytes + b_l1_bytes);
+  TASSIGN(bs_l1, a_l1_bytes + b_l1_bytes + BASE_M * SK_L1);
+  // the second set immediately after the first
+  constexpr uint32_t l1_set_bytes =
+      a_l1_bytes + b_l1_bytes + BASE_M * SK_L1 + SK_L1 * BASE_N;
+  TASSIGN(a_l1b, l1_set_bytes);
+  TASSIGN(b_l1b, l1_set_bytes + a_l1_bytes);
+  TASSIGN(as_l1b, l1_set_bytes + a_l1_bytes + b_l1_bytes);
+  TASSIGN(bs_l1b, l1_set_bytes + a_l1_bytes + b_l1_bytes + BASE_M * SK_L1);
+  // The third set is assigned unconditionally and simply goes untouched at
+  // L1_SETS == 2; an unused TASSIGN costs nothing at runtime.
+  TASSIGN(a_l1c, 2u * l1_set_bytes);
+  TASSIGN(b_l1c, 2u * l1_set_bytes + a_l1_bytes);
+  TASSIGN(as_l1c, 2u * l1_set_bytes + a_l1_bytes + b_l1_bytes);
+  TASSIGN(bs_l1c, 2u * l1_set_bytes + a_l1_bytes + b_l1_bytes + BASE_M * SK_L1);
+  // L1 is 512 KB on this part, established by bisection: two sets of a
+  // K_L1=512 slab are 272 KB and run exactly, two of a K_L1=1024 slab are
+  // 544 KB and fault at launch with 507015. So the widest double-buffered
+  // slab at the big output tile is 512, giving 256-byte GM->L1 bursts.
+  static_assert(
+      L1_SETS * (a_l1_bytes + b_l1_bytes + BASE_M * SK_L1 + SK_L1 * BASE_N) <=
+          512u * 1024u,
+      "L1 sets must fit the 512 KB L1");
+  constexpr uint32_t a_l0_bytes = (BASE_M * BASE_K) >> SHIFT_FP4;
+  constexpr uint32_t b_l0_bytes = (BASE_K * BASE_N) >> SHIFT_FP4;
+  static_assert(2u * a_l0_bytes <= 64u * 1024u, "two A tiles must fit L0A");
+  static_assert(2u * b_l0_bytes <= 64u * 1024u, "two B tiles must fit L0B");
+  TASSIGN(a_l0, 0x0);
+  TASSIGN(b_l0, 0x0);
+  TASSIGN(a_l0b, a_l0_bytes);
+  TASSIGN(b_l0b, b_l0_bytes);
+  TASSIGN(c_l0, 0x0);
+  TASSIGN(as_l0, GetScaleAddr(a_l0.data()));
+  TASSIGN(bs_l0, GetScaleAddr(b_l0.data()));
+  TASSIGN(as_l0b, GetScaleAddr(a_l0b.data()));
+  TASSIGN(bs_l0b, GetScaleAddr(b_l0b.data()));
+
+  const uint32_t m_tiles = m_total / BASE_M;
+  constexpr uint32_t n_tiles = N / BASE_N;
+  constexpr uint32_t k_tiles = K / BASE_K;
+  constexpr uint32_t k_slabs = K / K_L1;
+  static_assert(K % K_L1 == 0u, "K must be whole L1 slabs");
+  const uint32_t out_tiles = m_tiles * n_tiles;
+
+  const uint32_t per_group = SWIZZLE_GROUP * n_tiles;
+  // Strides between consecutive problems, in bytes, from the shape alone: fp4
+  // operands are half a byte per element and E8M0 scales one per 32.
+  const uint64_t a_step = ((uint64_t)m_total * K) >> SHIFT_FP4;
+  const uint64_t as_step = ((uint64_t)m_total * K) >> SHIFT_SCALE_FACTOR;
+  constexpr uint64_t b_step = ((uint64_t)K * N) >> SHIFT_FP4;
+  constexpr uint64_t bs_step = ((uint64_t)K * N) >> SHIFT_SCALE_FACTOR;
+  const uint64_t o_step = (uint64_t)m_total * N * sizeof(bfloat16_t);
+  const uint32_t work_items = out_tiles * groups;
+  for (uint32_t w = get_block_idx(); w < work_items; w += core_count) {
+    const uint32_t grp = w / out_tiles;
+    const uint32_t t = w % out_tiles;
+    __gm__ uint8_t *a_gm_g = (__gm__ uint8_t *)a_gm + grp * a_step;
+    __gm__ uint8_t *as_gm_g = (__gm__ uint8_t *)a_scale_gm + grp * as_step;
+    __gm__ uint8_t *b_gm_g = (__gm__ uint8_t *)b_gm + grp * b_step;
+    __gm__ uint8_t *bs_gm_g = (__gm__ uint8_t *)b_scale_gm + grp * bs_step;
+    __gm__ uint8_t *out_gm_g = (__gm__ uint8_t *)out_gm + grp * o_step;
+    const uint32_t in_group = t % per_group;
+    const uint32_t first_mt = (t / per_group) * SWIZZLE_GROUP;
+    const uint32_t group_mts =
+        m_tiles - first_mt < SWIZZLE_GROUP ? m_tiles - first_mt : SWIZZLE_GROUP;
+    const uint32_t mt = first_mt + in_group % group_mts;
+    const uint32_t nt = in_group / group_mts;
+    // The K loop is software pipelined across the two L1 sets: tile kt+1's
+    // GM->L1 load is issued before tile kt is extracted and multiplied, so
+    // the DMA and the rest overlap instead of taking each other's time.
+    // Measured single-buffered at K=N=8192, the loads cost 872 us and the
+    // extract-plus-multiply 599, and the total was their sum, 1472.
+    //
+    // One flag pair per buffer, so a wait cannot consume the other's token:
+    //   EVENT_ID0/1  buffer 0/1's load has landed   (MTE2 -> MTE1)
+    //   EVENT_ID2/3  buffer 0/1 is free to refill   (MTE1 -> MTE2)
+    //   EVENT_ID4    L0 extract done                (MTE1 -> M)
+    //   EVENT_ID5    the cube is done reading L0    (M -> MTE1)
+// Timing-only address collapses. MXMM_B_SAME_PANEL points every block at B
+// column panel 0, so B's footprint per launch falls from N/BASE_N panels to
+// one; MXMM_A_SAME_PANEL does the same for A's row panels. The access pattern,
+// the byte count issued and the instruction stream are all unchanged -- only
+// the range of addresses touched shrinks. If the load time falls, the memory
+// system is serving repeats from L2 and our traffic is being evicted; if it
+// does not, these DMA reads do not benefit from L2 and no traversal or cache
+// hint can help.
+#ifdef MXMM_A_SAME_PANEL
+#define MXMM_MT_LOAD 0u
+#else
+#define MXMM_MT_LOAD mt
+#endif
+#ifdef MXMM_B_SAME_PANEL
+#define MXMM_NT_LOAD 0u
+#else
+#define MXMM_NT_LOAD nt
+#endif
+
+#define MXMM_TILE_GM(kk)                                                   \
+  GmA a_g((__gm__ Fp4 *)a_gm_g +                                           \
+              (((uint64_t)MXMM_MT_LOAD * BASE_M * K + (uint64_t)(kk)) >>   \
+               SHIFT_FP4),                                                 \
+          DynShape(BASE_M, K_L1));                                         \
+  GmB b_g((__gm__ Fp4 *)b_gm_g +                                           \
+              (((uint64_t)MXMM_NT_LOAD * BASE_N * K + (uint64_t)(kk)) >>   \
+               SHIFT_FP4),                                                 \
+          DynShape(K_L1, BASE_N));                                         \
+  GmAS as_g((__gm__ E8m0 *)as_gm_g +                                       \
+                (((uint64_t)MXMM_MT_LOAD * BASE_M * K + (uint64_t)(kk)) >> \
+                 SHIFT_SCALE_FACTOR),                                      \
+            DynShape(BASE_M, SK_L1));                                      \
+  GmBS bs_g((__gm__ E8m0 *)bs_gm_g +                                       \
+                (((uint64_t)MXMM_NT_LOAD * BASE_N * K + (uint64_t)(kk)) >> \
+                 SHIFT_SCALE_FACTOR),                                      \
+            DynShape(SK_L1, BASE_N))
+
+// ATTRIBUTION SWITCHES, all three timing-only and all producing wrong output:
+//   -DMXMM_NO_LOAD     drops GM->L1, so the difference is the load
+//   -DMXMM_NO_EXTRACT  drops L1->L0, so the difference is the extract
+//   -DMXMM_NO_MATMUL   drops all but the first multiply, so the difference is
+//                      the cube issue itself
+// The bottleneck moved once the loads were overlapped, so which stage binds now
+// has to be measured rather than assumed.
+#ifdef MXMM_NO_LOAD
+#define MXMM_FILL(a1, b1, as1, bs1) ((void)0)
+#else
+#define MXMM_FILL(a1, b1, as1, bs1) \
+  do {                              \
+    TLOAD(a1, a_g);                 \
+    TLOAD(b1, b_g);                 \
+    TLOAD<MatAS, GmAS>(as1, as_g);  \
+    TLOAD<MatBS, GmBS>(bs1, bs_g);  \
+  } while (0)
+#endif
+
+#ifdef MXMM_NO_EXTRACT
+#define MXMM_DRAIN_TO_L0(a1, b1, as1, bs1, a0, b0, as0, bs0, sub) ((void)0)
+#else
+// sub is the tile's index within the slab. A holds K along its columns and B
+// along its rows, so the offset goes in a different argument for each.
+#define MXMM_DRAIN_TO_L0(a1, b1, as1, bs1, a0, b0, as0, bs0, sub) \
+  do {                                                            \
+    const uint16_t koff_ = (uint16_t)((sub) * BASE_K);            \
+    const uint16_t soff_ = (uint16_t)((sub) * BASE_SK);           \
+    TEXTRACT(a0, a1, 0, koff_);                                   \
+    TEXTRACT(b0, b1, koff_, 0);                                   \
+    TEXTRACT(as0, as1, 0, soff_);                                 \
+    TEXTRACT(bs0, bs1, soff_, 0);                                 \
+  } while (0)
+#endif
+
+// ID4 counts completed extracts and ID5 completed multiplies. Both pipes run
+// in order, so one counter each is enough: a wait releases the oldest
+// outstanding token, which is exactly the tile whose turn it is.
+#ifdef MXMM_NO_SYNC
+#define MXMM_POST_EXTRACT() ((void)0)
+#define MXMM_AWAIT_EXTRACT() ((void)0)
+#define MXMM_POST_MULTIPLY() ((void)0)
+#define MXMM_AWAIT_MULTIPLY() ((void)0)
+#else
+#define MXMM_POST_EXTRACT() set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4)
+#define MXMM_AWAIT_EXTRACT() wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4)
+#define MXMM_POST_MULTIPLY() set_flag(PIPE_M, PIPE_MTE1, EVENT_ID5)
+#define MXMM_AWAIT_MULTIPLY() wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5)
+#endif
+
+// ID0 counts landed loads and ID2 freed L1 sets. With three sets a pair of
+// flags per set would need six; one counter each way is enough because MTE2 and
+// MTE1 are both in order, so the oldest outstanding token always belongs to the
+// tile whose turn it is.
+#define MXMM_LOAD(sl, sel)                     \
+  do {                                         \
+    const uint32_t sel_ = (sel);               \
+    MXMM_TILE_GM((uint64_t)(sl) * K_L1);       \
+    if (sel_ == 0u) {                          \
+      MXMM_FILL(a_l1, b_l1, as_l1, bs_l1);     \
+    } else if (sel_ == 1u) {                   \
+      MXMM_FILL(a_l1b, b_l1b, as_l1b, bs_l1b); \
+    } else {                                   \
+      MXMM_FILL(a_l1c, b_l1c, as_l1c, bs_l1c); \
+    }                                          \
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0); \
+  } while (0)
+// e is the global K-tile index. A slab's load is waited for once, before its
+// first sub-tile, and the set is released once, after its last -- so ID0 and
+// ID2 count slabs while ID4 and ID5 still count cube tiles.
+#define MXMM_EXTRACT(e, a0, b0, as0, bs0)                                     \
+  do {                                                                        \
+    const uint32_t e_ = (e);                                                  \
+    const uint32_t slab_ = e_ / K_SUB;                                        \
+    const uint32_t sub_ = e_ % K_SUB;                                         \
+    const uint32_t sel_ = slab_ % L1_SETS;                                    \
+    if (sub_ == 0u) {                                                         \
+      wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);                             \
+    }                                                                         \
+    if (sel_ == 0u) {                                                         \
+      MXMM_DRAIN_TO_L0(a_l1, b_l1, as_l1, bs_l1, a0, b0, as0, bs0, sub_);     \
+    } else if (sel_ == 1u) {                                                  \
+      MXMM_DRAIN_TO_L0(a_l1b, b_l1b, as_l1b, bs_l1b, a0, b0, as0, bs0, sub_); \
+    } else {                                                                  \
+      MXMM_DRAIN_TO_L0(a_l1c, b_l1c, as_l1c, bs_l1c, a0, b0, as0, bs0, sub_); \
+    }                                                                         \
+    if (sub_ + 1u == K_SUB) {                                                 \
+      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);                              \
+    }                                                                         \
+    MXMM_POST_EXTRACT();                                                      \
+  } while (0)
+
+    // Prologue: LOOKAHEAD tiles are in flight before the first multiply, so
+    // a tile's extract waits on a load issued LOOKAHEAD passes earlier
+    // instead of one it started itself.
+    for (uint32_t j = 0u; j < LOOKAHEAD && j < k_slabs; ++j) {
+      MXMM_LOAD(j, j % L1_SETS);
+    }
+    for (uint32_t kt = 0; kt < k_tiles; ++kt) {
+      const bool odd = (kt & 1u) != 0u;
+      // One GM->L1 copy per slab, issued when the slab's first cube tile
+      // comes up rather than once per cube tile.
+      if (kt % K_SUB == 0u) {
+        const uint32_t slab_ahead = kt / K_SUB + LOOKAHEAD;
+        if (slab_ahead < k_slabs) {
+          if (slab_ahead >= L1_SETS) {  // that set must be fully extracted
+            wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
+          }
+          MXMM_LOAD(slab_ahead, slab_ahead % L1_SETS);
+        }
+      }
+#ifdef MXMM_SINGLE_L0
+      MXMM_EXTRACT(kt, a_l0, b_l0, as_l0, bs_l0);
+      MXMM_AWAIT_EXTRACT();
+#else
+      // Tile kt was extracted on the previous pass, so this pass extracts
+      // kt+1 into the OTHER L0 set and the cube's multiply of kt runs beside
+      // it. wait_flag stalls its target pipe, not the scalar unit, so the
+      // multiply still issues to M while MTE1 sits in the extract.
+      if (kt == 0u) {
+        MXMM_EXTRACT(0u, a_l0, b_l0, as_l0, bs_l0);
+      }
+      if (kt + 1u < k_tiles) {
+        if (kt >= 1u) {
+          MXMM_AWAIT_MULTIPLY();  // tile kt-1 has released that L0 set
+        }
+        if (odd) {  // kt+1 has the opposite parity, so the other L0 set
+          MXMM_EXTRACT(kt + 1u, a_l0, b_l0, as_l0, bs_l0);
+        } else {
+          MXMM_EXTRACT(kt + 1u, a_l0b, b_l0b, as_l0b, bs_l0b);
+        }
+      }
+      MXMM_AWAIT_EXTRACT();
+#endif
+#ifdef MXMM_NO_MATMUL
+      if (kt == 0u) {
+        TMATMUL_MX(c_l0, a_l0, as_l0, b_l0, bs_l0);
+      }
+#elif defined(MXMM_SINGLE_L0)
+      if (kt == 0u) {
+        TMATMUL_MX(c_l0, a_l0, as_l0, b_l0, bs_l0);
+      } else {
+        TMATMUL_MX(c_l0, c_l0, a_l0, as_l0, b_l0, bs_l0);
+      }
+#else
+      if (odd) {  // kt == 0 is even, so an odd tile always accumulates
+        TMATMUL_MX(c_l0, c_l0, a_l0b, as_l0b, b_l0b, bs_l0b);
+      } else if (kt == 0u) {
+        TMATMUL_MX(c_l0, a_l0, as_l0, b_l0, bs_l0);
+      } else {
+        TMATMUL_MX(c_l0, c_l0, a_l0, as_l0, b_l0, bs_l0);
+      }
+#endif
+      MXMM_POST_MULTIPLY();
+#ifdef MXMM_SINGLE_L0
+      // one L0 set, so the next extract cannot start until the cube is done
+      MXMM_AWAIT_MULTIPLY();
+#endif
+    }
+    // ID2 carries min(k_tiles, L1_SETS) tokens out of the loop: every extract
+    // posts one and only the loads far enough in consume one. Draining keeps
+    // a count from carrying into the next output tile, where a later wait
+    // would return early.
+    for (uint32_t d = 0u; d < L1_SETS && d < k_slabs; ++d) {
+      wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
+    }
+#ifndef MXMM_SINGLE_L0
+    // Every multiply posts on ID5 and only the extracts of tile 2 and later
+    // consume one, so min(k_tiles, 2) tokens are outstanding here.
+    MXMM_AWAIT_MULTIPLY();
+    if constexpr (k_tiles > 1u) {
+      MXMM_AWAIT_MULTIPLY();
+    }
+#endif
+#undef MXMM_TILE_GM
+#undef MXMM_FILL
+#undef MXMM_DRAIN_TO_L0
+#ifndef MXMM_NO_STORE
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    GmOut out_g((__gm__ bfloat16_t *)out_gm_g +
+                ((uint64_t)mt * BASE_M * N + (uint64_t)nt * BASE_N));
+    TSTORE(out_g, c_l0);
+    // The next output tile's first multiply is non-accumulating and overwrites
+    // c_l0, so it waits for the store; its loads and extracts do not.
+#ifdef MXMM_STORE_BLOCKS_MTE2
+    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
+#else
+    set_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
+    wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
+#endif
+#endif
+  }
+#else
+  (void)a_gm;
+  (void)a_scale_gm;
+  (void)b_gm;
+  (void)b_scale_gm;
+  (void)out_gm;
+  (void)core_count;
+#endif
+}
+
+// One instantiation while the numerics are being established. Generalising
+// means a dispatch fold like the fused kernel's, once this is right.
+// K = BASE_K and N = BASE_N deliberately: with one tile in every dimension the
+// TLOAD is not WINDOWED -- the L1 tile spans a whole row of the matrix, exactly
+// as in the conformance test, which is the one thing this kernel does
+// differently. If this is exact and K=512 is not, the strided load is the
+// fault.
+// The default shape must satisfy K % K_L1 == 0, so it cannot be under one
+// L1 slab. 512 is the narrowest K that builds at the default K_L1.
+#ifndef MXMM_TEST_K
+#define MXMM_TEST_K 512
+#endif
+#ifndef MXMM_TEST_N
+#define MXMM_TEST_N 512
+#endif
+constexpr unsigned TEST_M_MAX = 65536;  // an upper bound, not the shape
+// The launcher's alignment requirement is now the finest tile, so a caller
+// with M=16 needs no padding at all and one with M=1 pads to 16 rather than
+// 128.
+constexpr unsigned M_TILE_ROWS = TINY_M;
+constexpr unsigned TEST_K = MXMM_TEST_K, TEST_N = MXMM_TEST_N;
+
+// Which output tile suits this M. The big one moves less data but halves the
+// block count, so it only pays where the shape still fills the cores. The
+// threshold is the launcher's own block cap: below it fewer blocks means
+// idle cores and the saving is swamped. Measured 1.49x at M=4096 K=N=8192
+// where both shapes saturate, and 0.65x at M=256 where the big tile leaves
+// half the 32 cube cores idle.
+constexpr uint32_t TARGET_BLOCKS = 64u;
+inline uint32_t mxfp4_matmul_pick_m_tile(uint32_t m) {
+  if (m % BIG_M == 0u && (m / BIG_M) * (TEST_N / BIG_N) >= TARGET_BLOCKS) {
+    return BIG_M;
+  }
+  if (m % SMALL_M == 0u) {
+    return SMALL_M;
+  }
+  return TINY_M;
+}
+
+// What a caller with an awkward M should round up to.
+//
+// The tiny tile is only right up to its own height. Each output tile streams a
+// whole B column panel, so M=64 as four 16-row tiles reads B four times, while
+// one 128-row tile reads it once and merely wastes rows. B dominates the
+// traffic at small M, so the wasted rows are cheaper: measured at K=N=6144,
+// four 16-row tiles ran 0.66x of bf16 where the padded 128-row tile ran 1.63x.
+inline uint32_t mxfp4_matmul_pick_m_round(uint32_t m) {
+  if (m == 0u) return TINY_M;
+  if (m <= TINY_M) return TINY_M;
+  return ((m + SMALL_M - 1u) / SMALL_M) * SMALL_M;
+}
+
+static inline void mxfp4_matmul_launch(uint32_t block_dim, void *stream,
+                                       uint8_t *a_gm, uint8_t *a_scale_gm,
+                                       uint8_t *b_gm, uint8_t *b_scale_gm,
+                                       uint8_t *out_gm, uint32_t m, uint32_t k,
+                                       uint32_t n, uint32_t groups) {
+  // The host rejects what has no instantiation: a launcher that returns quietly
+  // hands the caller an untouched output buffer back.
+  if (block_dim == 0u) return;
+  if (k != TEST_K || n != TEST_N) return;
+  // M is runtime now, but still has to be whole tiles and within the declared
+  // maximum: a launcher that returns quietly hands back an untouched buffer.
+  if (m == 0u || m % M_TILE_ROWS != 0u || m > TEST_M_MAX) return;
+  // NEVER guard this launch with a device-pass macro.
+  const uint32_t tile = mxfp4_matmul_pick_m_tile(m);
+  if (tile == BIG_M) {
+    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, BIG_M, BIG_N>
+        <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
+                                         out_gm, m, block_dim, groups);
+  } else if (tile == SMALL_M) {
+    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, SMALL_M, SMALL_N>
+        <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
+                                         out_gm, m, block_dim, groups);
+  } else {
+    mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, TINY_M, TINY_N>
+        <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
+                                         out_gm, m, block_dim, groups);
+  }
+}
+
+// Launch the same kernel n times from C, so a caller measuring throughput
+// pays the Python and ctypes cost once instead of n times. At K=N=512 the
+// whole matmul is half a megaflop and 524 KB of weights, so essentially all of
+// the measured time is per-call overhead, and this separates the part that
+// belongs to the launch path from the part that belongs to the host binding.
+// One problem, the ordinary call.
+extern "C" void call_mxfp4_matmul(uint32_t block_dim, void *stream,
+                                  uint8_t *a_gm, uint8_t *a_scale_gm,
+                                  uint8_t *b_gm, uint8_t *b_scale_gm,
+                                  uint8_t *out_gm, uint32_t m, uint32_t k,
+                                  uint32_t n) {
+  mxfp4_matmul_launch(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
+                      out_gm, m, k, n, 1u);
+}
+
+// G problems of identical shape, laid out back to back, in a single launch.
+// block_dim should be sized against G * out_tiles rather than out_tiles.
+extern "C" void call_mxfp4_matmul_grouped(uint32_t groups, uint32_t block_dim,
+                                          void *stream, uint8_t *a_gm,
+                                          uint8_t *a_scale_gm, uint8_t *b_gm,
+                                          uint8_t *b_scale_gm, uint8_t *out_gm,
+                                          uint32_t m, uint32_t k, uint32_t n) {
+  if (groups == 0u) return;
+  mxfp4_matmul_launch(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
+                      out_gm, m, k, n, groups);
+}
+
+extern "C" void call_mxfp4_matmul_repeat(uint32_t reps, uint32_t block_dim,
+                                         void *stream, uint8_t *a_gm,
+                                         uint8_t *a_scale_gm, uint8_t *b_gm,
+                                         uint8_t *b_scale_gm, uint8_t *out_gm,
+                                         uint32_t m, uint32_t k, uint32_t n) {
+  for (uint32_t i = 0u; i < reps; ++i) {
+    call_mxfp4_matmul(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
+                      out_gm, m, k, n);
+  }
+}
+
+extern "C" uint32_t mxfp4_matmul_m_tile() { return M_TILE_ROWS; }
+// Callers should pass mxfp4_matmul_m_round(m) as the launch M, with an output
+// buffer of that many rows, rather than picking a multiple themselves.
+extern "C" uint32_t mxfp4_matmul_m_round(uint32_t m) {
+  return mxfp4_matmul_pick_m_round(m);
+}
+extern "C" uint32_t mxfp4_matmul_m_tile_for(uint32_t m) {
+  return mxfp4_matmul_pick_m_tile(m);
+}
+// the N extent that goes with it, so a caller can size its grid as
+// (m / m_tile_for) * (N / n_tile_for) without knowing the rule
+extern "C" uint32_t mxfp4_matmul_n_tile_for(uint32_t m) {
+  const uint32_t tile = mxfp4_matmul_pick_m_tile(m);
+  if (tile == BIG_M) return BIG_N;
+  return tile == SMALL_M ? SMALL_N : TINY_N;
+}
+extern "C" uint32_t mxfp4_matmul_m_max() { return TEST_M_MAX; }
+extern "C" uint32_t mxfp4_matmul_k() { return TEST_K; }
+extern "C" uint32_t mxfp4_matmul_n() { return TEST_N; }
+
+// ---------------------------------------------------------------------------
+// The layout traps above are the ones that cost real time; each is called
+// out at the declaration it applies to. Measured throughput, the tuning
+// sweeps behind the defaults, and the approaches that were tried and
+// rejected are in README.md rather than here.

--- a/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
+++ b/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
@@ -1,55 +1,40 @@
 // MXFP4 matmul on A5: y = A @ B with BOTH operands MXFP4, on the cube's
-// native microscaled path.
+// native microscaled path, TMATMUL_MX.
 //
 //   A: (M, K) E2M1 nibbles, two per byte, + one E8M0 scale per 32 along K
 //   B: (K, N) the same, stored DN -- see LAYOUTS
 //   y: (M, N) bf16, accumulated in fp32
 //
-// A5 has a microscaled matmul in hardware, TMATMUL_MX, whose semantics are
-// MXFP4 block-32 exactly. From PTO's own CPU reference
-// (pto/cpu/TMatmul.hpp:44-67):
+// The scaling is in the datapath, so this is not a dequantize-and-matmul.
+// From PTO's CPU reference (pto/cpu/TMatmul.hpp:44-67):
 //
 //     acc += a(i, k) * b(k, j) * aScale(i, k / 32) * bScale(k / 32, j)
 //
-// So the scaling is in the datapath; this is not a dequantize-and-matmul. And
-// aScale is (M, K/32), exactly what our activation kernel writes, so the two
-// halves of the chain meet with no repacking.
-//
-// STRUCTURE follows the vendor's tuned reference at pto-isa/kernels/manual/a5/
-// matmul_mxfp4_performance/mxmatmul_performance_kernel.cpp, because a first
-// version written from the header signatures alone got FOUR separate things
-// wrong and produced plausible-looking garbage (rel 1.5, not noise). Each is
-// called out below so the reasoning survives.
-//
-// LAYOUTS -- asymmetric, and not guessable from the type names
-//   A data   Layout::ND       plain row-major (M, K)
-//   A scale  Layout::MX_A_ND  plain row-major (M, K/32)
+// LAYOUTS -- asymmetric, and not implied by the type names:
+//   A data   Layout::ND       row-major (M, K)
+//   A scale  Layout::MX_A_ND  row-major (M, K/32)
 //   B data   Layout::DN       NOT ND
 //   B scale  Layout::MX_B_DN  NOT MX_B_ND
-// B being DN costs nothing, since weights are prepared offline, but feeding
-// row-major B silently computes something else.
+// Feeding row-major B compiles and computes something else.
 //
-// STRIDES come from a BaseShape2D of the WHOLE matrix, not of the tile.
-// Deriving them from the tile width makes every row after the first read from
-// the wrong place, which was most of what went wrong the first time.
+// FP4 POINTER ARITHMETIC IS IN BYTES. sizeof(float4_e2m1x2_t) is 1 and it
+// holds two elements, so a K-element step is (K >> 1) bytes and a scale step
+// is (K >> 5).
 //
-// FP4 POINTER ARITHMETIC IS IN BYTES. sizeof(float4_e2m1x2_t) is 1 and it holds
-// two elements, so a K-element step is (K >> 1) bytes and a scale step is
-// (K >> 5). Advancing by element counts double-steps.
+// SCALE TILES BIND BY ADDRESS. TMATMUL_MX takes them for the type check but
+// never forwards them to the mad_mx builtin (a5/TMatmul.hpp:259-271). The
+// hardware reads them at GetScaleAddr(operand.data()), a >> 4 of the
+// operand's L0 address (a5/utils.hpp:82-87): the MX scale store is a 1/16
+// shadow of L0A/L0B. TASSIGNing them anywhere else compiles and multiplies
+// by whatever happens to be there.
 //
-// SCALE TILES BIND BY ADDRESS. TMATMUL_MX takes them, but TMATMUL_MX_IMPL never
-// forwards them to the mad_mx builtin (a5/TMatmul.hpp:259-271) -- they exist
-// for the type check. The hardware reads them at GetScaleAddr(operand.data()),
-// a
-// >> 4 of the operand's L0 address (a5/utils.hpp:82-87): the MX scale store is
-// a 1/16 shadow of L0A/L0B. TASSIGNing them anywhere else compiles and
-// multiplies by whatever happens to be there.
-//
-// Alignment, all asserted by CheckMadMxValid: K a multiple of 64 ELEMENTS (from
-// BASEK, and because the scale count K/32 must be even), N a multiple of 64 for
-// fp4, M a multiple of 16, accumulator fp32.
+// Alignment, all asserted by CheckMadMxValid: K a multiple of 64 ELEMENTS,
+// N a multiple of 64 for fp4, M a multiple of 16, accumulator fp32.
 //
 // Arch: cube plus a store, so dav-c310. No MIX, no cross-core sync.
+//
+// Measured throughput, the sweeps behind the defaults, and the approaches
+// tried and rejected are in README.md.
 #include <pto/common/constants.hpp>
 #include <pto/common/pto_tile.hpp>
 #include <pto/pto-inst.hpp>
@@ -61,69 +46,33 @@ constexpr uint32_t SHIFT_SCALE_FACTOR = 5;  // log2(SCALE_FACTOR)
 constexpr uint32_t SHIFT_FP4 = 1;           // two nibbles per byte
 
 // Output-tile shape. The L1 fill for the whole matmul is
-// M*N*K*bytes_per_elem * (1/BASE_M + 1/BASE_N), so both dimensions cut
-// re-fetch and L0C, which holds one output tile as fp32, is what bounds
-// them. Overridable so the tradeoff can be swept.
+// M*N*K*bytes_per_elem * (1/BASE_M + 1/BASE_N), and L0C, which holds one
+// output tile as fp32, is what bounds both dimensions.
 #ifndef MXMM_BASE_M
 #define MXMM_BASE_M 128
 #endif
 #ifndef MXMM_BASE_N
 #define MXMM_BASE_N 256
 #endif
-// Two output-tile shapes, chosen at launch. The big one cuts L1 re-fetch by
-// (1/BASE_M + 1/BASE_N) and measured 1.49x at M=4096 K=N=8192, but it also
-// halves the block count, and at M=256 that starved the 32 cube cores and
-// measured 0.65x. So the launcher picks per M rather than one being right.
 constexpr unsigned SMALL_M = MXMM_BASE_M;  // 16-aligned
 constexpr unsigned SMALL_N = MXMM_BASE_N;  // 64-aligned for fp4
-// A K_L1=1024 slab needs 544 KB for two L1 sets at a (256,256) output tile,
-// over the 512 KB L1, so testing it requires holding the tile at (128,256) --
-// which costs 1.5x the fill per output element, (1/128 + 1/256) against
-// (1/256 + 1/256). Defining this collapses the big tile onto the small one so
-// only one shape is instantiated and the assert has a chance of passing.
-#ifdef MXMM_NO_BIG_TILE
-constexpr unsigned BIG_M = SMALL_M;
-#else
+
+// A taller tile for large M: less L1 re-fetch, half the block count.
 constexpr unsigned BIG_M = 2u * SMALL_M;
-#endif
 constexpr unsigned BIG_N = SMALL_N;
 
-// A third, 16-row output tile for small M. Below M=128 the launcher had to pad
-// up to the 128-row tile, which does 128 rows of arithmetic for a caller that
-// wants one -- and at K=N=2048 to 4096 that padding cost more than the format
-// saved, leaving those shapes at 0.91-0.98x of bf16. Sixteen is the alignment
-// floor TMATMUL_MX imposes, so it is the finest tile available.
-//
-// The extra fill this costs is real, (1/16 + 1/256) against (1/128 + 1/256)
-// per output element, but at small M the traffic is dominated by streaming B
-// regardless, and B's share does not change with the M tile.
+// A 16-row tile for small M, so a caller with M below SMALL_M is not padded
+// up to it. 16 is the alignment floor TMATMUL_MX imposes.
 #ifndef MXMM_TINY_M
 #define MXMM_TINY_M 16
 #endif
 constexpr unsigned TINY_M = MXMM_TINY_M;
 constexpr unsigned TINY_N = SMALL_N;
-constexpr unsigned BASE_K = 256;  // multiple of 64
+constexpr unsigned BASE_K = 256;  // the cube's K tile, a multiple of 64
 
-// How many L1 sets, and so how far ahead the GM->L1 load runs: a tile is
-// extracted LOOKAHEAD passes after it is loaded.
-//
-// Two, not three. Three measured 1.00x at every shape from K=N=4096 to 8192,
-// because the loads are already at the memory system's limit rather than
-// waiting on latency: with the extract and the multiply both switched off the
-// kernel still takes 687 of its 687 us at K=N=8192, moving 1.14 GB at
-// 1660 GB/s against a 1600 GB/s peak. A deeper prefetch hides latency, and
-// there is none here to hide. The third set stays wired up behind the knob
-// because it costs 68 KB of L1 to enable and the balance is proven.
 // The L1 slab's K extent, independent of the cube's BASE_K. A GM->L1 copy of
-// a (BASE_M, K_L1) fp4 tile moves K_L1/2 contiguous bytes per row, so at the
-// default 256 that is 128 B -- a quarter of a 512-byte line. Widening it
-// lengthens every DMA burst without changing the byte count, and the cube
-// still consumes BASE_K at a time from a K_SUB-step inner loop. The vendor's
-// kernel_qbmm_mx does exactly this, sizing its kL1 against half of L1.
-// 512, not 256. Measured 1.35x at K=N=4096 and 1.57x at 8192, and the
-// loads-only arm moves the same bytes 1.60x faster, so the limit was
-// per-descriptor issue cost rather than bandwidth. 1024 would give full
-// 512-byte bursts but needs 544 KB for two sets against a 512 KB L1.
+// a (BASE_M, K_L1) fp4 tile moves K_L1/2 contiguous bytes per row, and the
+// cube still consumes BASE_K at a time from a K_SUB-step inner loop.
 #ifndef MXMM_K_L1
 #define MXMM_K_L1 512
 #endif
@@ -132,28 +81,23 @@ constexpr unsigned K_SUB = K_L1 / BASE_K;
 static_assert(K_L1 % BASE_K == 0, "the slab must be whole cube K tiles");
 static_assert(K_SUB >= 1u, "at least one sub-tile per slab");
 
+// How many L1 sets, and so how far ahead the GM->L1 load runs: a slab is
+// extracted LOOKAHEAD passes after it is loaded. With one set the slab is
+// loaded at the top of its own iteration and extracted immediately after, so
+// the load no longer overlaps the extract and multiply, and half the L1 is
+// free for a wider slab.
 #ifndef MXMM_L1_SETS
 #define MXMM_L1_SETS 2
 #endif
 constexpr uint32_t L1_SETS = (uint32_t)(MXMM_L1_SETS);
 constexpr uint32_t LOOKAHEAD = L1_SETS - 1u;
-// One set is allowed. With LOOKAHEAD 0 the slab is loaded at the top of its
-// own iteration and extracted immediately after, so the load no longer
-// overlaps the extract and multiply -- which costs little when the load is
-// already 97% of the runtime, and buys a 1024-wide slab at the wide output
-// tile: 272 KB for one set against 544 for two.
-static_assert(L1_SETS >= 1u, "at least one L1 set");
-static_assert(L1_SETS <= 3u, "only two and three sets are wired up");
+static_assert(L1_SETS >= 1u && L1_SETS <= 2u, "one or two L1 sets");
 
 // Output tiles are walked SWIZZLE_GROUP rows down before stepping across, so
-// the blocks resident at one time form a square-ish patch of the output rather
-// than a full-width strip. 1 restores the plain row-major walk.
-//
-// The right group depends on how many N tiles there are, so the default is
-// chosen per instantiation from n_tiles rather than fixed: a group of 2 is
-// worth 7-11% once n_tiles reaches 48, and is neutral to slightly worse below
-// that, where 8 holds. 16 is worse at every width measured. -DMXMM_SWIZZLE
-// overrides it. The numbers behind the threshold are in README.md.
+// the blocks resident at one time form a square-ish patch of the output
+// rather than a full-width strip. 1 restores the plain row-major walk. The
+// default is chosen per instantiation from n_tiles; -DMXMM_SWIZZLE overrides
+// it.
 constexpr uint32_t SWIZZLE_WIDE_TILES = 48u;
 constexpr uint32_t SWIZZLE_WIDE = 2u;
 constexpr uint32_t SWIZZLE_NARROW = 8u;
@@ -168,27 +112,20 @@ static_assert(BIG_M % SMALL_M == 0,
               "one admissibility check covers both");
 static_assert(BASE_K % 64 == 0, "TMATMUL_MX needs K a multiple of 64");
 
-// K and N are template parameters so the GM strides stay static -- they are
-// per-layer constants. M is RUNTIME, which is the whole point: block_dim is
-// m_tiles * n_tiles, so a compile-time M of 128 capped parallelism at N/256,
-// i.e. four cores at N=1024. M is the token count of the batch, and letting it
-// grow is what fills the machine.
+// K and N are template parameters so the GM strides stay static; they are
+// per-layer constants. M is RUNTIME, because block_dim is m_tiles * n_tiles
+// and a compile-time M would cap parallelism at N/BASE_N.
 //
 // M_MAX only sizes the BaseShape2D extents. Every GM offset here is computed
-// explicitly from BASE_M/BASE_N/BASE_K, so addressing does not depend on it; it
-// has to be an upper bound on the real M, which the host checks.
+// explicitly from BASE_M/BASE_N/BASE_K, so addressing does not depend on it;
+// it has to be an upper bound on the real M, which the host checks.
 template <unsigned M_MAX, unsigned K, unsigned N, unsigned BM, unsigned BN>
-// groups: how many independent problems of this same shape sit back to back
-// in memory. One launch covers all of them, because the host can only issue a
-// kernel every 5 us or so, and at K=N=512 that is 94% of a matmul's cost.
-// groups == 1 is the ordinary path and compiles to the same work list.
 __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
                                     __gm__ void *b_gm, __gm__ void *b_scale_gm,
                                     __gm__ void *out_gm, uint32_t m_total,
-                                    uint32_t core_count, uint32_t groups) {
-  // The body reads BASE_M/BASE_N throughout; binding them here means the
-  // tile shape becomes a template parameter without touching a single
-  // offset, Shape type or TASSIGN below.
+                                    uint32_t core_count) {
+  // The body reads BASE_M/BASE_N throughout, so binding them here makes the
+  // tile shape a template parameter without touching an offset or Shape type.
   constexpr unsigned BASE_M = BM;
   constexpr unsigned BASE_N = BN;
 #if defined(__DAV_CUBE__)
@@ -196,11 +133,10 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   using E8m0 = float8_e8m0_t;
   constexpr unsigned SK = K / SCALE_FACTOR;
 
-  // DYNAMIC shape, whole-matrix stride -- exactly what both reference sources
-  // do. Pairing a STATIC tile shape with a full-matrix BaseShape2D left A's
-  // first 8 rows reading as zero; the dynamic form passes the real extents at
-  // construction instead of encoding them in the type. It is also why the scale
-  // assert accepts these: staticShape[4] == 2 OR -1 (a5/TLoad.hpp:85).
+  // DYNAMIC shape, whole-matrix stride. Pairing a static tile shape with a
+  // full-matrix BaseShape2D reads A's first 8 rows as zero. It is also why
+  // the scale assert accepts these: staticShape[4] == 2 OR -1
+  // (a5/TLoad.hpp:85).
   using DynShape = pto::Shape<1, 1, 1, -1, -1>;
   using GmA = GlobalTensor<Fp4, DynShape,
                            BaseShape2D<Fp4, M_MAX, K, Layout::ND>, Layout::ND>;
@@ -209,8 +145,7 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   // The scale tensors' SHAPE must come from TileShape2D, not a hand-written
   // pto::Shape: TLoad asserts staticShape[4] == 2 for every MX_*_ND/DN layout
   // (a5/TLoad.hpp:85), because scales are grouped in pairs along K. That
-  // pairing is also why K/32 has to be even, i.e. why K must be a multiple of
-  // 64 and not merely of 32.
+  // pairing is why K must be a multiple of 64 and not merely of 32.
   using GmAS = GlobalTensor<E8m0, DynShape,
                             BaseShape2D<E8m0, M_MAX, SK, Layout::MX_A_ND>,
                             Layout::MX_A_ND>;
@@ -221,35 +156,24 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
       GlobalTensor<bfloat16_t, pto::Shape<1, 1, 1, BASE_M, BASE_N>,
                    BaseShape2D<bfloat16_t, M_MAX, N, Layout::ND>, Layout::ND>;
 
-  // L1. A is ColMajor with a RowMajor fractal, B RowMajor with a ColMajor one;
-  // the asymmetry is what CheckMadMxValid asserts on the L0 tiles downstream.
-  // The explicit 512-byte fractal matters. Omitting it, as the vendor's tuned
-  // reference does, left A's FIRST 8 ROWS reading as zero -- output rows 0..7
-  // came back written-but-zero at every probe shift while rows 8+ were exactly
-  // right, so the K pairing was already identity and only A's row placement was
-  // wrong. The conformance test passes 512 explicitly; the vendor relies on a
-  // default that evidently is not the same here.
-  // L1 holds a K_L1-wide slab; L0 below still holds BASE_K, and the extract
-  // picks sub-tile j out of the slab at column offset j*BASE_K.
-  constexpr unsigned SK_L1 = K_L1 / SCALE_FACTOR;
+  // L1. A is ColMajor with a RowMajor fractal, B RowMajor with a ColMajor
+  // one; CheckMadMxValid asserts that asymmetry on the L0 tiles downstream.
+  // The 512-byte fractal has to be explicit: omitting it reads A's first 8
+  // rows as zero.
+  //
+  // L1 holds a K_L1-wide slab; L0 below holds BASE_K, and the extract picks
+  // sub-tile j out of the slab at column offset j*BASE_K.
   using MatA = Tile<TileType::Mat, Fp4, BASE_M, K_L1, BLayout::ColMajor, BASE_M,
                     K_L1, SLayout::RowMajor, 512>;
   using MatB = Tile<TileType::Mat, Fp4, K_L1, BASE_N, BLayout::RowMajor, K_L1,
                     BASE_N, SLayout::ColMajor, 512>;
-  // The scales are held for the WHOLE K of an output tile, not per slab.
-  // Per slab they were 256 rows of 16 bytes each -- 3% of the bytes moved and
-  // 50% of the DMA descriptors issued, on a kernel whose loads are bound by
-  // descriptor issue rather than bandwidth. Held whole, they are one load of
-  // 256 rows of SK_ALL bytes, so the burst becomes a full cache line at
-  // K >= 16384 and the descriptor count per output tile falls from
-  // 4 * k_slabs units to 2 * k_slabs + 2. The vendor does the same thing at a
-  // cadence of 4 slabs (mxmatmul_performance_kernel.cpp:20, mxScalePara);
-  // whole-K is the same idea taken as far as L1 allows.
-  constexpr uint32_t SK_ALL = K / SCALE_FACTOR;
-  using MatAS = Tile<TileType::Mat, E8m0, BASE_M, SK_ALL, BLayout::RowMajor,
-                     BASE_M, SK_ALL, SLayout::RowMajor, 32>;
-  using MatBS = Tile<TileType::Mat, E8m0, SK_ALL, BASE_N, BLayout::ColMajor,
-                     SK_ALL, BASE_N, SLayout::ColMajor, 32>;
+  // The scales are held for the WHOLE K of an output tile, not per slab: one
+  // pair of loads covers every slab, so the burst is longer and the
+  // descriptor count per output tile falls from 4*k_slabs to 2*k_slabs + 2.
+  using MatAS = Tile<TileType::Mat, E8m0, BASE_M, SK, BLayout::RowMajor, BASE_M,
+                     SK, SLayout::RowMajor, 32>;
+  using MatBS = Tile<TileType::Mat, E8m0, SK, BASE_N, BLayout::ColMajor, SK,
+                     BASE_N, SLayout::ColMajor, 32>;
 
   // L0, using the Compact variants the tuned reference uses.
   using Left = TileLeft<Fp4, BASE_M, BASE_K, BASE_M, BASE_K>;
@@ -258,18 +182,17 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   using RightS = TileRightScale<E8m0, BASE_SK, BASE_N, BASE_SK, BASE_N>;
   using Acc = TileAcc<float, BASE_M, BASE_N, BASE_M, BASE_N>;
 
-  // L1 is double buffered so the K loop can overlap its GM->L1 load with
-  // its extract and multiply. One set is 51 KB.
-  MatA a_l1, a_l1b, a_l1c;
-  MatB b_l1, b_l1b, b_l1c;
-  // one scale pair, not one per set: it is loaded once per output tile and
-  // read by every extract, so it does not ping-pong with the data slabs
+  // L1 is double buffered so the K loop can overlap its GM->L1 load with its
+  // extract and multiply. One set is 96 KB at the default slab and tile.
+  MatA a_l1, a_l1b;
+  MatB b_l1, b_l1b;
+  // One scale pair, not one per set: it is loaded once per output tile and
+  // read by every extract, so it does not ping-pong with the data slabs.
   MatAS as_l1;
   MatBS bs_l1;
   // L0 is double buffered too. One fp4 operand tile is 32 KB and L0A and L0B
-  // are 64 KB each, so two sets fit exactly, which is why BASE_K stays 256:
-  // (256,512,256) measures 1692 TF/s on the cube against 1653 here, but needs
-  // all 64 KB per side and leaves no room for the second set.
+  // are 64 KB each, so two sets fit exactly, which is what holds BASE_K at
+  // 256.
   Left a_l0, a_l0b;
   Right b_l0, b_l0b;
   LeftS as_l0, as_l0b;
@@ -280,25 +203,16 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   constexpr uint32_t b_l1_bytes = (K_L1 * BASE_N) >> SHIFT_FP4;
   // Data slabs first, L1_SETS of them, then the single whole-K scale pair.
   constexpr uint32_t l1_set_bytes = a_l1_bytes + b_l1_bytes;
-  constexpr uint32_t scale_bytes = BASE_M * SK_ALL + SK_ALL * BASE_N;
+  constexpr uint32_t scale_bytes = BASE_M * SK + SK * BASE_N;
   TASSIGN(a_l1, 0x0);
   TASSIGN(b_l1, a_l1_bytes);
   TASSIGN(a_l1b, l1_set_bytes);
   TASSIGN(b_l1b, l1_set_bytes + a_l1_bytes);
-  // The third set is assigned unconditionally and simply goes untouched at
-  // L1_SETS == 2; an unused TASSIGN costs nothing at runtime.
-  TASSIGN(a_l1c, 2u * l1_set_bytes);
-  TASSIGN(b_l1c, 2u * l1_set_bytes + a_l1_bytes);
   TASSIGN(as_l1, L1_SETS * l1_set_bytes);
-  TASSIGN(bs_l1, L1_SETS * l1_set_bytes + BASE_M * SK_ALL);
-  // L1 is 512 KB on this part, established by bisection: two sets of a
-  // K_L1=512 slab are 272 KB and run exactly, two of a K_L1=1024 slab are
-  // 544 KB and fault at launch with 507015.
-  //
-  // Holding the scales for the whole K costs 16*K bytes, which is 256 KB at
-  // K=16384 and exactly fills L1 beside two 128 KB data sets. Past that width,
-  // or with a third data set, it does not fit -- and this refuses to build
-  // rather than faulting on device.
+  TASSIGN(bs_l1, L1_SETS * l1_set_bytes + BASE_M * SK);
+  // L1 is 512 KB on this part. Holding the scales for the whole K costs 16*K
+  // bytes, so past K=16384 they no longer fit beside two data sets -- and
+  // this refuses to build rather than faulting on device with 507015.
   static_assert(L1_SETS * l1_set_bytes + scale_bytes <= 512u * 1024u,
                 "the data sets plus the whole-K scale pair must fit the 512 KB "
                 "L1; reduce L1_SETS or K");
@@ -329,120 +243,60 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   constexpr uint32_t k_slabs = K / K_L1;
   static_assert(K % K_L1 == 0u, "K must be whole L1 slabs");
   const uint32_t out_tiles = m_tiles * n_tiles;
-
   const uint32_t per_group = SWIZZLE_GROUP * n_tiles;
-  // Strides between consecutive problems, in bytes, from the shape alone: fp4
-  // operands are half a byte per element and E8M0 scales one per 32.
-  const uint64_t a_step = ((uint64_t)m_total * K) >> SHIFT_FP4;
-  const uint64_t as_step = ((uint64_t)m_total * K) >> SHIFT_SCALE_FACTOR;
-  constexpr uint64_t b_step = ((uint64_t)K * N) >> SHIFT_FP4;
-  constexpr uint64_t bs_step = ((uint64_t)K * N) >> SHIFT_SCALE_FACTOR;
-  const uint64_t o_step = (uint64_t)m_total * N * sizeof(bfloat16_t);
-  const uint32_t work_items = out_tiles * groups;
-  // ID1 says the whole-K scales for this output tile have landed and ID3 that
-  // MTE1 has finished reading the previous tile's, so MTE2 may overwrite them.
-  // MTE2 runs ahead of MTE1 by design, which is the whole point of the L1
-  // pipeline, so the scale buffer needs the same release handshake the data
-  // sets get on ID2 -- without it a tile's scale load can land on top of
-  // scales the previous tile is still extracting.
+
+  // Pipeline flags. Every pipe is in order, so one counter per direction is
+  // enough: a wait releases the oldest outstanding token, which is the tile
+  // whose turn it is.
+  //
+  //   MTE2 -> MTE1  ID0  a data slab has landed in L1
+  //                 ID1  the whole-K scale pair has landed
+  //   MTE1 -> MTE2  ID2  an L1 data set is free to refill
+  //                 ID3  the scale buffer is free to refill
+  //   MTE1 -> M     ID4  an L0 extract is done
+  //   M    -> MTE1  ID5  the cube has released an L0 set
+  //   M    -> FIX   ID0  the accumulator is complete
+  //   FIX  -> M     ID6  the store has read the accumulator
+  //
+  // MTE2 runs ahead of MTE1 by design, so the scale buffer needs the same
+  // release handshake the data sets get: without ID3 a tile's scale load can
+  // land on top of scales the previous tile is still extracting.
   bool scales_held = false;
-  for (uint32_t w = get_block_idx(); w < work_items; w += core_count) {
-    const uint32_t grp = w / out_tiles;
-    const uint32_t t = w % out_tiles;
-    __gm__ uint8_t *a_gm_g = (__gm__ uint8_t *)a_gm + grp * a_step;
-    __gm__ uint8_t *as_gm_g = (__gm__ uint8_t *)a_scale_gm + grp * as_step;
-    __gm__ uint8_t *b_gm_g = (__gm__ uint8_t *)b_gm + grp * b_step;
-    __gm__ uint8_t *bs_gm_g = (__gm__ uint8_t *)b_scale_gm + grp * bs_step;
-    __gm__ uint8_t *out_gm_g = (__gm__ uint8_t *)out_gm + grp * o_step;
+  for (uint32_t t = get_block_idx(); t < out_tiles; t += core_count) {
     const uint32_t in_group = t % per_group;
     const uint32_t first_mt = (t / per_group) * SWIZZLE_GROUP;
     const uint32_t group_mts =
         m_tiles - first_mt < SWIZZLE_GROUP ? m_tiles - first_mt : SWIZZLE_GROUP;
     const uint32_t mt = first_mt + in_group % group_mts;
     const uint32_t nt = in_group / group_mts;
-    // The K loop is software pipelined across the two L1 sets: tile kt+1's
-    // GM->L1 load is issued before tile kt is extracted and multiplied, so
-    // the DMA and the rest overlap instead of taking each other's time.
-    // Measured single-buffered at K=N=8192, the loads cost 872 us and the
-    // extract-plus-multiply 599, and the total was their sum, 1472.
-    //
-    // One flag pair per buffer, so a wait cannot consume the other's token:
-    //   EVENT_ID0/1  buffer 0/1's load has landed   (MTE2 -> MTE1)
-    //   EVENT_ID2/3  buffer 0/1 is free to refill   (MTE1 -> MTE2)
-    //   EVENT_ID4    L0 extract done                (MTE1 -> M)
-    //   EVENT_ID5    the cube is done reading L0    (M -> MTE1)
-// Timing-only address collapses. MXMM_B_SAME_PANEL points every block at B
-// column panel 0, so B's footprint per launch falls from N/BASE_N panels to
-// one; MXMM_A_SAME_PANEL does the same for A's row panels. The access pattern,
-// the byte count issued and the instruction stream are all unchanged -- only
-// the range of addresses touched shrinks. If the load time falls, the memory
-// system is serving repeats from L2 and our traffic is being evicted; if it
-// does not, these DMA reads do not benefit from L2 and no traversal or cache
-// hint can help.
-#ifdef MXMM_A_SAME_PANEL
-#define MXMM_MT_LOAD 0u
-#else
-#define MXMM_MT_LOAD mt
-#endif
-#ifdef MXMM_B_SAME_PANEL
-#define MXMM_NT_LOAD 0u
-#else
-#define MXMM_NT_LOAD nt
-#endif
 
-#define MXMM_TILE_GM(kk)                                                 \
-  GmA a_g((__gm__ Fp4 *)a_gm_g +                                         \
-              (((uint64_t)MXMM_MT_LOAD * BASE_M * K + (uint64_t)(kk)) >> \
-               SHIFT_FP4),                                               \
-          DynShape(BASE_M, K_L1));                                       \
-  GmB b_g((__gm__ Fp4 *)b_gm_g +                                         \
-              (((uint64_t)MXMM_NT_LOAD * BASE_N * K + (uint64_t)(kk)) >> \
-               SHIFT_FP4),                                               \
-          DynShape(K_L1, BASE_N));                                       \
+#define MXMM_TILE_GM(kk)                                                   \
+  GmA a_g((__gm__ Fp4 *)a_gm +                                             \
+              (((uint64_t)mt * BASE_M * K + (uint64_t)(kk)) >> SHIFT_FP4), \
+          DynShape(BASE_M, K_L1));                                         \
+  GmB b_g((__gm__ Fp4 *)b_gm +                                             \
+              (((uint64_t)nt * BASE_N * K + (uint64_t)(kk)) >> SHIFT_FP4), \
+          DynShape(K_L1, BASE_N));                                         \
   (void)0
 
 // The scale tensors are indexed by the output tile alone, not by the slab:
 // A's scales by its row panel and B's by its column panel, spanning all of K.
-#define MXMM_SCALE_GM()                                                        \
-  GmAS as_g((__gm__ E8m0 *)as_gm_g +                                           \
-                (((uint64_t)MXMM_MT_LOAD * BASE_M * K) >> SHIFT_SCALE_FACTOR), \
-            DynShape(BASE_M, SK_ALL));                                         \
-  GmBS bs_g((__gm__ E8m0 *)bs_gm_g +                                           \
-                (((uint64_t)MXMM_NT_LOAD * BASE_N * K) >> SHIFT_SCALE_FACTOR), \
-            DynShape(SK_ALL, BASE_N))
-
-// ATTRIBUTION SWITCHES, all three timing-only and all producing wrong output:
-//   -DMXMM_NO_LOAD     drops GM->L1, so the difference is the load
-//   -DMXMM_NO_EXTRACT  drops L1->L0, so the difference is the extract
-//   -DMXMM_NO_MATMUL   drops all but the first multiply, so the difference is
-//                      the cube issue itself
-// The bottleneck moved once the loads were overlapped, so which stage binds now
-// has to be measured rather than assumed.
-#ifdef MXMM_NO_LOAD
-#define MXMM_FILL(a1, b1) ((void)0)
-#define MXMM_FILL_SCALES() ((void)0)
-#else
-#define MXMM_FILL(a1, b1) \
-  do {                    \
-    TLOAD(a1, a_g);       \
-    TLOAD(b1, b_g);       \
+#define MXMM_FILL_SCALES()                                             \
+  do {                                                                 \
+    GmAS as_g((__gm__ E8m0 *)a_scale_gm +                              \
+                  (((uint64_t)mt * BASE_M * K) >> SHIFT_SCALE_FACTOR), \
+              DynShape(BASE_M, SK));                                   \
+    GmBS bs_g((__gm__ E8m0 *)b_scale_gm +                              \
+                  (((uint64_t)nt * BASE_N * K) >> SHIFT_SCALE_FACTOR), \
+              DynShape(SK, BASE_N));                                   \
+    TLOAD<MatAS, GmAS>(as_l1, as_g);                                   \
+    TLOAD<MatBS, GmBS>(bs_l1, bs_g);                                   \
   } while (0)
-// Once per output tile, covering every slab's scales in one pair of loads.
-#define MXMM_FILL_SCALES()           \
-  do {                               \
-    MXMM_SCALE_GM();                 \
-    TLOAD<MatAS, GmAS>(as_l1, as_g); \
-    TLOAD<MatBS, GmBS>(bs_l1, bs_g); \
-  } while (0)
-#endif
 
-#ifdef MXMM_NO_EXTRACT
-#define MXMM_DRAIN_TO_L0(a1, b1, a0, b0, as0, bs0, sub, tile) ((void)0)
-#else
 // sub is the tile's index within the slab and tile its index within the whole
-// K. A holds K along its columns and B along its rows, so the offset goes in a
-// different argument for each. The data offset is per slab; the scale offset
-// is per output tile, because one scale buffer spans all of K.
+// K. A holds K along its columns and B along its rows, so the offset goes in
+// a different argument for each. The data offset is per slab; the scale
+// offset is per output tile, because one scale buffer spans all of K.
 #define MXMM_DRAIN_TO_L0(a1, b1, a0, b0, as0, bs0, sub, tile) \
   do {                                                        \
     const uint16_t koff_ = (uint16_t)((sub) * BASE_K);        \
@@ -452,63 +306,41 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     TEXTRACT(as0, as_l1, 0, soff_);                           \
     TEXTRACT(bs0, bs_l1, soff_, 0);                           \
   } while (0)
-#endif
 
-// ID4 counts completed extracts and ID5 completed multiplies. Both pipes run
-// in order, so one counter each is enough: a wait releases the oldest
-// outstanding token, which is exactly the tile whose turn it is.
-#ifdef MXMM_NO_SYNC
-#define MXMM_POST_EXTRACT() ((void)0)
-#define MXMM_AWAIT_EXTRACT() ((void)0)
-#define MXMM_POST_MULTIPLY() ((void)0)
-#define MXMM_AWAIT_MULTIPLY() ((void)0)
-#else
-#define MXMM_POST_EXTRACT() set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4)
-#define MXMM_AWAIT_EXTRACT() wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4)
-#define MXMM_POST_MULTIPLY() set_flag(PIPE_M, PIPE_MTE1, EVENT_ID5)
-#define MXMM_AWAIT_MULTIPLY() wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5)
-#endif
-
-// ID0 counts landed loads and ID2 freed L1 sets. With three sets a pair of
-// flags per set would need six; one counter each way is enough because MTE2 and
-// MTE1 are both in order, so the oldest outstanding token always belongs to the
-// tile whose turn it is.
+// One GM->L1 copy per slab into the set its index selects.
 #define MXMM_LOAD(sl, sel)                     \
   do {                                         \
-    const uint32_t sel_ = (sel);               \
     MXMM_TILE_GM((uint64_t)(sl) * K_L1);       \
-    if (sel_ == 0u) {                          \
-      MXMM_FILL(a_l1, b_l1);                   \
-    } else if (sel_ == 1u) {                   \
-      MXMM_FILL(a_l1b, b_l1b);                 \
+    if ((sel) == 0u) {                         \
+      TLOAD(a_l1, a_g);                        \
+      TLOAD(b_l1, b_g);                        \
     } else {                                   \
-      MXMM_FILL(a_l1c, b_l1c);                 \
+      TLOAD(a_l1b, a_g);                       \
+      TLOAD(b_l1b, b_g);                       \
     }                                          \
     set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0); \
   } while (0)
+
 // e is the global K-tile index. A slab's load is waited for once, before its
-// first sub-tile, and the set is released once, after its last -- so ID0 and
-// ID2 count slabs while ID4 and ID5 still count cube tiles.
+// first sub-tile, and the set released once, after its last -- so ID0 and ID2
+// count slabs while ID4 and ID5 count cube tiles.
 #define MXMM_EXTRACT(e, a0, b0, as0, bs0)                         \
   do {                                                            \
     const uint32_t e_ = (e);                                      \
     const uint32_t slab_ = e_ / K_SUB;                            \
     const uint32_t sub_ = e_ % K_SUB;                             \
-    const uint32_t sel_ = slab_ % L1_SETS;                        \
     if (sub_ == 0u) {                                             \
       wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);                 \
     }                                                             \
-    if (sel_ == 0u) {                                             \
+    if (slab_ % L1_SETS == 0u) {                                  \
       MXMM_DRAIN_TO_L0(a_l1, b_l1, a0, b0, as0, bs0, sub_, e_);   \
-    } else if (sel_ == 1u) {                                      \
-      MXMM_DRAIN_TO_L0(a_l1b, b_l1b, a0, b0, as0, bs0, sub_, e_); \
     } else {                                                      \
-      MXMM_DRAIN_TO_L0(a_l1c, b_l1c, a0, b0, as0, bs0, sub_, e_); \
+      MXMM_DRAIN_TO_L0(a_l1b, b_l1b, a0, b0, as0, bs0, sub_, e_); \
     }                                                             \
     if (sub_ + 1u == K_SUB) {                                     \
       set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);                  \
     }                                                             \
-    MXMM_POST_EXTRACT();                                          \
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);                       \
   } while (0)
 
     // One pair of scale loads for the whole output tile, before the data
@@ -520,9 +352,9 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
     scales_held = true;
 
-    // Prologue: LOOKAHEAD tiles are in flight before the first multiply, so
-    // a tile's extract waits on a load issued LOOKAHEAD passes earlier
-    // instead of one it started itself.
+    // Prologue: LOOKAHEAD slabs are in flight before the first multiply, so a
+    // tile's extract waits on a load issued LOOKAHEAD passes earlier instead
+    // of one it started itself.
     for (uint32_t j = 0u; j < LOOKAHEAD && j < k_slabs; ++j) {
       MXMM_LOAD(j, j % L1_SETS);
     }
@@ -542,10 +374,6 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
           MXMM_LOAD(slab_ahead, slab_ahead % L1_SETS);
         }
       }
-#ifdef MXMM_SINGLE_L0
-      MXMM_EXTRACT(kt, a_l0, b_l0, as_l0, bs_l0);
-      MXMM_AWAIT_EXTRACT();
-#else
       // Tile kt was extracted on the previous pass, so this pass extracts
       // kt+1 into the OTHER L0 set and the cube's multiply of kt runs beside
       // it. wait_flag stalls its target pipe, not the scalar unit, so the
@@ -555,7 +383,8 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
       }
       if (kt + 1u < k_tiles) {
         if (kt >= 1u) {
-          MXMM_AWAIT_MULTIPLY();  // tile kt-1 has released that L0 set
+          // tile kt-1 has released that L0 set
+          wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
         }
         if (odd) {  // kt+1 has the opposite parity, so the other L0 set
           MXMM_EXTRACT(kt + 1u, a_l0, b_l0, as_l0, bs_l0);
@@ -563,19 +392,7 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
           MXMM_EXTRACT(kt + 1u, a_l0b, b_l0b, as_l0b, bs_l0b);
         }
       }
-      MXMM_AWAIT_EXTRACT();
-#endif
-#ifdef MXMM_NO_MATMUL
-      if (kt == 0u) {
-        TMATMUL_MX(c_l0, a_l0, as_l0, b_l0, bs_l0);
-      }
-#elif defined(MXMM_SINGLE_L0)
-      if (kt == 0u) {
-        TMATMUL_MX(c_l0, a_l0, as_l0, b_l0, bs_l0);
-      } else {
-        TMATMUL_MX(c_l0, c_l0, a_l0, as_l0, b_l0, bs_l0);
-      }
-#else
+      wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
       if (odd) {  // kt == 0 is even, so an odd tile always accumulates
         TMATMUL_MX(c_l0, c_l0, a_l0b, as_l0b, b_l0b, bs_l0b);
       } else if (kt == 0u) {
@@ -583,56 +400,44 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
       } else {
         TMATMUL_MX(c_l0, c_l0, a_l0, as_l0, b_l0, bs_l0);
       }
-#endif
-      MXMM_POST_MULTIPLY();
-#ifdef MXMM_SINGLE_L0
-      // one L0 set, so the next extract cannot start until the cube is done
-      MXMM_AWAIT_MULTIPLY();
-#endif
+      set_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
     }
-    // ID2 carries min(k_tiles, L1_SETS) tokens out of the loop: every extract
-    // posts one and only the loads far enough in consume one. Draining keeps
-    // a count from carrying into the next output tile, where a later wait
-    // would return early.
+    // ID2 carries min(k_slabs, L1_SETS) tokens out of the loop: every slab's
+    // last extract posts one and only the loads far enough ahead consume one.
+    // Draining keeps a count from carrying into the next output tile, where a
+    // later wait would return early.
     for (uint32_t d = 0u; d < L1_SETS && d < k_slabs; ++d) {
       wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
     }
-    // Every extract in the loop above read the scale buffer, and MTE1 is in
-    // order, so one post here releases it for the next output tile.
+    // Every extract above read the scale buffer, and MTE1 is in order, so one
+    // post here releases it for the next output tile.
     set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
-#ifndef MXMM_SINGLE_L0
     // Every multiply posts on ID5 and only the extracts of tile 2 and later
     // consume one, so min(k_tiles, 2) tokens are outstanding here.
-    MXMM_AWAIT_MULTIPLY();
+    wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
     if constexpr (k_tiles > 1u) {
-      MXMM_AWAIT_MULTIPLY();
+      wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID5);
     }
-#endif
 #undef MXMM_TILE_GM
-#undef MXMM_SCALE_GM
-#undef MXMM_FILL
 #undef MXMM_FILL_SCALES
 #undef MXMM_DRAIN_TO_L0
-#ifndef MXMM_NO_STORE
+#undef MXMM_LOAD
+#undef MXMM_EXTRACT
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
     wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-    GmOut out_g((__gm__ bfloat16_t *)out_gm_g +
+    GmOut out_g((__gm__ bfloat16_t *)out_gm +
                 ((uint64_t)mt * BASE_M * N + (uint64_t)nt * BASE_N));
     TSTORE(out_g, c_l0);
-    // The next output tile's first multiply is non-accumulating and overwrites
-    // c_l0, so it waits for the store; its loads and extracts do not.
-#ifdef MXMM_STORE_BLOCKS_MTE2
-    set_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_FIX, PIPE_MTE2, EVENT_ID0);
-#else
+    // The next output tile's first multiply is non-accumulating and
+    // overwrites c_l0, so it waits for the store; its loads and extracts do
+    // not.
     set_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
     wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
-#endif
-#endif
   }
 
-  // One ID3 post is outstanding: every tile posts and every tile but the first
-  // consumed one. Drain it so a later launch's first wait cannot return early.
+  // One ID3 post is outstanding: every tile posts and every tile but the
+  // first consumed one. Drain it so a later launch's first wait cannot return
+  // early.
   if (scales_held) {
     wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
   }
@@ -646,15 +451,9 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 #endif
 }
 
-// One instantiation while the numerics are being established. Generalising
-// means a dispatch fold like the fused kernel's, once this is right.
-// K = BASE_K and N = BASE_N deliberately: with one tile in every dimension the
-// TLOAD is not WINDOWED -- the L1 tile spans a whole row of the matrix, exactly
-// as in the conformance test, which is the one thing this kernel does
-// differently. If this is exact and K=512 is not, the strided load is the
-// fault.
-// The default shape must satisfy K % K_L1 == 0, so it cannot be under one
-// L1 slab. 512 is the narrowest K that builds at the default K_L1.
+// The shape this translation unit is built for. K must be a multiple of K_L1,
+// so it cannot be under one L1 slab; 512 is the narrowest that builds at the
+// default slab width.
 #ifndef MXMM_TEST_K
 #define MXMM_TEST_K 512
 #endif
@@ -662,18 +461,12 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 #define MXMM_TEST_N 512
 #endif
 constexpr unsigned TEST_M_MAX = 65536;  // an upper bound, not the shape
-// The launcher's alignment requirement is now the finest tile, so a caller
-// with M=16 needs no padding at all and one with M=1 pads to 16 rather than
-// 128.
 constexpr unsigned M_TILE_ROWS = TINY_M;
 constexpr unsigned TEST_K = MXMM_TEST_K, TEST_N = MXMM_TEST_N;
 
 // Which output tile suits this M. The big one moves less data but halves the
-// block count, so it only pays where the shape still fills the cores. The
-// threshold is the launcher's own block cap: below it fewer blocks means
-// idle cores and the saving is swamped. Measured 1.49x at M=4096 K=N=8192
-// where both shapes saturate, and 0.65x at M=256 where the big tile leaves
-// half the 32 cube cores idle.
+// block count, so it only pays where the shape still fills the cores; the
+// threshold is the launcher's own block cap.
 constexpr uint32_t TARGET_BLOCKS = 64u;
 inline uint32_t mxfp4_matmul_pick_m_tile(uint32_t m) {
   if (m % BIG_M == 0u && (m / BIG_M) * (TEST_N / BIG_N) >= TARGET_BLOCKS) {
@@ -685,13 +478,10 @@ inline uint32_t mxfp4_matmul_pick_m_tile(uint32_t m) {
   return TINY_M;
 }
 
-// What a caller with an awkward M should round up to.
-//
-// The tiny tile is only right up to its own height. Each output tile streams a
-// whole B column panel, so M=64 as four 16-row tiles reads B four times, while
-// one 128-row tile reads it once and merely wastes rows. B dominates the
-// traffic at small M, so the wasted rows are cheaper: measured at K=N=6144,
-// four 16-row tiles ran 0.66x of bf16 where the padded 128-row tile ran 1.63x.
+// What a caller with an awkward M should round up to. The tiny tile is only
+// right up to its own height: each output tile streams a whole B column
+// panel, so M=64 as four 16-row tiles reads B four times where one padded
+// 128-row tile reads it once.
 inline uint32_t mxfp4_matmul_pick_m_round(uint32_t m) {
   if (m == 0u) return TINY_M;
   if (m <= TINY_M) return TINY_M;
@@ -702,67 +492,38 @@ static inline void mxfp4_matmul_launch(uint32_t block_dim, void *stream,
                                        uint8_t *a_gm, uint8_t *a_scale_gm,
                                        uint8_t *b_gm, uint8_t *b_scale_gm,
                                        uint8_t *out_gm, uint32_t m, uint32_t k,
-                                       uint32_t n, uint32_t groups) {
-  // The host rejects what has no instantiation: a launcher that returns quietly
-  // hands the caller an untouched output buffer back.
+                                       uint32_t n) {
+  // The host rejects what has no instantiation: a launcher that returns
+  // quietly hands the caller an untouched output buffer back.
   if (block_dim == 0u) return;
   if (k != TEST_K || n != TEST_N) return;
-  // M is runtime now, but still has to be whole tiles and within the declared
-  // maximum: a launcher that returns quietly hands back an untouched buffer.
+  // M is runtime, but still has to be whole tiles and within the declared
+  // maximum.
   if (m == 0u || m % M_TILE_ROWS != 0u || m > TEST_M_MAX) return;
   // NEVER guard this launch with a device-pass macro.
   const uint32_t tile = mxfp4_matmul_pick_m_tile(m);
   if (tile == BIG_M) {
     mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, BIG_M, BIG_N>
         <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
-                                         out_gm, m, block_dim, groups);
+                                         out_gm, m, block_dim);
   } else if (tile == SMALL_M) {
     mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, SMALL_M, SMALL_N>
         <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
-                                         out_gm, m, block_dim, groups);
+                                         out_gm, m, block_dim);
   } else {
     mxfp4_matmul<TEST_M_MAX, TEST_K, TEST_N, TINY_M, TINY_N>
         <<<block_dim, nullptr, stream>>>(a_gm, a_scale_gm, b_gm, b_scale_gm,
-                                         out_gm, m, block_dim, groups);
+                                         out_gm, m, block_dim);
   }
 }
 
-// Launch the same kernel n times from C, so a caller measuring throughput
-// pays the Python and ctypes cost once instead of n times. At K=N=512 the
-// whole matmul is half a megaflop and 524 KB of weights, so essentially all of
-// the measured time is per-call overhead, and this separates the part that
-// belongs to the launch path from the part that belongs to the host binding.
-// One problem, the ordinary call.
 extern "C" void call_mxfp4_matmul(uint32_t block_dim, void *stream,
                                   uint8_t *a_gm, uint8_t *a_scale_gm,
                                   uint8_t *b_gm, uint8_t *b_scale_gm,
                                   uint8_t *out_gm, uint32_t m, uint32_t k,
                                   uint32_t n) {
   mxfp4_matmul_launch(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
-                      out_gm, m, k, n, 1u);
-}
-
-// G problems of identical shape, laid out back to back, in a single launch.
-// block_dim should be sized against G * out_tiles rather than out_tiles.
-extern "C" void call_mxfp4_matmul_grouped(uint32_t groups, uint32_t block_dim,
-                                          void *stream, uint8_t *a_gm,
-                                          uint8_t *a_scale_gm, uint8_t *b_gm,
-                                          uint8_t *b_scale_gm, uint8_t *out_gm,
-                                          uint32_t m, uint32_t k, uint32_t n) {
-  if (groups == 0u) return;
-  mxfp4_matmul_launch(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
-                      out_gm, m, k, n, groups);
-}
-
-extern "C" void call_mxfp4_matmul_repeat(uint32_t reps, uint32_t block_dim,
-                                         void *stream, uint8_t *a_gm,
-                                         uint8_t *a_scale_gm, uint8_t *b_gm,
-                                         uint8_t *b_scale_gm, uint8_t *out_gm,
-                                         uint32_t m, uint32_t k, uint32_t n) {
-  for (uint32_t i = 0u; i < reps; ++i) {
-    call_mxfp4_matmul(block_dim, stream, a_gm, a_scale_gm, b_gm, b_scale_gm,
                       out_gm, m, k, n);
-  }
 }
 
 extern "C" uint32_t mxfp4_matmul_m_tile() { return M_TILE_ROWS; }
@@ -784,9 +545,3 @@ extern "C" uint32_t mxfp4_matmul_n_tile_for(uint32_t m) {
 extern "C" uint32_t mxfp4_matmul_m_max() { return TEST_M_MAX; }
 extern "C" uint32_t mxfp4_matmul_k() { return TEST_K; }
 extern "C" uint32_t mxfp4_matmul_n() { return TEST_N; }
-
-// ---------------------------------------------------------------------------
-// The layout traps above are the ones that cost real time; each is called
-// out at the declaration it applies to. Measured throughput, the tuning
-// sweeps behind the defaults, and the approaches that were tried and
-// rejected are in README.md rather than here.

--- a/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
+++ b/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
@@ -236,10 +236,20 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
                     K_L1, SLayout::RowMajor, 512>;
   using MatB = Tile<TileType::Mat, Fp4, K_L1, BASE_N, BLayout::RowMajor, K_L1,
                     BASE_N, SLayout::ColMajor, 512>;
-  using MatAS = Tile<TileType::Mat, E8m0, BASE_M, SK_L1, BLayout::RowMajor,
-                     BASE_M, SK_L1, SLayout::RowMajor, 32>;
-  using MatBS = Tile<TileType::Mat, E8m0, SK_L1, BASE_N, BLayout::ColMajor,
-                     SK_L1, BASE_N, SLayout::ColMajor, 32>;
+  // The scales are held for the WHOLE K of an output tile, not per slab.
+  // Per slab they were 256 rows of 16 bytes each -- 3% of the bytes moved and
+  // 50% of the DMA descriptors issued, on a kernel whose loads are bound by
+  // descriptor issue rather than bandwidth. Held whole, they are one load of
+  // 256 rows of SK_ALL bytes, so the burst becomes a full cache line at
+  // K >= 16384 and the descriptor count per output tile falls from
+  // 4 * k_slabs units to 2 * k_slabs + 2. The vendor does the same thing at a
+  // cadence of 4 slabs (mxmatmul_performance_kernel.cpp:20, mxScalePara);
+  // whole-K is the same idea taken as far as L1 allows.
+  constexpr uint32_t SK_ALL = K / SCALE_FACTOR;
+  using MatAS = Tile<TileType::Mat, E8m0, BASE_M, SK_ALL, BLayout::RowMajor,
+                     BASE_M, SK_ALL, SLayout::RowMajor, 32>;
+  using MatBS = Tile<TileType::Mat, E8m0, SK_ALL, BASE_N, BLayout::ColMajor,
+                     SK_ALL, BASE_N, SLayout::ColMajor, 32>;
 
   // L0, using the Compact variants the tuned reference uses.
   using Left = TileLeft<Fp4, BASE_M, BASE_K, BASE_M, BASE_K>;
@@ -252,8 +262,10 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   // its extract and multiply. One set is 51 KB.
   MatA a_l1, a_l1b, a_l1c;
   MatB b_l1, b_l1b, b_l1c;
-  MatAS as_l1, as_l1b, as_l1c;
-  MatBS bs_l1, bs_l1b, bs_l1c;
+  // one scale pair, not one per set: it is loaded once per output tile and
+  // read by every extract, so it does not ping-pong with the data slabs
+  MatAS as_l1;
+  MatBS bs_l1;
   // L0 is double buffered too. One fp4 operand tile is 32 KB and L0A and L0B
   // are 64 KB each, so two sets fit exactly, which is why BASE_K stays 256:
   // (256,512,256) measures 1692 TF/s on the cube against 1653 here, but needs
@@ -266,31 +278,30 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 
   constexpr uint32_t a_l1_bytes = (BASE_M * K_L1) >> SHIFT_FP4;
   constexpr uint32_t b_l1_bytes = (K_L1 * BASE_N) >> SHIFT_FP4;
+  // Data slabs first, L1_SETS of them, then the single whole-K scale pair.
+  constexpr uint32_t l1_set_bytes = a_l1_bytes + b_l1_bytes;
+  constexpr uint32_t scale_bytes = BASE_M * SK_ALL + SK_ALL * BASE_N;
   TASSIGN(a_l1, 0x0);
   TASSIGN(b_l1, a_l1_bytes);
-  TASSIGN(as_l1, a_l1_bytes + b_l1_bytes);
-  TASSIGN(bs_l1, a_l1_bytes + b_l1_bytes + BASE_M * SK_L1);
-  // the second set immediately after the first
-  constexpr uint32_t l1_set_bytes =
-      a_l1_bytes + b_l1_bytes + BASE_M * SK_L1 + SK_L1 * BASE_N;
   TASSIGN(a_l1b, l1_set_bytes);
   TASSIGN(b_l1b, l1_set_bytes + a_l1_bytes);
-  TASSIGN(as_l1b, l1_set_bytes + a_l1_bytes + b_l1_bytes);
-  TASSIGN(bs_l1b, l1_set_bytes + a_l1_bytes + b_l1_bytes + BASE_M * SK_L1);
   // The third set is assigned unconditionally and simply goes untouched at
   // L1_SETS == 2; an unused TASSIGN costs nothing at runtime.
   TASSIGN(a_l1c, 2u * l1_set_bytes);
   TASSIGN(b_l1c, 2u * l1_set_bytes + a_l1_bytes);
-  TASSIGN(as_l1c, 2u * l1_set_bytes + a_l1_bytes + b_l1_bytes);
-  TASSIGN(bs_l1c, 2u * l1_set_bytes + a_l1_bytes + b_l1_bytes + BASE_M * SK_L1);
+  TASSIGN(as_l1, L1_SETS * l1_set_bytes);
+  TASSIGN(bs_l1, L1_SETS * l1_set_bytes + BASE_M * SK_ALL);
   // L1 is 512 KB on this part, established by bisection: two sets of a
   // K_L1=512 slab are 272 KB and run exactly, two of a K_L1=1024 slab are
-  // 544 KB and fault at launch with 507015. So the widest double-buffered
-  // slab at the big output tile is 512, giving 256-byte GM->L1 bursts.
-  static_assert(
-      L1_SETS * (a_l1_bytes + b_l1_bytes + BASE_M * SK_L1 + SK_L1 * BASE_N) <=
-          512u * 1024u,
-      "L1 sets must fit the 512 KB L1");
+  // 544 KB and fault at launch with 507015.
+  //
+  // Holding the scales for the whole K costs 16*K bytes, which is 256 KB at
+  // K=16384 and exactly fills L1 beside two 128 KB data sets. Past that width,
+  // or with a third data set, it does not fit -- and this refuses to build
+  // rather than faulting on device.
+  static_assert(L1_SETS * l1_set_bytes + scale_bytes <= 512u * 1024u,
+                "the data sets plus the whole-K scale pair must fit the 512 KB "
+                "L1; reduce L1_SETS or K");
   constexpr uint32_t a_l0_bytes = (BASE_M * BASE_K) >> SHIFT_FP4;
   constexpr uint32_t b_l0_bytes = (BASE_K * BASE_N) >> SHIFT_FP4;
   static_assert(2u * a_l0_bytes <= 64u * 1024u, "two A tiles must fit L0A");
@@ -328,6 +339,13 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
   constexpr uint64_t bs_step = ((uint64_t)K * N) >> SHIFT_SCALE_FACTOR;
   const uint64_t o_step = (uint64_t)m_total * N * sizeof(bfloat16_t);
   const uint32_t work_items = out_tiles * groups;
+  // ID1 says the whole-K scales for this output tile have landed and ID3 that
+  // MTE1 has finished reading the previous tile's, so MTE2 may overwrite them.
+  // MTE2 runs ahead of MTE1 by design, which is the whole point of the L1
+  // pipeline, so the scale buffer needs the same release handshake the data
+  // sets get on ID2 -- without it a tile's scale load can land on top of
+  // scales the previous tile is still extracting.
+  bool scales_held = false;
   for (uint32_t w = get_block_idx(); w < work_items; w += core_count) {
     const uint32_t grp = w / out_tiles;
     const uint32_t t = w % out_tiles;
@@ -372,23 +390,26 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 #define MXMM_NT_LOAD nt
 #endif
 
-#define MXMM_TILE_GM(kk)                                                   \
-  GmA a_g((__gm__ Fp4 *)a_gm_g +                                           \
-              (((uint64_t)MXMM_MT_LOAD * BASE_M * K + (uint64_t)(kk)) >>   \
-               SHIFT_FP4),                                                 \
-          DynShape(BASE_M, K_L1));                                         \
-  GmB b_g((__gm__ Fp4 *)b_gm_g +                                           \
-              (((uint64_t)MXMM_NT_LOAD * BASE_N * K + (uint64_t)(kk)) >>   \
-               SHIFT_FP4),                                                 \
-          DynShape(K_L1, BASE_N));                                         \
-  GmAS as_g((__gm__ E8m0 *)as_gm_g +                                       \
-                (((uint64_t)MXMM_MT_LOAD * BASE_M * K + (uint64_t)(kk)) >> \
-                 SHIFT_SCALE_FACTOR),                                      \
-            DynShape(BASE_M, SK_L1));                                      \
-  GmBS bs_g((__gm__ E8m0 *)bs_gm_g +                                       \
-                (((uint64_t)MXMM_NT_LOAD * BASE_N * K + (uint64_t)(kk)) >> \
-                 SHIFT_SCALE_FACTOR),                                      \
-            DynShape(SK_L1, BASE_N))
+#define MXMM_TILE_GM(kk)                                                 \
+  GmA a_g((__gm__ Fp4 *)a_gm_g +                                         \
+              (((uint64_t)MXMM_MT_LOAD * BASE_M * K + (uint64_t)(kk)) >> \
+               SHIFT_FP4),                                               \
+          DynShape(BASE_M, K_L1));                                       \
+  GmB b_g((__gm__ Fp4 *)b_gm_g +                                         \
+              (((uint64_t)MXMM_NT_LOAD * BASE_N * K + (uint64_t)(kk)) >> \
+               SHIFT_FP4),                                               \
+          DynShape(K_L1, BASE_N));                                       \
+  (void)0
+
+// The scale tensors are indexed by the output tile alone, not by the slab:
+// A's scales by its row panel and B's by its column panel, spanning all of K.
+#define MXMM_SCALE_GM()                                                        \
+  GmAS as_g((__gm__ E8m0 *)as_gm_g +                                           \
+                (((uint64_t)MXMM_MT_LOAD * BASE_M * K) >> SHIFT_SCALE_FACTOR), \
+            DynShape(BASE_M, SK_ALL));                                         \
+  GmBS bs_g((__gm__ E8m0 *)bs_gm_g +                                           \
+                (((uint64_t)MXMM_NT_LOAD * BASE_N * K) >> SHIFT_SCALE_FACTOR), \
+            DynShape(SK_ALL, BASE_N))
 
 // ATTRIBUTION SWITCHES, all three timing-only and all producing wrong output:
 //   -DMXMM_NO_LOAD     drops GM->L1, so the difference is the load
@@ -398,30 +419,38 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 // The bottleneck moved once the loads were overlapped, so which stage binds now
 // has to be measured rather than assumed.
 #ifdef MXMM_NO_LOAD
-#define MXMM_FILL(a1, b1, as1, bs1) ((void)0)
+#define MXMM_FILL(a1, b1) ((void)0)
+#define MXMM_FILL_SCALES() ((void)0)
 #else
-#define MXMM_FILL(a1, b1, as1, bs1) \
-  do {                              \
-    TLOAD(a1, a_g);                 \
-    TLOAD(b1, b_g);                 \
-    TLOAD<MatAS, GmAS>(as1, as_g);  \
-    TLOAD<MatBS, GmBS>(bs1, bs_g);  \
+#define MXMM_FILL(a1, b1) \
+  do {                    \
+    TLOAD(a1, a_g);       \
+    TLOAD(b1, b_g);       \
+  } while (0)
+// Once per output tile, covering every slab's scales in one pair of loads.
+#define MXMM_FILL_SCALES()           \
+  do {                               \
+    MXMM_SCALE_GM();                 \
+    TLOAD<MatAS, GmAS>(as_l1, as_g); \
+    TLOAD<MatBS, GmBS>(bs_l1, bs_g); \
   } while (0)
 #endif
 
 #ifdef MXMM_NO_EXTRACT
-#define MXMM_DRAIN_TO_L0(a1, b1, as1, bs1, a0, b0, as0, bs0, sub) ((void)0)
+#define MXMM_DRAIN_TO_L0(a1, b1, a0, b0, as0, bs0, sub, tile) ((void)0)
 #else
-// sub is the tile's index within the slab. A holds K along its columns and B
-// along its rows, so the offset goes in a different argument for each.
-#define MXMM_DRAIN_TO_L0(a1, b1, as1, bs1, a0, b0, as0, bs0, sub) \
-  do {                                                            \
-    const uint16_t koff_ = (uint16_t)((sub) * BASE_K);            \
-    const uint16_t soff_ = (uint16_t)((sub) * BASE_SK);           \
-    TEXTRACT(a0, a1, 0, koff_);                                   \
-    TEXTRACT(b0, b1, koff_, 0);                                   \
-    TEXTRACT(as0, as1, 0, soff_);                                 \
-    TEXTRACT(bs0, bs1, soff_, 0);                                 \
+// sub is the tile's index within the slab and tile its index within the whole
+// K. A holds K along its columns and B along its rows, so the offset goes in a
+// different argument for each. The data offset is per slab; the scale offset
+// is per output tile, because one scale buffer spans all of K.
+#define MXMM_DRAIN_TO_L0(a1, b1, a0, b0, as0, bs0, sub, tile) \
+  do {                                                        \
+    const uint16_t koff_ = (uint16_t)((sub) * BASE_K);        \
+    const uint16_t soff_ = (uint16_t)((tile) * BASE_SK);      \
+    TEXTRACT(a0, a1, 0, koff_);                               \
+    TEXTRACT(b0, b1, koff_, 0);                               \
+    TEXTRACT(as0, as_l1, 0, soff_);                           \
+    TEXTRACT(bs0, bs_l1, soff_, 0);                           \
   } while (0)
 #endif
 
@@ -449,38 +478,47 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     const uint32_t sel_ = (sel);               \
     MXMM_TILE_GM((uint64_t)(sl) * K_L1);       \
     if (sel_ == 0u) {                          \
-      MXMM_FILL(a_l1, b_l1, as_l1, bs_l1);     \
+      MXMM_FILL(a_l1, b_l1);                   \
     } else if (sel_ == 1u) {                   \
-      MXMM_FILL(a_l1b, b_l1b, as_l1b, bs_l1b); \
+      MXMM_FILL(a_l1b, b_l1b);                 \
     } else {                                   \
-      MXMM_FILL(a_l1c, b_l1c, as_l1c, bs_l1c); \
+      MXMM_FILL(a_l1c, b_l1c);                 \
     }                                          \
     set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0); \
   } while (0)
 // e is the global K-tile index. A slab's load is waited for once, before its
 // first sub-tile, and the set is released once, after its last -- so ID0 and
 // ID2 count slabs while ID4 and ID5 still count cube tiles.
-#define MXMM_EXTRACT(e, a0, b0, as0, bs0)                                     \
-  do {                                                                        \
-    const uint32_t e_ = (e);                                                  \
-    const uint32_t slab_ = e_ / K_SUB;                                        \
-    const uint32_t sub_ = e_ % K_SUB;                                         \
-    const uint32_t sel_ = slab_ % L1_SETS;                                    \
-    if (sub_ == 0u) {                                                         \
-      wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);                             \
-    }                                                                         \
-    if (sel_ == 0u) {                                                         \
-      MXMM_DRAIN_TO_L0(a_l1, b_l1, as_l1, bs_l1, a0, b0, as0, bs0, sub_);     \
-    } else if (sel_ == 1u) {                                                  \
-      MXMM_DRAIN_TO_L0(a_l1b, b_l1b, as_l1b, bs_l1b, a0, b0, as0, bs0, sub_); \
-    } else {                                                                  \
-      MXMM_DRAIN_TO_L0(a_l1c, b_l1c, as_l1c, bs_l1c, a0, b0, as0, bs0, sub_); \
-    }                                                                         \
-    if (sub_ + 1u == K_SUB) {                                                 \
-      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);                              \
-    }                                                                         \
-    MXMM_POST_EXTRACT();                                                      \
+#define MXMM_EXTRACT(e, a0, b0, as0, bs0)                         \
+  do {                                                            \
+    const uint32_t e_ = (e);                                      \
+    const uint32_t slab_ = e_ / K_SUB;                            \
+    const uint32_t sub_ = e_ % K_SUB;                             \
+    const uint32_t sel_ = slab_ % L1_SETS;                        \
+    if (sub_ == 0u) {                                             \
+      wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);                 \
+    }                                                             \
+    if (sel_ == 0u) {                                             \
+      MXMM_DRAIN_TO_L0(a_l1, b_l1, a0, b0, as0, bs0, sub_, e_);   \
+    } else if (sel_ == 1u) {                                      \
+      MXMM_DRAIN_TO_L0(a_l1b, b_l1b, a0, b0, as0, bs0, sub_, e_); \
+    } else {                                                      \
+      MXMM_DRAIN_TO_L0(a_l1c, b_l1c, a0, b0, as0, bs0, sub_, e_); \
+    }                                                             \
+    if (sub_ + 1u == K_SUB) {                                     \
+      set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);                  \
+    }                                                             \
+    MXMM_POST_EXTRACT();                                          \
   } while (0)
+
+    // One pair of scale loads for the whole output tile, before the data
+    // prologue so it is the first thing MTE2 has queued.
+    if (scales_held) {
+      wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
+    }
+    MXMM_FILL_SCALES();
+    set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
+    scales_held = true;
 
     // Prologue: LOOKAHEAD tiles are in flight before the first multiply, so
     // a tile's extract waits on a load issued LOOKAHEAD passes earlier
@@ -488,6 +526,9 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     for (uint32_t j = 0u; j < LOOKAHEAD && j < k_slabs; ++j) {
       MXMM_LOAD(j, j % L1_SETS);
     }
+    // MTE1 blocks here until the scales are in L1; the prologue's data loads
+    // are already issued on MTE2, so this costs them nothing.
+    wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);
     for (uint32_t kt = 0; kt < k_tiles; ++kt) {
       const bool odd = (kt & 1u) != 0u;
       // One GM->L1 copy per slab, issued when the slab's first cube tile
@@ -556,6 +597,9 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     for (uint32_t d = 0u; d < L1_SETS && d < k_slabs; ++d) {
       wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID2);
     }
+    // Every extract in the loop above read the scale buffer, and MTE1 is in
+    // order, so one post here releases it for the next output tile.
+    set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
 #ifndef MXMM_SINGLE_L0
     // Every multiply posts on ID5 and only the extracts of tile 2 and later
     // consume one, so min(k_tiles, 2) tokens are outstanding here.
@@ -565,7 +609,9 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     }
 #endif
 #undef MXMM_TILE_GM
+#undef MXMM_SCALE_GM
 #undef MXMM_FILL
+#undef MXMM_FILL_SCALES
 #undef MXMM_DRAIN_TO_L0
 #ifndef MXMM_NO_STORE
     set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
@@ -583,6 +629,12 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
     wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
 #endif
 #endif
+  }
+
+  // One ID3 post is outstanding: every tile posts and every tile but the first
+  // consumed one. Drain it so a later launch's first wait cannot return early.
+  if (scales_held) {
+    wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID3);
   }
 #else
   (void)a_gm;

--- a/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
+++ b/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
@@ -148,11 +148,15 @@ static_assert(L1_SETS <= 3u, "only two and three sets are wired up");
 // Output tiles are walked SWIZZLE_GROUP rows down before stepping across, so
 // the blocks resident at one time form a square-ish patch of the output rather
 // than a full-width strip. 1 restores the plain row-major walk.
-#ifndef MXMM_SWIZZLE
-#define MXMM_SWIZZLE 8
-#endif
-constexpr uint32_t SWIZZLE_GROUP = (uint32_t)(MXMM_SWIZZLE);
-static_assert(SWIZZLE_GROUP >= 1u, "a group spans at least one tile row");
+//
+// The right group depends on how many N tiles there are, so the default is
+// chosen per instantiation from n_tiles rather than fixed: a group of 2 is
+// worth 7-11% once n_tiles reaches 48, and is neutral to slightly worse below
+// that, where 8 holds. 16 is worse at every width measured. -DMXMM_SWIZZLE
+// overrides it. The numbers behind the threshold are in README.md.
+constexpr uint32_t SWIZZLE_WIDE_TILES = 48u;
+constexpr uint32_t SWIZZLE_WIDE = 2u;
+constexpr uint32_t SWIZZLE_NARROW = 8u;
 constexpr unsigned BASE_SK = BASE_K / SCALE_FACTOR;
 
 static_assert(SMALL_M % 16 == 0 && BIG_M % 16 == 0, "M must be 16-aligned");
@@ -303,6 +307,13 @@ __global__ AICORE void mxfp4_matmul(__gm__ void *a_gm, __gm__ void *a_scale_gm,
 
   const uint32_t m_tiles = m_total / BASE_M;
   constexpr uint32_t n_tiles = N / BASE_N;
+#ifdef MXMM_SWIZZLE
+  constexpr uint32_t SWIZZLE_GROUP = (uint32_t)(MXMM_SWIZZLE);
+#else
+  constexpr uint32_t SWIZZLE_GROUP =
+      n_tiles >= SWIZZLE_WIDE_TILES ? SWIZZLE_WIDE : SWIZZLE_NARROW;
+#endif
+  static_assert(SWIZZLE_GROUP >= 1u, "a group spans at least one tile row");
   constexpr uint32_t k_tiles = K / BASE_K;
   constexpr uint32_t k_slabs = K / K_L1;
   static_assert(K % K_L1 == 0u, "K must be whole L1 slabs");

--- a/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
+++ b/examples/jit_cpp/mxfp4_matmul_a5/mxfp4_matmul_a5.cpp
@@ -87,7 +87,13 @@ constexpr uint32_t SWIZZLE_NARROW = 8u;
 #endif
 constexpr unsigned TEST_M_MAX = 65536;
 constexpr unsigned TEST_K = MXMM_TEST_K, TEST_N = MXMM_TEST_N;
-constexpr uint32_t TARGET_BLOCKS = 64u;
+// The block count the tile picker aims to fill. jit_util passes the device's
+// cube_core_num; the default is what an A5 reports.
+#ifndef MXMM_TARGET_BLOCKS
+#define MXMM_TARGET_BLOCKS 32
+#endif
+constexpr uint32_t TARGET_BLOCKS = (uint32_t)(MXMM_TARGET_BLOCKS);
+static_assert(TARGET_BLOCKS >= 1u, "At least one block.");
 
 namespace {
 

--- a/examples/jit_cpp/mxfp4_matmul_a5/run_benchmark.sh
+++ b/examples/jit_cpp/mxfp4_matmul_a5/run_benchmark.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# One-command on-device benchmark for mxfp4_matmul_a5 on an Ascend 950 (A5).
+# Requires a real A5 device, torch + torch_npu, and bisheng (CANN toolkit).
+#
+# Source your own toolkit first to pick it: the vendor arm is torch_npu
+# dispatching into libopapi from whichever toolkit is active, so that arm moves
+# with it, and the MXFP4 matmul needs 9.1.0 or newer.
+if [[ -z "${ASCEND_TOOLKIT_HOME:-}" && -z "${ASCEND_HOME_PATH:-}" ]]; then
+  source /usr/local/Ascend/ascend-toolkit/set_env.sh
+fi
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${ASCEND_HOME_PATH:=${ASCEND_TOOLKIT_HOME:-/usr/local/Ascend/ascend-toolkit/latest}}"
+export ASCEND_HOME_PATH
+cd "${SCRIPT_DIR}"
+exec python3 benchmark.py "$@"

--- a/examples/jit_cpp/mxfp4_matmul_a5/test_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/test_mxfp4_matmul_a5.py
@@ -1,0 +1,322 @@
+"""Correctness for the A5 MXFP4 matmul.
+
+The reference is the operation's own definition, from PTO's CPU implementation
+(``pto/cpu/TMatmul.hpp``):
+
+    acc(i, j) = sum_k a(i, k) * b(k, j) * aScale(i, k / 32) * bScale(k / 32, j)
+
+with a and b E2M1 nibbles and the scales E8M0, a biased power of two. Operands
+are built from nibble CODES rather than from random floats, deliberately: every
+value is then exactly representable, so the only rounding in the whole path is
+the bf16 output cast and a mismatch means the kernel is wrong rather than
+differently rounded. There is no tolerance to tune.
+
+Two structural gates carry more weight than the error figure, because no layout
+mistake survives either: uniform operands under a 2^0 scale must return exactly
+K, and a one-hot activation row must recover the matching weight row.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+torch_npu = pytest.importorskip("torch_npu")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from jit_util_mxfp4_matmul_a5 import (  # noqa: E402
+    MX_BLOCK,
+    compile_kernel,
+    kernel_shape,
+    load_matmul,
+    tile_plan,
+)
+
+# E2M1: sign in bit 3, magnitude in bits 0..2.
+E2M1 = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float64)
+E8M0_BIAS = 127
+# bf16 carries about three decimal digits, so this is the storage limit of the
+# output, not an arithmetic tolerance.
+REL_TOLERANCE = 5e-3
+
+# (K, N) pairs. Non-square is included because K and N are independent template
+# arguments and a square-only matrix would let a transposed stride pass.
+SHAPES = [(512, 512), (1024, 1024), (1024, 512), (512, 1024), (2048, 1024)]
+
+
+def decode(codes: np.ndarray) -> np.ndarray:
+    """Nibble codes -> the exact float values they denote."""
+    magnitude = E2M1[codes & 0x7]
+    return np.where(codes >= 8, -magnitude, magnitude)
+
+
+def pack(codes: np.ndarray) -> np.ndarray:
+    """Two nibbles per byte, low nibble first."""
+    low, high = codes[..., 0::2], codes[..., 1::2]
+    return (low | (high << 4)).astype(np.uint8)
+
+
+def scaled(codes: np.ndarray, exponents: np.ndarray, axis: int) -> np.ndarray:
+    """Apply one E8M0 scale per MX_BLOCK elements along ``axis``."""
+    factors = np.ldexp(1.0, exponents.astype(np.int32) - E8M0_BIAS)
+    return decode(codes) * np.repeat(factors, MX_BLOCK, axis=axis)
+
+
+def fail_without_vendor(why: str):
+    """A comparison with nothing to compare against proves nothing."""
+    if os.environ.get("PTO_ALLOW_NO_VENDOR") == "1":
+        pytest.skip(f"{why} (PTO_ALLOW_NO_VENDOR=1)")
+    pytest.fail(f"{why}: no reference to compare against, so this proves nothing")
+
+
+def to_device(array: np.ndarray):
+    """Host-side generation only.
+
+    Device-side RNG runs on the vector cores, so on a part with one failing
+    vector core it raises at the next synchronize and looks exactly like a
+    fault in whatever was launched most recently.
+    """
+    return torch.from_numpy(np.ascontiguousarray(array)).npu()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def device():
+    torch.npu.set_device(0)
+
+
+def build(k: int, n: int):
+    so = compile_kernel(k, n, verbose=False)
+    return so, load_matmul(so, k, n)
+
+
+def operands(m: int, k: int, n: int, seed: int, exponent_span=(120, 136)):
+    """Random nibble codes plus their exact host product.
+
+    B is ``Layout::DN``: stored (N, K) row-major, that is transposed, and its
+    scales likewise. Weights are prepared offline so the transpose is free, but
+    feeding row-major B computes something else and looks plausible doing it.
+    """
+    rng = np.random.default_rng(seed)
+    low, high = exponent_span
+    a_codes = rng.integers(0, 16, size=(m, k), dtype=np.uint8)
+    b_codes = rng.integers(0, 16, size=(k, n), dtype=np.uint8)
+    a_exp = rng.integers(low, high, size=(m, k // MX_BLOCK), dtype=np.uint8)
+    b_exp = rng.integers(low, high, size=(k // MX_BLOCK, n), dtype=np.uint8)
+    want = scaled(a_codes, a_exp, axis=1) @ scaled(b_codes, b_exp, axis=0)
+    packed = (
+        to_device(pack(a_codes)),
+        to_device(a_exp),
+        to_device(pack(b_codes.T)),
+        to_device(b_exp.T),
+    )
+    return packed, want
+
+
+def relative_error(got: np.ndarray, want: np.ndarray) -> float:
+    denominator = max(np.abs(want).mean(), 1e-30)
+    return float(np.abs(got - want).mean() / denominator)
+
+
+def run(matmul, packed, m: int):
+    out = matmul(*packed, m=m)
+    torch.npu.synchronize()
+    got = out.float().cpu().numpy().astype(np.float64)
+    unwritten = int(np.isnan(got).sum())
+    return got, unwritten
+
+
+@pytest.mark.parametrize("k,n", SHAPES)
+def test_matches_exact_reference(k, n):
+    so, matmul = build(k, n)
+    plan = tile_plan(so)
+    m = plan(256)[0]
+    packed, want = operands(m, k, n, seed=7)
+    got, unwritten = run(matmul, packed, m)
+    assert unwritten == 0, f"{unwritten} output elements were never written"
+    assert relative_error(got, want) < REL_TOLERANCE
+
+
+# M values chosen to land on DIFFERENT tile branches, not merely to be spread
+# out: the kernel picks a tile from M, so a set of widths that all take one
+# branch reports five passes for one code path.
+@pytest.mark.parametrize("m", [16, 32, 128, 256, 512, 4096])
+def test_matches_exact_reference_across_tile_branches(m):
+    k = n = 1024
+    so, matmul = build(k, n)
+    m_run, _, _ = tile_plan(so)(m)
+    packed, want = operands(m_run, k, n, seed=11)
+    got, unwritten = run(matmul, packed, m_run)
+    assert unwritten == 0, f"{unwritten} output elements were never written"
+    assert relative_error(got, want) < REL_TOLERANCE
+
+
+def test_tile_branches_are_actually_covered():
+    """Pin that the parametrization above spans the tile picks it claims to."""
+    so, _ = build(1024, 1024)
+    plan = tile_plan(so)
+    tiles = {plan(m)[1] for m in (16, 32, 128, 256, 512, 4096)}
+    # Exactly the three the kernel has -- TINY, SMALL, BIG. Asserting ">= 2"
+    # would pass while one whole branch went untested, which is the hole this
+    # test exists to close.
+    assert len(tiles) == 3, f"tile branches covered: {sorted(tiles)}"
+
+
+def test_uniform_operands_return_exactly_k():
+    """1.0 is exact in E2M1 under a 2^0 scale, so the sum must be exactly K."""
+    k = n = 512
+    so, matmul = build(k, n)
+    m = tile_plan(so)(128)[0]
+    ones = np.full((m, k), 2, dtype=np.uint8)  # code 2 == 1.0
+    weights = np.full((k, n), 2, dtype=np.uint8)
+    unit = np.full((m, k // MX_BLOCK), E8M0_BIAS, dtype=np.uint8)
+    weight_unit = np.full((k // MX_BLOCK, n), E8M0_BIAS, dtype=np.uint8)
+    packed = (
+        to_device(pack(ones)),
+        to_device(unit),
+        to_device(pack(weights.T)),
+        to_device(weight_unit.T),
+    )
+    got, unwritten = run(matmul, packed, m)
+    assert unwritten == 0
+    assert np.all(got == float(k)), f"expected exactly {k}, got {np.unique(got)}"
+
+
+def test_one_hot_activation_recovers_the_weight_row():
+    """The sharpest layout probe: a wrong stride returns a different row."""
+    k = n = 512
+    so, matmul = build(k, n)
+    m = tile_plan(so)(128)[0]
+    rng = np.random.default_rng(3)
+    b_codes = rng.integers(0, 16, size=(k, n), dtype=np.uint8)
+    a_codes = np.zeros((m, k), dtype=np.uint8)
+    picks = [(row, (row * 37) % k) for row in range(0, m, max(1, m // 24))]
+    for row, column in picks:
+        a_codes[row, column] = 2  # 1.0
+    unit = np.full((m, k // MX_BLOCK), E8M0_BIAS, dtype=np.uint8)
+    weight_unit = np.full((k // MX_BLOCK, n), E8M0_BIAS, dtype=np.uint8)
+    packed = (
+        to_device(pack(a_codes)),
+        to_device(unit),
+        to_device(pack(b_codes.T)),
+        to_device(weight_unit.T),
+    )
+    got, unwritten = run(matmul, packed, m)
+    assert unwritten == 0
+    for row, column in picks:
+        expected = decode(b_codes[column])
+        assert np.array_equal(got[row], expected), f"row {row} took the wrong B row"
+
+
+def test_matches_the_vendor_on_the_vendors_own_operands():
+    """Feed both kernels one quantization and require the same answer.
+
+    ``npu_dynamic_mx_quant`` emits scales shaped (rows, K/64, 2) -- pairs of
+    E8M0 bytes -- which is this kernel's (rows, K/32) layout reshaped, so the
+    same bytes drive both. That makes this a layout test as much as an
+    arithmetic one: if the pairing along K were the other way round, the two
+    results would differ.
+    """
+    if not hasattr(torch_npu, "npu_quant_matmul") or not hasattr(
+        torch_npu, "npu_dynamic_mx_quant"
+    ):
+        fail_without_vendor("torch_npu has no MXFP4 matmul")
+    k = n = 1024
+    so, matmul = build(k, n)
+    m = tile_plan(so)(256)[0]
+    rng = np.random.default_rng(29)
+    activations = to_device(
+        np.asarray(rng.normal(0, 1, (m, k)), dtype=np.float32)
+    ).bfloat16()
+    weights = to_device(
+        np.asarray(rng.normal(0, 0.05, (k, n)), dtype=np.float32)
+    ).bfloat16()
+
+    a_packed, a_scale = torch_npu.npu_dynamic_mx_quant(activations)
+    b_packed, b_scale = torch_npu.npu_dynamic_mx_quant(weights.t().contiguous())
+    fp4, e8m0 = torch.float4_e2m1fn_x2, torch.float8_e8m0fnu
+    reference = torch_npu.npu_quant_matmul(
+        a_packed.view(fp4),
+        b_packed.view(fp4).t(),
+        b_scale.view(e8m0).transpose(0, 1),
+        pertoken_scale=a_scale.view(e8m0),
+        output_dtype=torch.bfloat16,
+        group_sizes=[1, 1, 32],
+    )
+    torch.npu.synchronize()
+
+    ours = matmul(
+        a_packed.view(torch.uint8).reshape(m, k // 2),
+        a_scale.view(torch.uint8).reshape(m, k // MX_BLOCK),
+        b_packed.view(torch.uint8).reshape(n, k // 2),
+        b_scale.view(torch.uint8).reshape(n, k // MX_BLOCK),
+        m=m,
+    )
+    torch.npu.synchronize()
+    got = ours.float().cpu().numpy().astype(np.float64)
+    want = reference.float().cpu().numpy().astype(np.float64)
+    assert int(np.isnan(got).sum()) == 0
+    assert relative_error(got, want) < REL_TOLERANCE
+
+
+def test_build_rejects_shapes_the_kernel_would_silently_decline():
+    """The launcher answers a shape it was not built for by writing nothing."""
+    with pytest.raises(ValueError, match="whole L1 slabs"):
+        compile_kernel(256, 512, verbose=False)
+    with pytest.raises(ValueError, match="multiple of 64"):
+        compile_kernel(512, 96, verbose=False)
+
+
+def test_load_rejects_a_mismatched_binary():
+    so = compile_kernel(512, 512, verbose=False)
+    with pytest.raises(ValueError, match="was built for"):
+        load_matmul(so, 1024, 1024)
+
+
+def test_row_count_is_rounded_up_and_the_padding_is_visible():
+    """An M off the tile grid is rounded UP, which the caller can see.
+
+    Rounding is the intended behaviour -- the kernel launches on whole tiles --
+    so the contract is that the returned buffer has m_round(m) rows, not m. A
+    caller who supplies its own output buffer at the unrounded height is told,
+    rather than having the extra rows written past the end of it.
+    """
+    k = n = 512
+    so, matmul = build(k, n)
+    m_tile = kernel_shape(so)["m_tile"]
+    off_grid = m_tile + 1
+    m_run = tile_plan(so)(off_grid)[0]
+    assert m_run > off_grid and m_run % m_tile == 0
+
+    packed, _ = operands(m_run, k, n, seed=5)
+    out = matmul(*packed, m=off_grid)
+    torch.npu.synchronize()
+    assert tuple(out.shape) == (m_run, n)
+
+    too_short = torch.empty((off_grid, n), dtype=torch.bfloat16, device="npu")
+    with pytest.raises(ValueError, match="out must be"):
+        matmul(*packed, out=too_short, m=off_grid)
+
+
+def test_launcher_rejects_a_row_count_it_cannot_serve():
+    k = n = 512
+    so, matmul = build(k, n)
+    m = tile_plan(so)(128)[0]
+    packed, _ = operands(m, k, n, seed=5)
+    with pytest.raises(ValueError, match="positive"):
+        matmul(*packed, m=0)
+    with pytest.raises(ValueError, match="at most"):
+        matmul(*packed, m=kernel_shape(so)["m_max"] + 1)
+
+
+def test_output_buffer_shape_is_checked():
+    k = n = 512
+    so, matmul = build(k, n)
+    m = tile_plan(so)(128)[0]
+    packed, _ = operands(m, k, n, seed=13)
+    wrong = torch.empty((m, n // 2), dtype=torch.bfloat16, device="npu")
+    with pytest.raises(ValueError, match="out must be"):
+        matmul(*packed, out=wrong, m=m)

--- a/examples/jit_cpp/mxfp4_matmul_a5/test_mxfp4_matmul_a5.py
+++ b/examples/jit_cpp/mxfp4_matmul_a5/test_mxfp4_matmul_a5.py
@@ -28,7 +28,7 @@ torch_npu = pytest.importorskip("torch_npu")
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from jit_util_mxfp4_matmul_a5 import (  # noqa: E402
+from jit_util_mxfp4_matmul_a5 import (  # noqa
     MX_BLOCK,
     compile_kernel,
     kernel_shape,


### PR DESCRIPTION
## mxfp4_matmul_a5

Adds an MXFP4 matmul for A5.

Measured on Ascend950PR, CANN 9.1.0, against `torch_npu`'s
`npu_quant_matmul`. Median of six processes over 16 batch sizes per width;
L2 is evicted before every timed launch and the arms are interleaved.

| K=N | ours / vendor | ours wins | ours peak | vendor peak |
| ---- | ------------: | --------: | --------: | ----------: |
| 512 | **1.77x** | 16/16 | 378 TF/s | 280 TF/s |
| 1024 | **1.71x** | 16/16 | 808 | 761 |
| 2048 | **1.67x** | 14/16 | 1236 | 1316 |
| 3072 | **1.48x** | 14/16 | 1399 | 1514 |
| 4096 | **1.42x** | 13/16 | 1488 | 1590 |
| 6144 | **1.19x** | 13/16 | 1536 | 1662 |
| 8192 | **1.05x** | 12/16 | 1555 | 1685 |
| 12288 | 0.89x | 1/16 | 1590 | 1698 |
| 16384 | 0.80x | 1/16 | 1607 | 1712 |

100 of 144 shapes. It also beats a bf16 GEMM at every width, 1.29x to 2.28x,
where the vendor does not below K=N=3072.

![ours over torch_npu](https://raw.githubusercontent.com/Mocchibird/pto-kernels-plots/main/mxfp4_matmul_a5/ours_over_vendor.png)

![torch_npu over bf16 torch.matmul](https://raw.githubusercontent.com/Mocchibird/pto-kernels-plots/main/mxfp4_matmul_a5/vendor_over_bf16.png)

![ours over bf16 torch.matmul](https://raw.githubusercontent.com/Mocchibird/pto-kernels-plots/main/mxfp4_matmul_a5/ours_over_bf16.png)

Requires CANN with MXFP4 support: 9.1.0 or newer.